### PR TITLE
feat: add page geometry and rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -72,6 +78,12 @@ jobs:
         run: ctest --test-dir build-asan --output-on-failure
 
   macos:
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'full-ci')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +131,12 @@ jobs:
         run: ctest --test-dir build --output-on-failure
 
   windows:
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'full-ci')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/**') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
+
       - name: Bootstrap pinned vcpkg
         shell: bash
         run: |
@@ -40,7 +48,10 @@ jobs:
 
       - name: Install MuPDF 1.28.2 with vcpkg
         shell: bash
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
+          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           "$VCPKG_ROOT/vcpkg" install \
             --triplet x64-linux \
             --overlay-ports="$GITHUB_WORKSPACE/vcpkg-ports"
@@ -62,6 +73,8 @@ jobs:
 
       - name: Configure sanitizer build
         shell: bash
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
           cmake -S . -B build-asan \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
@@ -88,6 +101,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/**') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
+
       - name: Bootstrap pinned vcpkg
         shell: bash
         run: |
@@ -110,7 +131,10 @@ jobs:
 
       - name: Install MuPDF 1.28.2 with vcpkg
         shell: bash
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
+          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           "$VCPKG_ROOT/vcpkg" install \
             --triplet "$VCPKG_TRIPLET" \
             --overlay-ports="$GITHUB_WORKSPACE/vcpkg-ports"
@@ -141,6 +165,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/**') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
+
       - name: Bootstrap pinned vcpkg
         shell: pwsh
         run: |
@@ -154,7 +186,10 @@ jobs:
 
       - name: Install static MuPDF 1.28.2 with vcpkg
         shell: pwsh
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
+          New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
           & "$env:VCPKG_ROOT\vcpkg.exe" install `
             --triplet x64-windows-static-md `
             --overlay-ports="$env:GITHUB_WORKSPACE\vcpkg-ports"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
 
+      - name: Configure vcpkg binary cache
+        shell: bash
+        run: |
+          mkdir -p "${{ runner.temp }}/vcpkg-binary-cache"
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ runner.temp }}/vcpkg-binary-cache" >> "$GITHUB_ENV"
+
       - name: Bootstrap pinned vcpkg
         shell: bash
         run: |
@@ -48,10 +54,7 @@ jobs:
 
       - name: Install MuPDF 1.28.2 with vcpkg
         shell: bash
-        env:
-          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
-          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           "$VCPKG_ROOT/vcpkg" install \
             --triplet x64-linux \
             --overlay-ports="$GITHUB_WORKSPACE/vcpkg-ports"
@@ -73,8 +76,6 @@ jobs:
 
       - name: Configure sanitizer build
         shell: bash
-        env:
-          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
           cmake -S . -B build-asan \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
@@ -109,6 +110,12 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
 
+      - name: Configure vcpkg binary cache
+        shell: bash
+        run: |
+          mkdir -p "${{ runner.temp }}/vcpkg-binary-cache"
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ runner.temp }}/vcpkg-binary-cache" >> "$GITHUB_ENV"
+
       - name: Bootstrap pinned vcpkg
         shell: bash
         run: |
@@ -131,10 +138,7 @@ jobs:
 
       - name: Install MuPDF 1.28.2 with vcpkg
         shell: bash
-        env:
-          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
-          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           "$VCPKG_ROOT/vcpkg" install \
             --triplet "$VCPKG_TRIPLET" \
             --overlay-ports="$GITHUB_WORKSPACE/vcpkg-ports"
@@ -173,6 +177,13 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
 
+      - name: Configure vcpkg binary cache
+        shell: pwsh
+        run: |
+          $cache = Join-Path $env:RUNNER_TEMP "vcpkg-binary-cache"
+          New-Item -ItemType Directory -Force -Path $cache | Out-Null
+          "VCPKG_DEFAULT_BINARY_CACHE=$cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Bootstrap pinned vcpkg
         shell: pwsh
         run: |
@@ -186,10 +197,7 @@ jobs:
 
       - name: Install static MuPDF 1.28.2 with vcpkg
         shell: pwsh
-        env:
-          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}/vcpkg-binary-cache
         run: |
-          New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
           & "$env:VCPKG_ROOT\vcpkg.exe" install `
             --triplet x64-windows-static-md `
             --overlay-ports="$env:GITHUB_WORKSPACE\vcpkg-ports"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/vcpkg-binary-cache
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/**') }}
@@ -58,6 +59,13 @@ jobs:
           "$VCPKG_ROOT/vcpkg" install \
             --triplet x64-linux \
             --overlay-ports="$GITHUB_WORKSPACE/vcpkg-ports"
+
+      - name: Save vcpkg binary cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
 
       - name: Configure static build
         shell: bash
@@ -103,7 +111,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/vcpkg-binary-cache
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/**') }}
@@ -143,6 +152,13 @@ jobs:
             --triplet "$VCPKG_TRIPLET" \
             --overlay-ports="$GITHUB_WORKSPACE/vcpkg-ports"
 
+      - name: Save vcpkg binary cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
+
       - name: Configure
         shell: bash
         run: |
@@ -170,7 +186,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/vcpkg-binary-cache
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/**') }}
@@ -201,6 +218,13 @@ jobs:
           & "$env:VCPKG_ROOT\vcpkg.exe" install `
             --triplet x64-windows-static-md `
             --overlay-ports="$env:GITHUB_WORKSPACE\vcpkg-ports"
+
+      - name: Save vcpkg binary cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
 
       - name: Configure ExtractPDF DLL
         shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ endif()
 add_library(extractpdf
   src/status.c
   src/document.c
-  src/page.c)
+  src/page.c
+  src/render.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ endif()
 
 add_library(extractpdf
   src/status.c
-  src/document.c)
+  src/document.c
+  src/page.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ExtractPDF is a small C11 library that keeps MuPDF behind a stable C ABI suitable for native callers and .NET P/Invoke.
 
-The v2 foundation targets **MuPDF 1.28.2**. It replaces the original 2015 MuPDF 1.3 proof of concept with explicit document ownership, stable status handling, deterministic tests, CMake/CTest, and exact-head Windows/Linux/macOS CI.
+The v2 implementation targets **MuPDF 1.28.2**. It replaces the original 2015 MuPDF 1.3 proof of concept with explicit ownership, stable status handling, deterministic tests, CMake/CTest, and exact-head Windows/Linux/macOS CI.
 
-## Phase 1 API
+## Current v2 API
+
+Document lifecycle remains the root of the API:
 
 ```c
 #include <extractpdf/extractpdf.h>
@@ -20,27 +22,110 @@ if (extractpdf_open("file.pdf", NULL, &doc) == EXTRACTPDF_OK) {
 }
 ```
 
-Phase 1 exports only:
+Page + Render adds opaque page and bitmap handles:
 
-- `extractpdf_open`
-- `extractpdf_page_count`
-- `extractpdf_status_string`
-- `extractpdf_close`
+```c
+extractpdf_page *page = NULL;
+extractpdf_bitmap *bitmap = NULL;
+int width, height, stride, components;
 
-Text extraction is Phase 2. Page-observed image extraction is Phase 3.
+if (extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK) {
+    if (extractpdf_render_page(page, &bitmap) == EXTRACTPDF_OK) {
+        extractpdf_bitmap_dimensions(
+            bitmap, &width, &height, &stride, &components);
+        /* inspect bitmap data */
+        extractpdf_drop_bitmap(bitmap);
+    }
+    extractpdf_drop_page(page);
+}
+```
+
+The current supported surface includes:
+
+- document open / password authentication / page count / close
+- opaque page load / drop
+- page bounds plus MediaBox/CropBox bounds
+- RGB and RGBA page rendering
+- DPI/zoom, rotation, and page-space clipping
+- aspect-preserving thumbnail rendering
+- bitmap dimensions and borrowed sample access
+- stable status strings
+
+Plain UTF-8 text, structured text/search, page images, and links are tracked as the next Content phase in issue #2.
 
 ## API contract
 
 - The public header contains no MuPDF types.
 - Each `extractpdf_document` owns one MuPDF context and document.
+- `extractpdf_page` and `extractpdf_bitmap` borrow their parent document. The document must outlive all derived page and bitmap handles.
+- A bitmap does not borrow its source page after rendering, so the page may be dropped before the bitmap, provided the document remains alive.
 - ExtractPDF keeps no mutable process-global or thread-local document state.
 - Input paths are UTF-8.
 - `password == NULL` means no password was supplied.
 - Missing or incorrect passwords return `EXTRACTPDF_ERROR_PASSWORD`.
 - `extractpdf_open` leaves the output handle NULL on failure.
-- `extractpdf_close(NULL)` is safe.
+- `extractpdf_close(NULL)`, `extractpdf_drop_page(NULL)`, and `extractpdf_drop_bitmap(NULL)` are safe.
 - MuPDF exceptions are caught inside the library and translated to `extractpdf_status`.
-- Phase 1 is deliberately single-threaded. Separate handles may coexist and be used sequentially/interleaved on one thread; concurrent MuPDF calls are not yet part of the contract.
+- The current runtime contract is deliberately single-threaded. Separate handles may coexist and be used sequentially/interleaved on one thread; concurrent MuPDF calls are not yet part of the contract.
+
+## Page coordinates
+
+All public page rectangles use **Fitz page space** rather than raw PDF object coordinates:
+
+- the CropBox top-left is the page-space origin `(0, 0)`;
+- x increases to the right;
+- y increases downward;
+- values are page points before render scaling (`72 points = 1 inch`).
+
+`extractpdf_page_box_bounds(..., EXTRACTPDF_PAGE_BOX_MEDIA, ...)` may therefore have negative coordinates when MediaBox extends outside CropBox.
+
+This same page-space contract is intended for later text geometry, search quads, images, links, and annotations.
+
+Intrinsic format-specific rotation metadata is intentionally not part of the generic Page API. Fitz bounds already describe displayed page geometry; PDF `/Rotate`, if needed by callers, belongs in a later PDF-specific metadata surface. Rendering rotation is explicit and per-call.
+
+## Rendering
+
+The convenience call:
+
+```c
+extractpdf_render_page(page, &bitmap);
+```
+
+renders the full page at 72 DPI, zero additional rotation, opaque DeviceRGB, and a white background.
+
+For explicit rendering use a versioned options struct:
+
+```c
+extractpdf_render_options options = {
+    sizeof(extractpdf_render_options),
+    144.0f, /* dpi */
+    0.0f,   /* rotation_degrees */
+    0,      /* clip_enabled */
+    { 0 },  /* clip in Fitz page space */
+    0       /* alpha */
+};
+
+extractpdf_render_page_with_options(page, &options, &bitmap);
+```
+
+`struct_size` is part of the ABI contract. Callers should initialize it to the size of the struct they compiled against. New fields are append-only; the library ignores fields beyond the caller-provided size so older binaries retain their original defaults.
+
+`dpi` is the canonical zoom/resolution input: 72 DPI is scale 1.0, 144 DPI is scale 2.0. Rotation is in degrees and is applied only to that render call. When clipping is enabled, `clip` is expressed in Fitz page space and is transformed by the same DPI/rotation matrix; ExtractPDF renders directly into the clipped device bbox rather than allocating a full-page intermediate image.
+
+`alpha` accepts only 0 or 1:
+
+- `0`: 8-bit interleaved RGB, opaque white untouched pixels;
+- `1`: 8-bit interleaved RGBA, transparent untouched pixels.
+
+RGBA samples produced by the renderer use **premultiplied alpha**, matching MuPDF's rendered pixmap contract. `stride` returned by `extractpdf_bitmap_dimensions` is the authoritative byte distance between rows; callers must not assume a different packing rule. The pointer returned by `extractpdf_bitmap_data` is borrowed read-only storage and remains valid only until `extractpdf_drop_bitmap`.
+
+## Thumbnails
+
+```c
+extractpdf_render_thumbnail(page, max_width, max_height, &bitmap);
+```
+
+renders opaque RGB while preserving the page aspect ratio. The result fits inside the requested pixel box and never upscales beyond the page's 72-DPI size. Thumbnail rendering derives a DPI and reuses the same renderer rather than maintaining a separate raster path.
 
 ## Dependency model
 
@@ -69,7 +154,7 @@ Only the `extractpdf_*` ABI is exported by the wrapper.
 
 ## Build with vcpkg
 
-Set `VCPKG_ROOT` to a vcpkg checkout compatible with the baseline in `vcpkg.json`. CI bootstraps the exact baseline commit declared by the repository workflow.
+Set `VCPKG_ROOT` to a vcpkg checkout compatible with the baseline in `vcpkg.json`. CI bootstraps the exact pinned commit declared by the repository workflow.
 
 ### Linux x64
 
@@ -90,23 +175,7 @@ ctest --test-dir build --output-on-failure
 
 ### macOS
 
-Use `arm64-osx` on Apple Silicon or `x64-osx` on Intel, then run the same manifest/overlay flow. For example:
-
-```sh
-triplet=arm64-osx
-"$VCPKG_ROOT/vcpkg" install \
-  --triplet "$triplet" \
-  --overlay-ports="$PWD/vcpkg-ports"
-
-cmake -S . -B build \
-  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
-  -DVCPKG_TARGET_TRIPLET="$triplet" \
-  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
-  -DBUILD_SHARED_LIBS=OFF
-
-cmake --build build
-ctest --test-dir build --output-on-failure
-```
+Use `arm64-osx` on Apple Silicon or `x64-osx` on Intel, then run the same manifest/overlay flow.
 
 ### Windows x64 DLL
 
@@ -125,25 +194,25 @@ cmake --build build --config Release
 ctest --test-dir build -C Release --output-on-failure
 ```
 
-The test build stages `extractpdf.dll` beside the Windows test executables. Consumers are responsible for deploying `extractpdf.dll` beside their executable or otherwise making it available through normal Windows DLL search rules.
+The test build stages `extractpdf.dll` beside every Windows test executable. Consumers are responsible for deploying `extractpdf.dll` beside their executable or otherwise making it available through normal Windows DLL search rules.
 
 ## Tests
 
-CTest covers the Phase 1 contract, including invalid arguments, missing files, one/two-page counts, encrypted PDFs with missing/wrong/correct passwords, malformed input, 100 repeated open/count/close cycles, interleaved independent handles, `close(NULL)`, and a UTF-8 filename.
+CTest covers the document lifecycle plus Page + Render contracts, including invalid arguments, page geometry, MediaBox/CropBox coordinates, RGB/RGBA output, versioned render options, DPI, rotation, clipping, thumbnails, encrypted PDFs, malformed input, repeated lifecycle stress, interleaved handles, and UTF-8 paths.
 
-Linux additionally runs AddressSanitizer and UndefinedBehaviorSanitizer. Windows tests have explicit runtime bounds so a loader or lifecycle regression cannot occupy CI indefinitely.
+Linux additionally runs AddressSanitizer and UndefinedBehaviorSanitizer.
 
 ## CI
 
-Feature branches are validated by the pull-request workflow. `master` is validated again on push after merge. All three desktop jobs bootstrap the same pinned vcpkg baseline and consume the same MuPDF 1.28.2 overlay port.
+Normal pull-request updates use Linux as the fast development loop. Windows and macOS are reserved for explicit `full-ci` checkpoints, manual workflow dispatch, and pushes to `master`.
 
-The supported proof is always the CI result on the **exact PR head SHA**; an older green run is not considered evidence for a newer head.
+The workflow persists vcpkg binary packages through GitHub Actions cache, keyed by OS/architecture, pinned vcpkg commit, manifest, and overlay content. This avoids rebuilding the MuPDF/HarfBuzz/FreeType dependency graph on each RED/GREEN iteration while leaving vcpkg's package ABI checks authoritative.
+
+A feature is not considered cross-platform complete until Linux, macOS, and Windows pass on the same exact head SHA. Older green runs do not satisfy acceptance for a newer head.
 
 ## Legacy implementation
 
 The root `libpdf.c` is the original MuPDF 1.3 experiment from 2015. It remains untouched during the v2 migration for historical reference and is not the supported v2 API.
-
-After the v2 lifecycle, text, and image surfaces are covered, it can be moved intact under `legacy/` as a separate migration step.
 
 ## License
 

--- a/docs/superpowers/specs/2026-08-27-extractpdf-v2-design.md
+++ b/docs/superpowers/specs/2026-08-27-extractpdf-v2-design.md
@@ -1,7 +1,7 @@
 # ExtractPDF v2 design
 
 Date: 2026-08-27  
-Status: Phase 1 implementation in verification  
+Status: v2 foundation implemented; Page + Render implemented; Content in progress  
 Target baseline: MuPDF 1.28.2
 
 ## Context
@@ -11,25 +11,17 @@ The repository started as a 2015 MuPDF 1.3 proof of concept whose single `libpdf
 ## Goals
 
 1. Stable C11 ABI for C, C++, and .NET P/Invoke.
-2. Opaque document ownership with no MuPDF types in public headers.
+2. Opaque ownership with no MuPDF types in public headers.
 3. No mutable process-global or thread-local document state.
-4. Explicit password, error, and cleanup behavior.
-5. Deterministic CTest coverage before text/image extraction.
-6. One dependency model across Windows, Linux, and macOS.
-7. Exact-head cross-platform CI.
+4. Explicit password, error, allocation, and cleanup behavior.
+5. Deterministic CTest coverage before publishing each capability.
+6. One pinned dependency model across Windows, Linux, and macOS.
+7. Linux-first RED/GREEN development with exact-head cross-platform feature checkpoints.
+8. Small primitives that compose into higher-level PDF operations.
 
-## Non-goals for Phase 1
+## Foundation ABI
 
-- PDF editing/writing.
-- OCR.
-- JavaScript execution.
-- Concurrent MuPDF calls.
-- Text or image extraction APIs.
-- Preserving legacy exported names or unsafe buffer conventions.
-
-## Public ABI
-
-`include/extractpdf/extractpdf.h` exposes an opaque handle:
+The document handle owns one MuPDF context and document:
 
 ```c
 typedef struct extractpdf_document extractpdf_document;
@@ -56,35 +48,139 @@ EXTRACTPDF_API const char *extractpdf_status_string(extractpdf_status status);
 EXTRACTPDF_API void extractpdf_close(extractpdf_document *document);
 ```
 
-Windows exports use `EXTRACTPDF_SHARED` plus `EXTRACTPDF_BUILDING_LIBRARY`; callers never see MuPDF import/export macros.
-
-### ABI rules
+### Foundation rules
 
 - Input paths are UTF-8.
 - `password == NULL` means no password supplied.
 - `extractpdf_open` sets `*out_document = NULL` on failure.
 - Missing/incorrect passwords return `EXTRACTPDF_ERROR_PASSWORD`.
 - `extractpdf_close(NULL)` is a no-op.
-- Status codes, not strings, define program behavior.
+- Status codes, not diagnostic strings, define behavior.
 - No MuPDF exception crosses the ABI.
-- Phase 1 is single-threaded. Multiple handles may coexist and be used sequentially/interleaved on one thread; concurrency requires a separate future contract.
+- The runtime contract remains single-threaded until concurrency is separately designed and tested.
 
-## Internal ownership
+## Phase 2 — Page + Render
+
+Page operations are anchored by an opaque page handle:
 
 ```c
-struct extractpdf_document {
-    fz_context *ctx;
-    fz_document *doc;
-};
+typedef struct extractpdf_page extractpdf_page;
+typedef struct extractpdf_bitmap extractpdf_bitmap;
+
+typedef struct extractpdf_rect {
+    float x0;
+    float y0;
+    float x1;
+    float y1;
+} extractpdf_rect;
 ```
 
-Each handle owns one context and one document. Open validates arguments, allocates the wrapper, creates/registers the MuPDF context, opens the document, authenticates if needed, and returns the handle. Failure unwinds in reverse order. Close drops the document before the context and then frees the wrapper.
+The Page + Render surface includes:
 
-All MuPDF calls that can throw are contained by `fz_try`/`fz_catch` boundaries.
+- page load/drop;
+- page bounds and MediaBox/CropBox bounds;
+- full-page RGB/RGBA rendering;
+- DPI/zoom;
+- per-call rotation;
+- page-space clipping;
+- aspect-preserving thumbnails;
+- bitmap dimensions and borrowed sample access.
+
+### Derived-handle ownership
+
+`extractpdf_page` and `extractpdf_bitmap` borrow their parent `extractpdf_document`; the document must outlive them. A bitmap no longer depends on the page object after rendering, so the page may be dropped before the bitmap as long as the document remains alive.
+
+This intentionally keeps Phase 2 ownership simple and explicit rather than adding hidden document reference counting. If independent child-handle lifetime becomes a demonstrated requirement, that is a separate ABI/lifetime design decision.
+
+### Coordinate contract
+
+Public geometry is **Fitz page space**:
+
+```text
+CropBox top-left = (0, 0)
+x → right
+y → down
+72 page points = 1 inch before rendering
+```
+
+MuPDF uses CropBox to establish the displayed-page origin, so MediaBox bounds may be negative relative to that origin. Raw PDF box coordinates are not exposed through the generic page geometry API.
+
+This coordinate model is the shared basis for later text geometry, search quads, image placement, links, and annotations.
+
+The generic Page API deliberately does not expose a format-independent intrinsic rotation property. Fitz bounds already represent displayed page geometry, while PDF `/Rotate` is format-specific metadata. Rendering rotation remains explicit and per-call.
+
+### Render options ABI
+
+```c
+typedef struct extractpdf_render_options {
+    size_t struct_size;
+    float dpi;
+    float rotation_degrees;
+    int clip_enabled;
+    extractpdf_rect clip;
+    int alpha;
+} extractpdf_render_options;
+```
+
+The struct is append-only. `struct_size` tells the library which fields the caller compiled against; fields beyond that size are ignored and retain their historical defaults.
+
+`dpi` is the canonical scale representation: 72 DPI = scale 1.0. Rotation and clipping are per-call state; there is no persistent document zoom state.
+
+When clipping, ExtractPDF transforms the page-space clip through the same render matrix and renders directly into the resulting device bbox. It does not render a full-page intermediate and crop afterward.
+
+`alpha=0` produces opaque DeviceRGB on white. `alpha=1` produces rendered DeviceRGB + alpha. Samples are 8-bit interleaved RGB/RGBA; RGBA produced by rendering is premultiplied alpha. Callers use the returned stride rather than assuming row packing.
+
+Thumbnail rendering derives a DPI from the requested maximum pixel box, preserves aspect ratio, never upscales above 72-DPI page size, and calls the same internal render primitive.
+
+## Phase 3 — Content
+
+Content builds on `extractpdf_page` and reuses the Phase 2 coordinate model.
+
+Planned order:
+
+1. plain UTF-8 text;
+2. structured text blocks/lines/spans with geometry;
+3. search returning page-space quads/bounds;
+4. page-observed images and geometry;
+5. links and destinations.
+
+The first plain-text slice returns ExtractPDF-owned, NUL-terminated UTF-8 memory and an explicit byte length. The exported deallocator keeps allocator ownership inside the DLL and lets the returned text outlive its page/document.
+
+Structured text and search should use MuPDF's structured-text layer rather than parsing PDF content streams directly.
+
+## Later phases
+
+### PDF composition
+
+- subset/export selected pages;
+- split;
+- reorder/delete/duplicate;
+- merge;
+- output abstraction and save/write.
+
+Prefer a small page-selection/export primitive that can express multiple higher-level operations rather than independent engines for every command.
+
+### Interactive PDF
+
+- metadata;
+- outlines;
+- annotations;
+- forms/widgets.
+
+### Rewrite/transform
+
+- crop/trim;
+- poster split;
+- flatten/bake;
+- optimize/garbage collect;
+- image recompression;
+- encryption/re-encryption.
+
+The authoritative feature checklist is issue #2.
 
 ## Error translation
 
-The public error contract is deliberately coarse:
+The public error contract remains deliberately coarse:
 
 - bad caller arguments -> `EXTRACTPDF_ERROR_ARGUMENT`
 - path/system failures -> `EXTRACTPDF_ERROR_IO`
@@ -98,7 +194,7 @@ Callers do not depend on MuPDF numeric error values.
 
 ## Canonical dependency architecture
 
-All supported desktop platforms use the repository's vcpkg manifest plus overlay port.
+All supported desktop platforms use the repository's pinned vcpkg manifest plus overlay port.
 
 ```text
 vcpkg.json
@@ -112,90 +208,36 @@ vcpkg.json
                   ExtractPDF
 ```
 
-The overlay pins MuPDF 1.28.2 and the matching MuJS gitlink required by `source/fitz/regexp.c`. Optional upstream features that are outside Phase 1 and otherwise require additional embedded/submodule resources are disabled explicitly (including JavaScript, Markdown, and hyphenation).
+The overlay pins MuPDF 1.28.2 and the matching MuJS gitlink required by `source/fitz/regexp.c`. Optional upstream features outside the current scope that otherwise require additional resources are disabled explicitly.
 
 MuPDF source is fetched from upstream by vcpkg; it is not committed into this repository.
 
 ### Windows
 
-Windows uses `x64-windows-static-md`: MuPDF and transitive dependencies are static libraries using the dynamic MSVC CRT. They are linked privately into `extractpdf.dll`.
+Windows uses `x64-windows-static-md`: MuPDF and transitive dependencies are static libraries using the dynamic MSVC CRT and are linked privately into `extractpdf.dll`.
 
-```text
-static MuPDF 1.28.2 + static third-party libs
-                    |
-                    v
-              extractpdf.dll
-                    |
-                    v
-             public extractpdf_* ABI
-```
+The overlay retains a host-side `libmupdf` build dependency solely to provide MuPDF's `bin2coff` build tool for embedding resources. This host tool is not a runtime dependency.
 
-The overlay retains a host-side `libmupdf` build dependency solely to provide MuPDF's `bin2coff` build tool for embedding fonts. This host tool is not a runtime dependency and does not change the static-MuPDF/shared-ExtractPDF boundary.
-
-There is intentionally no `mupdfcpp64`, `FZ_DLL_CLIENT`, or MuPDF DLL path in the v2 build.
+There is intentionally no `mupdfcpp64`, `FZ_DLL_CLIENT`, or MuPDF DLL path in v2.
 
 ### Linux/macOS
 
-Linux and macOS consume the same overlay target through their native vcpkg triplets. CI builds ExtractPDF static on these platforms; Linux also runs ASan/UBSan.
+Linux and macOS consume the same overlay target through native vcpkg triplets. CI currently builds ExtractPDF static on these platforms; Linux also runs ASan/UBSan.
 
-## Test strategy
+## Test and CI strategy
 
-Phase 1 CTest coverage locks:
+Every capability follows RED -> minimal GREEN with deterministic CTest coverage.
 
-1. invalid/null argument rejection;
-2. missing file -> I/O error;
-3. one- and two-page counts;
-4. encrypted PDF with no/wrong/correct password;
-5. malformed/truncated input;
-6. 100 repeated open/count/close lifecycles;
-7. two interleaved independent handles;
-8. `extractpdf_close(NULL)`;
-9. UTF-8 path behavior.
+Normal pull-request updates run Linux only. Windows/macOS run for explicit `full-ci` feature checkpoints, manual workflow dispatch, and `master` pushes. A feature is cross-platform complete only when all supported jobs pass on the same exact head SHA.
 
-Windows shared-library tests stage `extractpdf.dll` beside the test executables so CTest validates the ABI rather than relying on an accidental machine PATH. MSVC compiles the UTF-8 fixture test with `/utf-8`. Tests have explicit timeouts to turn loader/lifecycle hangs into bounded failures.
+The workflow persists the vcpkg **binary package cache**, not `vcpkg_installed`. Cache namespaces include OS/architecture and pinned vcpkg state; vcpkg package ABI checks remain authoritative. Binary archives are saved immediately after a successful dependency install so an intentional later RED does not force the next iteration to rebuild MuPDF/HarfBuzz/FreeType.
 
-## CI
+Windows shared-library tests stage `extractpdf.dll` beside every test executable so CTest validates the exported ABI rather than relying on machine PATH state.
 
-The pull-request workflow is the canonical feature-branch proof. `master` runs again on push. Every desktop job bootstraps the same pinned vcpkg commit and uses the repository overlay. Linux, macOS, and Windows must pass on the exact PR head SHA; older runs do not satisfy acceptance.
+## Legacy implementation
 
-## Phase 2: text
-
-After Phase 1 is green, text extraction returns UTF-8 memory through the ABI and adds an exported deallocator so callers never mix allocators. A planned shape is:
-
-```c
-EXTRACTPDF_API extractpdf_status extractpdf_extract_text(
-    extractpdf_document *document,
-    int page_index,
-    char **out_utf8,
-    size_t *out_size);
-EXTRACTPDF_API void extractpdf_free(void *memory);
-```
-
-Empty-page representation must be locked by tests before publishing the API.
-
-## Phase 3: images
-
-The default meaning of "images on a page" is images encountered in page content, not every object in the PDF xref table. Raw PDF image-XObject access, if ever needed, is a separately named advanced API. The core library does not choose output filenames or silently impose an output image format.
-
-## Legacy migration
-
-The root `libpdf.c` remains untouched during Phase 1. After the lifecycle, text, and image surfaces are covered, it may be moved intact to `legacy/`. A compatibility shim is added only for a demonstrated downstream need; unsafe legacy conventions are not preserved by default.
+The root `libpdf.c` remains the untouched MuPDF 1.3 historical proof of concept during the v2 migration. A compatibility shim is added only for a demonstrated downstream need; unsafe legacy conventions are not preserved by default.
 
 ## Licensing
 
-The repository baseline is **AGPL-3.0-or-later**. MuPDF is fetched as an upstream dependency and has its own licensing options. No dependency packaging choice changes the public ExtractPDF ABI.
-
-## Phase 1 acceptance
-
-Phase 1 is complete only when one exact head satisfies all of the following:
-
-- AGPL license/README are present;
-- public header contains no MuPDF types;
-- no mutable ExtractPDF-owned global/TLS document state exists;
-- open/password/page-count/close/error tests pass;
-- malformed and encrypted inputs fail safely;
-- UTF-8 path behavior passes on all supported platforms;
-- Windows proves static MuPDF privately linked into shared ExtractPDF;
-- Linux sanitizer tests are clean;
-- project CMake has one canonical vcpkg package target and no MuPDF DLL-client fallback;
-- Linux/macOS/Windows CI is green on the exact head.
+The repository baseline is **AGPL-3.0-or-later**. MuPDF is fetched as an upstream dependency and has its own AGPL/commercial licensing options. Dependency packaging does not remove those obligations.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -33,6 +33,11 @@ typedef enum extractpdf_page_box {
     EXTRACTPDF_PAGE_BOX_CROP = 1
 } extractpdf_page_box;
 
+typedef struct extractpdf_render_options {
+    size_t struct_size;
+    float dpi;
+} extractpdf_render_options;
+
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
     EXTRACTPDF_ERROR_ARGUMENT = 1,
@@ -69,6 +74,11 @@ EXTRACTPDF_API extractpdf_status extractpdf_page_box_bounds(
 
 EXTRACTPDF_API extractpdf_status extractpdf_render_page(
     extractpdf_page *page,
+    extractpdf_bitmap **out_bitmap);
+
+EXTRACTPDF_API extractpdf_status extractpdf_render_page_with_options(
+    extractpdf_page *page,
+    const extractpdf_render_options *options,
     extractpdf_bitmap **out_bitmap);
 
 EXTRACTPDF_API extractpdf_status extractpdf_bitmap_dimensions(

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -36,6 +36,7 @@ typedef enum extractpdf_page_box {
 typedef struct extractpdf_render_options {
     size_t struct_size;
     float dpi;
+    float rotation_degrees;
 } extractpdf_render_options;
 
 typedef enum extractpdf_status {

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -19,6 +19,7 @@ extern "C" {
 
 typedef struct extractpdf_document extractpdf_document;
 typedef struct extractpdf_page extractpdf_page;
+typedef struct extractpdf_bitmap extractpdf_bitmap;
 
 typedef struct extractpdf_rect {
     float x0;
@@ -66,8 +67,27 @@ EXTRACTPDF_API extractpdf_status extractpdf_page_box_bounds(
     extractpdf_page_box box,
     extractpdf_rect *out_bounds);
 
+EXTRACTPDF_API extractpdf_status extractpdf_render_page(
+    extractpdf_page *page,
+    extractpdf_bitmap **out_bitmap);
+
+EXTRACTPDF_API extractpdf_status extractpdf_bitmap_dimensions(
+    extractpdf_bitmap *bitmap,
+    int *out_width,
+    int *out_height,
+    int *out_stride,
+    int *out_components);
+
+EXTRACTPDF_API extractpdf_status extractpdf_bitmap_data(
+    extractpdf_bitmap *bitmap,
+    const unsigned char **out_data,
+    size_t *out_size);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
+
+EXTRACTPDF_API void extractpdf_drop_bitmap(
+    extractpdf_bitmap *bitmap);
 
 EXTRACTPDF_API void extractpdf_drop_page(
     extractpdf_page *page);

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -39,6 +39,7 @@ typedef struct extractpdf_render_options {
     float rotation_degrees;
     int clip_enabled;
     extractpdf_rect clip;
+    int alpha;
 } extractpdf_render_options;
 
 typedef enum extractpdf_status {

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 typedef struct extractpdf_document extractpdf_document;
+typedef struct extractpdf_page extractpdf_page;
 
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
@@ -39,8 +40,16 @@ EXTRACTPDF_API extractpdf_status extractpdf_page_count(
     extractpdf_document *document,
     int *out_page_count);
 
+EXTRACTPDF_API extractpdf_status extractpdf_load_page(
+    extractpdf_document *document,
+    int page_index,
+    extractpdf_page **out_page);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
+
+EXTRACTPDF_API void extractpdf_drop_page(
+    extractpdf_page *page);
 
 EXTRACTPDF_API void extractpdf_close(
     extractpdf_document *document);

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -27,6 +27,11 @@ typedef struct extractpdf_rect {
     float y1;
 } extractpdf_rect;
 
+typedef enum extractpdf_page_box {
+    EXTRACTPDF_PAGE_BOX_MEDIA = 0,
+    EXTRACTPDF_PAGE_BOX_CROP = 1
+} extractpdf_page_box;
+
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
     EXTRACTPDF_ERROR_ARGUMENT = 1,
@@ -54,6 +59,11 @@ EXTRACTPDF_API extractpdf_status extractpdf_load_page(
 
 EXTRACTPDF_API extractpdf_status extractpdf_page_bounds(
     extractpdf_page *page,
+    extractpdf_rect *out_bounds);
+
+EXTRACTPDF_API extractpdf_status extractpdf_page_box_bounds(
+    extractpdf_page *page,
+    extractpdf_page_box box,
     extractpdf_rect *out_bounds);
 
 EXTRACTPDF_API const char *extractpdf_status_string(

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -85,6 +85,12 @@ EXTRACTPDF_API extractpdf_status extractpdf_render_page_with_options(
     const extractpdf_render_options *options,
     extractpdf_bitmap **out_bitmap);
 
+EXTRACTPDF_API extractpdf_status extractpdf_render_thumbnail(
+    extractpdf_page *page,
+    int max_width,
+    int max_height,
+    extractpdf_bitmap **out_bitmap);
+
 EXTRACTPDF_API extractpdf_status extractpdf_bitmap_dimensions(
     extractpdf_bitmap *bitmap,
     int *out_width,

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -37,6 +37,8 @@ typedef struct extractpdf_render_options {
     size_t struct_size;
     float dpi;
     float rotation_degrees;
+    int clip_enabled;
+    extractpdf_rect clip;
 } extractpdf_render_options;
 
 typedef enum extractpdf_status {

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -20,6 +20,13 @@ extern "C" {
 typedef struct extractpdf_document extractpdf_document;
 typedef struct extractpdf_page extractpdf_page;
 
+typedef struct extractpdf_rect {
+    float x0;
+    float y0;
+    float x1;
+    float y1;
+} extractpdf_rect;
+
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
     EXTRACTPDF_ERROR_ARGUMENT = 1,
@@ -44,6 +51,10 @@ EXTRACTPDF_API extractpdf_status extractpdf_load_page(
     extractpdf_document *document,
     int page_index,
     extractpdf_page **out_page);
+
+EXTRACTPDF_API extractpdf_status extractpdf_page_bounds(
+    extractpdf_page *page,
+    extractpdf_rect *out_bounds);
 
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);

--- a/src/internal.h
+++ b/src/internal.h
@@ -14,6 +14,11 @@ struct extractpdf_page {
     fz_page *page;
 };
 
+struct extractpdf_bitmap {
+    extractpdf_document *document;
+    fz_pixmap *pixmap;
+};
+
 extractpdf_status extractpdf_status_from_mupdf(int code);
 
 #endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -9,6 +9,11 @@ struct extractpdf_document {
     fz_document *doc;
 };
 
+struct extractpdf_page {
+    extractpdf_document *document;
+    fz_page *page;
+};
+
 extractpdf_status extractpdf_status_from_mupdf(int code);
 
 #endif

--- a/src/page.c
+++ b/src/page.c
@@ -1,0 +1,73 @@
+#include "internal.h"
+
+#include <stdlib.h>
+
+extractpdf_status extractpdf_load_page(
+    extractpdf_document *document,
+    int page_index,
+    extractpdf_page **out_page)
+{
+    extractpdf_page *page;
+    int page_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_page == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_page = NULL;
+
+    if (document == NULL || page_index < 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(page_count);
+    fz_var(caught_code);
+
+    fz_try(document->ctx)
+    {
+        page_count = fz_count_pages(document->ctx, document->doc);
+    }
+    fz_catch(document->ctx)
+    {
+        caught_code = fz_caught(document->ctx);
+        fz_report_error(document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (page_index >= page_count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    page = (extractpdf_page *)calloc(1, sizeof(*page));
+    if (page == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    page->document = document;
+    caught_code = FZ_ERROR_NONE;
+
+    fz_try(document->ctx)
+    {
+        page->page = fz_load_page(document->ctx, document->doc, page_index);
+    }
+    fz_catch(document->ctx)
+    {
+        caught_code = fz_caught(document->ctx);
+        fz_report_error(document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        free(page);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+
+    *out_page = page;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_page(extractpdf_page *page)
+{
+    if (page == NULL)
+        return;
+
+    if (page->page != NULL)
+        fz_drop_page(page->document->ctx, page->page);
+    free(page);
+}

--- a/src/page.c
+++ b/src/page.c
@@ -62,6 +62,39 @@ extractpdf_status extractpdf_load_page(
     return EXTRACTPDF_OK;
 }
 
+extractpdf_status extractpdf_page_bounds(
+    extractpdf_page *page,
+    extractpdf_rect *out_bounds)
+{
+    fz_rect bounds;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (page == NULL || out_bounds == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(bounds);
+    fz_var(caught_code);
+
+    fz_try(page->document->ctx)
+    {
+        bounds = fz_bound_page(page->document->ctx, page->page);
+    }
+    fz_catch(page->document->ctx)
+    {
+        caught_code = fz_caught(page->document->ctx);
+        fz_report_error(page->document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+
+    out_bounds->x0 = bounds.x0;
+    out_bounds->y0 = bounds.y0;
+    out_bounds->x1 = bounds.x1;
+    out_bounds->y1 = bounds.y1;
+    return EXTRACTPDF_OK;
+}
+
 void extractpdf_drop_page(extractpdf_page *page)
 {
     if (page == NULL)

--- a/src/page.c
+++ b/src/page.c
@@ -95,6 +95,52 @@ extractpdf_status extractpdf_page_bounds(
     return EXTRACTPDF_OK;
 }
 
+extractpdf_status extractpdf_page_box_bounds(
+    extractpdf_page *page,
+    extractpdf_page_box box,
+    extractpdf_rect *out_bounds)
+{
+    fz_box_type mupdf_box;
+    fz_rect bounds;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (page == NULL || out_bounds == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    switch (box) {
+    case EXTRACTPDF_PAGE_BOX_MEDIA:
+        mupdf_box = FZ_MEDIA_BOX;
+        break;
+    case EXTRACTPDF_PAGE_BOX_CROP:
+        mupdf_box = FZ_CROP_BOX;
+        break;
+    default:
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    }
+
+    fz_var(bounds);
+    fz_var(caught_code);
+
+    fz_try(page->document->ctx)
+    {
+        bounds = fz_bound_page_box(page->document->ctx, page->page, mupdf_box);
+    }
+    fz_catch(page->document->ctx)
+    {
+        caught_code = fz_caught(page->document->ctx);
+        fz_report_error(page->document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+
+    out_bounds->x0 = bounds.x0;
+    out_bounds->y0 = bounds.y0;
+    out_bounds->x1 = bounds.x1;
+    out_bounds->y1 = bounds.y1;
+    return EXTRACTPDF_OK;
+}
+
 void extractpdf_drop_page(extractpdf_page *page)
 {
     if (page == NULL)

--- a/src/render.c
+++ b/src/render.c
@@ -4,9 +4,10 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-static extractpdf_status extractpdf_render_page_at_dpi(
+static extractpdf_status extractpdf_render_page_transformed(
     extractpdf_page *page,
     float dpi,
+    float rotation_degrees,
     extractpdf_bitmap **out_bitmap)
 {
     extractpdf_bitmap *bitmap;
@@ -17,7 +18,8 @@ static extractpdf_status extractpdf_render_page_at_dpi(
         return EXTRACTPDF_ERROR_ARGUMENT;
     *out_bitmap = NULL;
 
-    if (page == NULL || !isfinite(dpi) || dpi <= 0.0f)
+    if (page == NULL || !isfinite(dpi) || dpi <= 0.0f ||
+        !isfinite(rotation_degrees))
         return EXTRACTPDF_ERROR_ARGUMENT;
 
     bitmap = (extractpdf_bitmap *)calloc(1, sizeof(*bitmap));
@@ -26,6 +28,7 @@ static extractpdf_status extractpdf_render_page_at_dpi(
 
     bitmap->document = page->document;
     transform = fz_scale(dpi / 72.0f, dpi / 72.0f);
+    transform = fz_pre_rotate(transform, rotation_degrees);
     fz_var(caught_code);
 
     fz_try(page->document->ctx)
@@ -60,7 +63,7 @@ extractpdf_status extractpdf_render_page(
     extractpdf_page *page,
     extractpdf_bitmap **out_bitmap)
 {
-    return extractpdf_render_page_at_dpi(page, 72.0f, out_bitmap);
+    return extractpdf_render_page_transformed(page, 72.0f, 0.0f, out_bitmap);
 }
 
 extractpdf_status extractpdf_render_page_with_options(
@@ -69,6 +72,8 @@ extractpdf_status extractpdf_render_page_with_options(
     extractpdf_bitmap **out_bitmap)
 {
     size_t minimum_size;
+    size_t rotation_size;
+    float rotation_degrees = 0.0f;
 
     if (out_bitmap == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
@@ -81,7 +86,16 @@ extractpdf_status extractpdf_render_page_with_options(
     if (options->struct_size < minimum_size)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    return extractpdf_render_page_at_dpi(page, options->dpi, out_bitmap);
+    rotation_size = offsetof(extractpdf_render_options, rotation_degrees) +
+        sizeof(options->rotation_degrees);
+    if (options->struct_size >= rotation_size)
+        rotation_degrees = options->rotation_degrees;
+
+    return extractpdf_render_page_transformed(
+        page,
+        options->dpi,
+        rotation_degrees,
+        out_bitmap);
 }
 
 extractpdf_status extractpdf_bitmap_dimensions(

--- a/src/render.c
+++ b/src/render.c
@@ -176,6 +176,52 @@ extractpdf_status extractpdf_render_page_with_options(
         out_bitmap);
 }
 
+extractpdf_status extractpdf_render_thumbnail(
+    extractpdf_page *page,
+    int max_width,
+    int max_height,
+    extractpdf_bitmap **out_bitmap)
+{
+    extractpdf_rect bounds;
+    extractpdf_status status;
+    float page_width;
+    float page_height;
+    float scale_x;
+    float scale_y;
+    float scale;
+
+    if (out_bitmap == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_bitmap = NULL;
+
+    if (page == NULL || max_width <= 0 || max_height <= 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_page_bounds(page, &bounds);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    page_width = bounds.x1 - bounds.x0;
+    page_height = bounds.y1 - bounds.y0;
+    if (!isfinite(page_width) || !isfinite(page_height) ||
+        page_width <= 0.0f || page_height <= 0.0f)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    scale_x = (float)max_width / page_width;
+    scale_y = (float)max_height / page_height;
+    scale = scale_x < scale_y ? scale_x : scale_y;
+    if (scale > 1.0f)
+        scale = 1.0f;
+
+    return extractpdf_render_page_transformed(
+        page,
+        72.0f * scale,
+        0.0f,
+        NULL,
+        0,
+        out_bitmap);
+}
+
 extractpdf_status extractpdf_bitmap_dimensions(
     extractpdf_bitmap *bitmap,
     int *out_width,

--- a/src/render.c
+++ b/src/render.c
@@ -8,9 +8,12 @@ static extractpdf_status extractpdf_render_page_transformed(
     extractpdf_page *page,
     float dpi,
     float rotation_degrees,
+    const extractpdf_rect *clip,
     extractpdf_bitmap **out_bitmap)
 {
     extractpdf_bitmap *bitmap;
+    fz_context *ctx;
+    fz_device *device = NULL;
     fz_matrix transform;
     int caught_code = FZ_ERROR_NONE;
 
@@ -27,26 +30,57 @@ static extractpdf_status extractpdf_render_page_transformed(
         return EXTRACTPDF_ERROR_NOMEM;
 
     bitmap->document = page->document;
+    ctx = page->document->ctx;
     transform = fz_scale(dpi / 72.0f, dpi / 72.0f);
     transform = fz_pre_rotate(transform, rotation_degrees);
+    fz_var(device);
     fz_var(caught_code);
 
-    fz_try(page->document->ctx)
+    fz_try(ctx)
     {
-        bitmap->pixmap = fz_new_pixmap_from_page(
-            page->document->ctx,
-            page->page,
-            transform,
-            fz_device_rgb(page->document->ctx),
-            0);
+        if (clip != NULL) {
+            fz_rect clip_rect = fz_make_rect(
+                clip->x0,
+                clip->y0,
+                clip->x1,
+                clip->y1);
+            fz_irect bbox;
+
+            clip_rect = fz_transform_rect(clip_rect, transform);
+            bbox = fz_round_rect(clip_rect);
+            bitmap->pixmap = fz_new_pixmap_with_bbox(
+                ctx,
+                fz_device_rgb(ctx),
+                bbox,
+                NULL,
+                0);
+            fz_clear_pixmap_with_value(ctx, bitmap->pixmap, 0xFF);
+            device = fz_new_draw_device(ctx, transform, bitmap->pixmap);
+            fz_run_page(ctx, page->page, device, fz_identity, NULL);
+            fz_close_device(ctx, device);
+        }
+        else {
+            bitmap->pixmap = fz_new_pixmap_from_page(
+                ctx,
+                page->page,
+                transform,
+                fz_device_rgb(ctx),
+                0);
+        }
     }
-    fz_catch(page->document->ctx)
+    fz_always(ctx)
     {
-        caught_code = fz_caught(page->document->ctx);
-        fz_report_error(page->document->ctx);
+        fz_drop_device(ctx, device);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
     }
 
     if (caught_code != FZ_ERROR_NONE) {
+        if (bitmap->pixmap != NULL)
+            fz_drop_pixmap(ctx, bitmap->pixmap);
         free(bitmap);
         return extractpdf_status_from_mupdf(caught_code);
     }
@@ -63,7 +97,12 @@ extractpdf_status extractpdf_render_page(
     extractpdf_page *page,
     extractpdf_bitmap **out_bitmap)
 {
-    return extractpdf_render_page_transformed(page, 72.0f, 0.0f, out_bitmap);
+    return extractpdf_render_page_transformed(
+        page,
+        72.0f,
+        0.0f,
+        NULL,
+        out_bitmap);
 }
 
 extractpdf_status extractpdf_render_page_with_options(
@@ -73,7 +112,12 @@ extractpdf_status extractpdf_render_page_with_options(
 {
     size_t minimum_size;
     size_t rotation_size;
+    size_t clip_enabled_size;
+    size_t clip_size;
     float rotation_degrees = 0.0f;
+    int clip_enabled = 0;
+    extractpdf_rect clip = { 0 };
+    const extractpdf_rect *clip_ptr = NULL;
 
     if (out_bitmap == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
@@ -91,10 +135,29 @@ extractpdf_status extractpdf_render_page_with_options(
     if (options->struct_size >= rotation_size)
         rotation_degrees = options->rotation_degrees;
 
+    clip_enabled_size = offsetof(extractpdf_render_options, clip_enabled) +
+        sizeof(options->clip_enabled);
+    if (options->struct_size >= clip_enabled_size)
+        clip_enabled = options->clip_enabled != 0;
+
+    if (clip_enabled) {
+        clip_size = offsetof(extractpdf_render_options, clip) + sizeof(options->clip);
+        if (options->struct_size < clip_size)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        clip = options->clip;
+        if (!isfinite(clip.x0) || !isfinite(clip.y0) ||
+            !isfinite(clip.x1) || !isfinite(clip.y1) ||
+            clip.x1 <= clip.x0 || clip.y1 <= clip.y0)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        clip_ptr = &clip;
+    }
+
     return extractpdf_render_page_transformed(
         page,
         options->dpi,
         rotation_degrees,
+        clip_ptr,
         out_bitmap);
 }
 

--- a/src/render.c
+++ b/src/render.c
@@ -1,0 +1,106 @@
+#include "internal.h"
+
+#include <stdlib.h>
+
+extractpdf_status extractpdf_render_page(
+    extractpdf_page *page,
+    extractpdf_bitmap **out_bitmap)
+{
+    extractpdf_bitmap *bitmap;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_bitmap == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_bitmap = NULL;
+
+    if (page == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    bitmap = (extractpdf_bitmap *)calloc(1, sizeof(*bitmap));
+    if (bitmap == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    bitmap->document = page->document;
+    fz_var(caught_code);
+
+    fz_try(page->document->ctx)
+    {
+        bitmap->pixmap = fz_new_pixmap_from_page(
+            page->document->ctx,
+            page->page,
+            fz_identity,
+            fz_device_rgb(page->document->ctx),
+            0);
+    }
+    fz_catch(page->document->ctx)
+    {
+        caught_code = fz_caught(page->document->ctx);
+        fz_report_error(page->document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        free(bitmap);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+    if (bitmap->pixmap == NULL) {
+        free(bitmap);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    *out_bitmap = bitmap;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_bitmap_dimensions(
+    extractpdf_bitmap *bitmap,
+    int *out_width,
+    int *out_height,
+    int *out_stride,
+    int *out_components)
+{
+    fz_context *ctx;
+
+    if (bitmap == NULL || out_width == NULL || out_height == NULL ||
+        out_stride == NULL || out_components == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = bitmap->document->ctx;
+    *out_width = fz_pixmap_width(ctx, bitmap->pixmap);
+    *out_height = fz_pixmap_height(ctx, bitmap->pixmap);
+    *out_stride = fz_pixmap_stride(ctx, bitmap->pixmap);
+    *out_components = fz_pixmap_components(ctx, bitmap->pixmap);
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_bitmap_data(
+    extractpdf_bitmap *bitmap,
+    const unsigned char **out_data,
+    size_t *out_size)
+{
+    int stride;
+    int height;
+    size_t row_bytes;
+    fz_context *ctx;
+
+    if (bitmap == NULL || out_data == NULL || out_size == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = bitmap->document->ctx;
+    stride = fz_pixmap_stride(ctx, bitmap->pixmap);
+    height = fz_pixmap_height(ctx, bitmap->pixmap);
+    row_bytes = stride < 0 ? (size_t)(-(long long)stride) : (size_t)stride;
+
+    *out_data = fz_pixmap_samples(ctx, bitmap->pixmap);
+    *out_size = row_bytes * (size_t)height;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_bitmap(extractpdf_bitmap *bitmap)
+{
+    if (bitmap == NULL)
+        return;
+
+    if (bitmap->pixmap != NULL)
+        fz_drop_pixmap(bitmap->document->ctx, bitmap->pixmap);
+    free(bitmap);
+}

--- a/src/render.c
+++ b/src/render.c
@@ -1,19 +1,23 @@
 #include "internal.h"
 
+#include <math.h>
+#include <stddef.h>
 #include <stdlib.h>
 
-extractpdf_status extractpdf_render_page(
+static extractpdf_status extractpdf_render_page_at_dpi(
     extractpdf_page *page,
+    float dpi,
     extractpdf_bitmap **out_bitmap)
 {
     extractpdf_bitmap *bitmap;
+    fz_matrix transform;
     int caught_code = FZ_ERROR_NONE;
 
     if (out_bitmap == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
     *out_bitmap = NULL;
 
-    if (page == NULL)
+    if (page == NULL || !isfinite(dpi) || dpi <= 0.0f)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
     bitmap = (extractpdf_bitmap *)calloc(1, sizeof(*bitmap));
@@ -21,6 +25,7 @@ extractpdf_status extractpdf_render_page(
         return EXTRACTPDF_ERROR_NOMEM;
 
     bitmap->document = page->document;
+    transform = fz_scale(dpi / 72.0f, dpi / 72.0f);
     fz_var(caught_code);
 
     fz_try(page->document->ctx)
@@ -28,7 +33,7 @@ extractpdf_status extractpdf_render_page(
         bitmap->pixmap = fz_new_pixmap_from_page(
             page->document->ctx,
             page->page,
-            fz_identity,
+            transform,
             fz_device_rgb(page->document->ctx),
             0);
     }
@@ -49,6 +54,34 @@ extractpdf_status extractpdf_render_page(
 
     *out_bitmap = bitmap;
     return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_render_page(
+    extractpdf_page *page,
+    extractpdf_bitmap **out_bitmap)
+{
+    return extractpdf_render_page_at_dpi(page, 72.0f, out_bitmap);
+}
+
+extractpdf_status extractpdf_render_page_with_options(
+    extractpdf_page *page,
+    const extractpdf_render_options *options,
+    extractpdf_bitmap **out_bitmap)
+{
+    size_t minimum_size;
+
+    if (out_bitmap == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_bitmap = NULL;
+
+    if (page == NULL || options == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_render_options, dpi) + sizeof(options->dpi);
+    if (options->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    return extractpdf_render_page_at_dpi(page, options->dpi, out_bitmap);
 }
 
 extractpdf_status extractpdf_bitmap_dimensions(

--- a/src/render.c
+++ b/src/render.c
@@ -9,6 +9,7 @@ static extractpdf_status extractpdf_render_page_transformed(
     float dpi,
     float rotation_degrees,
     const extractpdf_rect *clip,
+    int alpha,
     extractpdf_bitmap **out_bitmap)
 {
     extractpdf_bitmap *bitmap;
@@ -22,7 +23,7 @@ static extractpdf_status extractpdf_render_page_transformed(
     *out_bitmap = NULL;
 
     if (page == NULL || !isfinite(dpi) || dpi <= 0.0f ||
-        !isfinite(rotation_degrees))
+        !isfinite(rotation_degrees) || (alpha != 0 && alpha != 1))
         return EXTRACTPDF_ERROR_ARGUMENT;
 
     bitmap = (extractpdf_bitmap *)calloc(1, sizeof(*bitmap));
@@ -53,8 +54,11 @@ static extractpdf_status extractpdf_render_page_transformed(
                 fz_device_rgb(ctx),
                 bbox,
                 NULL,
-                0);
-            fz_clear_pixmap_with_value(ctx, bitmap->pixmap, 0xFF);
+                alpha);
+            if (alpha)
+                fz_clear_pixmap(ctx, bitmap->pixmap);
+            else
+                fz_clear_pixmap_with_value(ctx, bitmap->pixmap, 0xFF);
             device = fz_new_draw_device(ctx, transform, bitmap->pixmap);
             fz_run_page(ctx, page->page, device, fz_identity, NULL);
             fz_close_device(ctx, device);
@@ -65,7 +69,7 @@ static extractpdf_status extractpdf_render_page_transformed(
                 page->page,
                 transform,
                 fz_device_rgb(ctx),
-                0);
+                alpha);
         }
     }
     fz_always(ctx)
@@ -102,6 +106,7 @@ extractpdf_status extractpdf_render_page(
         72.0f,
         0.0f,
         NULL,
+        0,
         out_bitmap);
 }
 
@@ -114,8 +119,10 @@ extractpdf_status extractpdf_render_page_with_options(
     size_t rotation_size;
     size_t clip_enabled_size;
     size_t clip_size;
+    size_t alpha_size;
     float rotation_degrees = 0.0f;
     int clip_enabled = 0;
+    int alpha = 0;
     extractpdf_rect clip = { 0 };
     const extractpdf_rect *clip_ptr = NULL;
 
@@ -153,11 +160,19 @@ extractpdf_status extractpdf_render_page_with_options(
         clip_ptr = &clip;
     }
 
+    alpha_size = offsetof(extractpdf_render_options, alpha) + sizeof(options->alpha);
+    if (options->struct_size >= alpha_size) {
+        alpha = options->alpha;
+        if (alpha != 0 && alpha != 1)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+    }
+
     return extractpdf_render_page_transformed(
         page,
         options->dpi,
         rotation_degrees,
         clip_ptr,
+        alpha,
         out_bitmap);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(extractpdf_test_document PRIVATE ExtractPDF::ExtractPDF)
 target_compile_definitions(extractpdf_test_document PRIVATE
   ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
   TWO_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/two-page.pdf"
+  PAGE_BOXES_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/page-boxes.pdf"
   ENCRYPTED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/encrypted-one-page.pdf"
   TRUNCATED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/truncated.pdf"
   MISSING_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/does-not-exist.pdf"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,8 @@ set_tests_properties(extractpdf.document PROPERTIES TIMEOUT 60)
 add_executable(extractpdf_test_render test_render.c)
 target_link_libraries(extractpdf_test_render PRIVATE ExtractPDF::ExtractPDF)
 target_compile_definitions(extractpdf_test_render PRIVATE
-  ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf")
+  ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
+  PAGE_BOXES_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/page-boxes.pdf")
 add_test(NAME extractpdf.render COMMAND extractpdf_test_render)
 set_tests_properties(extractpdf.render PROPERTIES TIMEOUT 30)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,8 +25,15 @@ endif()
 add_test(NAME extractpdf.document COMMAND extractpdf_test_document)
 set_tests_properties(extractpdf.document PROPERTIES TIMEOUT 60)
 
+add_executable(extractpdf_test_render test_render.c)
+target_link_libraries(extractpdf_test_render PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_render PRIVATE
+  ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf")
+add_test(NAME extractpdf.render COMMAND extractpdf_test_render)
+set_tests_properties(extractpdf.render PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
-  foreach(test_target IN ITEMS extractpdf_test_status extractpdf_test_document)
+  foreach(test_target IN ITEMS extractpdf_test_status extractpdf_test_document extractpdf_test_render)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/page-boxes.pdf
+++ b/tests/fixtures/page-boxes.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /CropBox [10 20 190 80] /Resources << >> >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+227
+%%EOF

--- a/tests/test_document.c
+++ b/tests/test_document.c
@@ -139,6 +139,31 @@ static void test_page_lifecycle(void)
     extractpdf_close(doc);
 }
 
+static void test_page_bounds(void)
+{
+    extractpdf_document *doc = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = { -1.0f, -2.0f, -3.0f, -4.0f };
+
+    trace_step("page bounds");
+    CHECK(extractpdf_page_bounds(NULL, &bounds) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bounds.x0 == -1.0f);
+    CHECK(bounds.y0 == -2.0f);
+    CHECK(bounds.x1 == -3.0f);
+    CHECK(bounds.y1 == -4.0f);
+
+    CHECK(extractpdf_open(ONE_PAGE_PDF, NULL, &doc) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_bounds(page, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+    CHECK(bounds.x0 == 0.0f);
+    CHECK(bounds.y0 == 0.0f);
+    CHECK(bounds.x1 == 72.0f);
+    CHECK(bounds.y1 == 72.0f);
+    extractpdf_drop_page(page);
+    extractpdf_close(doc);
+}
+
 static void test_utf8_path(void)
 {
     extractpdf_document *doc = NULL;
@@ -157,6 +182,7 @@ int main(void)
     test_repeated_lifecycle();
     test_handle_isolation();
     test_page_lifecycle();
+    test_page_bounds();
     test_utf8_path();
     trace_step("close null");
     extractpdf_close(NULL);

--- a/tests/test_document.c
+++ b/tests/test_document.c
@@ -184,17 +184,18 @@ static void test_page_box_bounds(void)
     CHECK(extractpdf_page_box_bounds(page, EXTRACTPDF_PAGE_BOX_MEDIA, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
     CHECK(extractpdf_page_box_bounds(page, (extractpdf_page_box)99, &sentinel) == EXTRACTPDF_ERROR_ARGUMENT);
 
+    /* Box bounds use MuPDF/Fitz page space: CropBox top-left is (0,0), y increases down. */
     CHECK(extractpdf_page_box_bounds(page, EXTRACTPDF_PAGE_BOX_MEDIA, &media) == EXTRACTPDF_OK);
-    CHECK(media.x0 == 0.0f);
-    CHECK(media.y0 == 0.0f);
-    CHECK(media.x1 == 200.0f);
-    CHECK(media.y1 == 100.0f);
+    CHECK(media.x0 == -10.0f);
+    CHECK(media.y0 == -20.0f);
+    CHECK(media.x1 == 190.0f);
+    CHECK(media.y1 == 80.0f);
 
     CHECK(extractpdf_page_box_bounds(page, EXTRACTPDF_PAGE_BOX_CROP, &crop) == EXTRACTPDF_OK);
-    CHECK(crop.x0 == 10.0f);
-    CHECK(crop.y0 == 20.0f);
-    CHECK(crop.x1 == 190.0f);
-    CHECK(crop.y1 == 80.0f);
+    CHECK(crop.x0 == 0.0f);
+    CHECK(crop.y0 == 0.0f);
+    CHECK(crop.x1 == 180.0f);
+    CHECK(crop.y1 == 60.0f);
 
     extractpdf_drop_page(page);
     extractpdf_close(doc);

--- a/tests/test_document.c
+++ b/tests/test_document.c
@@ -164,6 +164,42 @@ static void test_page_bounds(void)
     extractpdf_close(doc);
 }
 
+static void test_page_box_bounds(void)
+{
+    extractpdf_document *doc = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_rect media = { 0 };
+    extractpdf_rect crop = { 0 };
+    extractpdf_rect sentinel = { -1.0f, -2.0f, -3.0f, -4.0f };
+
+    trace_step("page box bounds");
+    CHECK(extractpdf_page_box_bounds(NULL, EXTRACTPDF_PAGE_BOX_MEDIA, &sentinel) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(sentinel.x0 == -1.0f);
+    CHECK(sentinel.y0 == -2.0f);
+    CHECK(sentinel.x1 == -3.0f);
+    CHECK(sentinel.y1 == -4.0f);
+
+    CHECK(extractpdf_open(PAGE_BOXES_PDF, NULL, &doc) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_box_bounds(page, EXTRACTPDF_PAGE_BOX_MEDIA, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_page_box_bounds(page, (extractpdf_page_box)99, &sentinel) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_page_box_bounds(page, EXTRACTPDF_PAGE_BOX_MEDIA, &media) == EXTRACTPDF_OK);
+    CHECK(media.x0 == 0.0f);
+    CHECK(media.y0 == 0.0f);
+    CHECK(media.x1 == 200.0f);
+    CHECK(media.y1 == 100.0f);
+
+    CHECK(extractpdf_page_box_bounds(page, EXTRACTPDF_PAGE_BOX_CROP, &crop) == EXTRACTPDF_OK);
+    CHECK(crop.x0 == 10.0f);
+    CHECK(crop.y0 == 20.0f);
+    CHECK(crop.x1 == 190.0f);
+    CHECK(crop.y1 == 80.0f);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(doc);
+}
+
 static void test_utf8_path(void)
 {
     extractpdf_document *doc = NULL;
@@ -183,6 +219,7 @@ int main(void)
     test_handle_isolation();
     test_page_lifecycle();
     test_page_bounds();
+    test_page_box_bounds();
     test_utf8_path();
     trace_step("close null");
     extractpdf_close(NULL);

--- a/tests/test_document.c
+++ b/tests/test_document.c
@@ -201,6 +201,58 @@ static void test_page_box_bounds(void)
     extractpdf_close(doc);
 }
 
+static void test_page_render(void)
+{
+    int sentinel = 0;
+    extractpdf_document *doc = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_bitmap *bitmap = (extractpdf_bitmap *)&sentinel;
+    int width = -1;
+    int height = -1;
+    int stride = -1;
+    int components = -1;
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    size_t i;
+
+    trace_step("page render 72 dpi rgb");
+    CHECK(extractpdf_render_page(NULL, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+
+    CHECK(extractpdf_open(ONE_PAGE_PDF, NULL, &doc) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_render_page(page, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    bitmap = NULL;
+    CHECK(extractpdf_render_page(page, &bitmap) == EXTRACTPDF_OK);
+    CHECK(bitmap != NULL);
+
+    /* The rendered bitmap does not depend on the page handle after creation. */
+    extractpdf_drop_page(page);
+    page = NULL;
+
+    CHECK(extractpdf_bitmap_dimensions(NULL, &width, &height, &stride, &components) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, NULL, &height, &stride, &components) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 72);
+    CHECK(height == 72);
+    CHECK(stride == 72 * 3);
+    CHECK(components == 3);
+
+    CHECK(extractpdf_bitmap_data(NULL, &data, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_data(bitmap, NULL, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_data(bitmap, &data, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_data(bitmap, &data, &size) == EXTRACTPDF_OK);
+    CHECK(data != NULL);
+    CHECK(size == (size_t)stride * (size_t)height);
+    for (i = 0; i < size; ++i)
+        CHECK(data[i] == 255);
+
+    extractpdf_drop_bitmap(bitmap);
+    extractpdf_drop_bitmap(NULL);
+    extractpdf_close(doc);
+}
+
 static void test_utf8_path(void)
 {
     extractpdf_document *doc = NULL;
@@ -221,6 +273,7 @@ int main(void)
     test_page_lifecycle();
     test_page_bounds();
     test_page_box_bounds();
+    test_page_render();
     test_utf8_path();
     trace_step("close null");
     extractpdf_close(NULL);

--- a/tests/test_document.c
+++ b/tests/test_document.c
@@ -108,6 +108,37 @@ static void test_handle_isolation(void)
     extractpdf_close(b);
 }
 
+static void test_page_lifecycle(void)
+{
+    int sentinel = 0;
+    extractpdf_document *doc = NULL;
+    extractpdf_page *page = (extractpdf_page *)&sentinel;
+
+    trace_step("page lifecycle");
+    CHECK(extractpdf_load_page(NULL, 0, &page) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(page == NULL);
+
+    CHECK(extractpdf_open(ONE_PAGE_PDF, NULL, &doc) == EXTRACTPDF_OK);
+
+    page = (extractpdf_page *)&sentinel;
+    CHECK(extractpdf_load_page(doc, -1, &page) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(page == NULL);
+
+    page = (extractpdf_page *)&sentinel;
+    CHECK(extractpdf_load_page(doc, 1, &page) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(page == NULL);
+
+    CHECK(extractpdf_load_page(doc, 0, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    page = NULL;
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    extractpdf_drop_page(page);
+    extractpdf_drop_page(NULL);
+
+    extractpdf_close(doc);
+}
+
 static void test_utf8_path(void)
 {
     extractpdf_document *doc = NULL;
@@ -125,6 +156,7 @@ int main(void)
     test_arguments_and_errors();
     test_repeated_lifecycle();
     test_handle_isolation();
+    test_page_lifecycle();
     test_utf8_path();
     trace_step("close null");
     extractpdf_close(NULL);

--- a/tests/test_render.c
+++ b/tests/test_render.c
@@ -95,6 +95,24 @@ int main(void)
     CHECK(bitmap == NULL);
     options.alpha = 0;
 
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_thumbnail(NULL, 144, 144, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+    CHECK(extractpdf_render_thumbnail(page, 0, 144, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+    CHECK(extractpdf_render_thumbnail(page, 144, 0, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+    CHECK(extractpdf_render_thumbnail(page, 144, 144, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    /* Thumbnail policy never upscales above the page's 72-DPI size. */
+    CHECK(extractpdf_render_thumbnail(page, 144, 144, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 72);
+    CHECK(height == 72);
+    CHECK(stride == 72 * 3);
+    CHECK(components == 3);
+    extractpdf_drop_bitmap(bitmap);
+
     extractpdf_drop_page(page);
     extractpdf_close(doc);
 
@@ -191,6 +209,25 @@ int main(void)
     bitmap = (extractpdf_bitmap *)&sentinel;
     CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
     CHECK(bitmap == NULL);
+
+    /* Fit within the requested pixel box while preserving aspect ratio. */
+    bitmap = NULL;
+    CHECK(extractpdf_render_thumbnail(page, 90, 90, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 90);
+    CHECK(height == 30);
+    CHECK(stride == 90 * 3);
+    CHECK(components == 3);
+    extractpdf_drop_bitmap(bitmap);
+
+    bitmap = NULL;
+    CHECK(extractpdf_render_thumbnail(page, 100, 20, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 60);
+    CHECK(height == 20);
+    CHECK(stride == 60 * 3);
+    CHECK(components == 3);
+    extractpdf_drop_bitmap(bitmap);
 
     extractpdf_drop_page(page);
     extractpdf_close(doc);

--- a/tests/test_render.c
+++ b/tests/test_render.c
@@ -21,6 +21,9 @@ int main(void)
     extractpdf_page *page = NULL;
     extractpdf_bitmap *bitmap = (extractpdf_bitmap *)&sentinel;
     extractpdf_render_options options = { sizeof(options), 144.0f, 0.0f, 0, { 0 } };
+    const unsigned char *data = NULL;
+    size_t data_size = 0;
+    size_t i;
     int width = 0;
     int height = 0;
     int stride = 0;
@@ -54,8 +57,44 @@ int main(void)
     CHECK(height == 144);
     CHECK(stride == 144 * 3);
     CHECK(components == 3);
-
     extractpdf_drop_bitmap(bitmap);
+
+    /* An older caller-provided options size must ignore a newer alpha field. */
+    options.struct_size = offsetof(extractpdf_render_options, alpha);
+    options.dpi = 72.0f;
+    options.rotation_degrees = 0.0f;
+    options.clip_enabled = 0;
+    options.alpha = 1;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 72);
+    CHECK(height == 72);
+    CHECK(stride == 72 * 3);
+    CHECK(components == 3);
+    extractpdf_drop_bitmap(bitmap);
+
+    options.struct_size = sizeof(options);
+    options.alpha = 1;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 72);
+    CHECK(height == 72);
+    CHECK(stride == 72 * 4);
+    CHECK(components == 4);
+    CHECK(extractpdf_bitmap_data(bitmap, &data, &data_size) == EXTRACTPDF_OK);
+    CHECK(data_size == (size_t)72 * 72 * 4);
+    for (i = 0; i < data_size; ++i)
+        CHECK(data[i] == 0);
+    extractpdf_drop_bitmap(bitmap);
+
+    options.alpha = 2;
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+    options.alpha = 0;
+
     extractpdf_drop_page(page);
     extractpdf_close(doc);
 
@@ -88,6 +127,7 @@ int main(void)
     options.struct_size = sizeof(options);
     options.rotation_degrees = 90.0f;
     options.clip_enabled = 0;
+    options.alpha = 0;
     bitmap = NULL;
     CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
     CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
@@ -116,6 +156,21 @@ int main(void)
     CHECK(stride == 60 * 3);
     CHECK(components == 3);
     extractpdf_drop_bitmap(bitmap);
+
+    options.alpha = 1;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 60);
+    CHECK(height == 30);
+    CHECK(stride == 60 * 4);
+    CHECK(components == 4);
+    CHECK(extractpdf_bitmap_data(bitmap, &data, &data_size) == EXTRACTPDF_OK);
+    CHECK(data_size == (size_t)60 * 30 * 4);
+    for (i = 0; i < data_size; ++i)
+        CHECK(data[i] == 0);
+    extractpdf_drop_bitmap(bitmap);
+    options.alpha = 0;
 
     options.rotation_degrees = 90.0f;
     bitmap = NULL;

--- a/tests/test_render.c
+++ b/tests/test_render.c
@@ -1,0 +1,60 @@
+#include <extractpdf/extractpdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+int main(void)
+{
+    int sentinel = 0;
+    extractpdf_document *doc = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_bitmap *bitmap = (extractpdf_bitmap *)&sentinel;
+    extractpdf_render_options options = { sizeof(options), 144.0f };
+    int width = 0;
+    int height = 0;
+    int stride = 0;
+    int components = 0;
+
+    CHECK(extractpdf_open(ONE_PAGE_PDF, NULL, &doc) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_render_page_with_options(NULL, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+    CHECK(extractpdf_render_page_with_options(page, NULL, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+    CHECK(extractpdf_render_page_with_options(page, &options, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    options.struct_size = 0;
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+
+    options.struct_size = sizeof(options);
+    options.dpi = 0.0f;
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+
+    options.dpi = 144.0f;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(bitmap != NULL);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 144);
+    CHECK(height == 144);
+    CHECK(stride == 144 * 3);
+    CHECK(components == 3);
+
+    extractpdf_drop_bitmap(bitmap);
+    extractpdf_drop_page(page);
+    extractpdf_close(doc);
+    return EXIT_SUCCESS;
+}

--- a/tests/test_render.c
+++ b/tests/test_render.c
@@ -20,7 +20,7 @@ int main(void)
     extractpdf_document *doc = NULL;
     extractpdf_page *page = NULL;
     extractpdf_bitmap *bitmap = (extractpdf_bitmap *)&sentinel;
-    extractpdf_render_options options = { sizeof(options), 144.0f, 0.0f };
+    extractpdf_render_options options = { sizeof(options), 144.0f, 0.0f, 0, { 0 } };
     int width = 0;
     int height = 0;
     int stride = 0;
@@ -75,8 +75,19 @@ int main(void)
     CHECK(height == 60);
     extractpdf_drop_bitmap(bitmap);
 
+    options.struct_size = offsetof(extractpdf_render_options, clip_enabled);
+    options.rotation_degrees = 90.0f;
+    options.clip_enabled = 1;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 60);
+    CHECK(height == 180);
+    extractpdf_drop_bitmap(bitmap);
+
     options.struct_size = sizeof(options);
     options.rotation_degrees = 90.0f;
+    options.clip_enabled = 0;
     bitmap = NULL;
     CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
     CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
@@ -87,6 +98,41 @@ int main(void)
     extractpdf_drop_bitmap(bitmap);
 
     options.rotation_degrees = NAN;
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+
+    options.rotation_degrees = 0.0f;
+    options.clip_enabled = 1;
+    options.clip.x0 = 20.0f;
+    options.clip.y0 = 10.0f;
+    options.clip.x1 = 80.0f;
+    options.clip.y1 = 40.0f;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 60);
+    CHECK(height == 30);
+    CHECK(stride == 60 * 3);
+    CHECK(components == 3);
+    extractpdf_drop_bitmap(bitmap);
+
+    options.rotation_degrees = 90.0f;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 30);
+    CHECK(height == 60);
+    extractpdf_drop_bitmap(bitmap);
+
+    options.rotation_degrees = 0.0f;
+    options.clip.x1 = options.clip.x0;
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+
+    options.clip.x1 = 80.0f;
+    options.clip.y0 = NAN;
     bitmap = (extractpdf_bitmap *)&sentinel;
     CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
     CHECK(bitmap == NULL);

--- a/tests/test_render.c
+++ b/tests/test_render.c
@@ -1,4 +1,6 @@
 #include <extractpdf/extractpdf.h>
+#include <math.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -18,7 +20,7 @@ int main(void)
     extractpdf_document *doc = NULL;
     extractpdf_page *page = NULL;
     extractpdf_bitmap *bitmap = (extractpdf_bitmap *)&sentinel;
-    extractpdf_render_options options = { sizeof(options), 144.0f };
+    extractpdf_render_options options = { sizeof(options), 144.0f, 0.0f };
     int width = 0;
     int height = 0;
     int stride = 0;
@@ -54,6 +56,41 @@ int main(void)
     CHECK(components == 3);
 
     extractpdf_drop_bitmap(bitmap);
+    extractpdf_drop_page(page);
+    extractpdf_close(doc);
+
+    doc = NULL;
+    page = NULL;
+    bitmap = NULL;
+    CHECK(extractpdf_open(PAGE_BOXES_PDF, NULL, &doc) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+
+    /* A caller using the v1 struct size gets the new field's default behavior. */
+    options.struct_size = offsetof(extractpdf_render_options, rotation_degrees);
+    options.dpi = 72.0f;
+    options.rotation_degrees = 90.0f;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 180);
+    CHECK(height == 60);
+    extractpdf_drop_bitmap(bitmap);
+
+    options.struct_size = sizeof(options);
+    options.rotation_degrees = 90.0f;
+    bitmap = NULL;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_OK);
+    CHECK(extractpdf_bitmap_dimensions(bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == 60);
+    CHECK(height == 180);
+    CHECK(stride == 60 * 3);
+    CHECK(components == 3);
+    extractpdf_drop_bitmap(bitmap);
+
+    options.rotation_degrees = NAN;
+    bitmap = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page_with_options(page, &options, &bitmap) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(bitmap == NULL);
+
     extractpdf_drop_page(page);
     extractpdf_close(doc);
     return EXIT_SUCCESS;


### PR DESCRIPTION
Phase 2 implementation from #2: Page + Render.

Scope covered:
- opaque `extractpdf_page` lifecycle
- page bounds plus MediaBox/CropBox geometry in Fitz page space
- shared coordinate contract: CropBox top-left origin, y down
- opaque `extractpdf_bitmap`
- RGB and premultiplied-RGBA rendering with explicit alpha semantics
- versioned append-only `extractpdf_render_options` using `struct_size`
- DPI/zoom rendering
- per-call rotation transforms
- page-space clip rendering without full-page intermediate allocation
- thumbnail helper that preserves aspect ratio, fits a max pixel box, never upscales, and reuses the same renderer
- bitmap dimensions/data accessors and documented lifetime/stride rules
- README and v2 design documentation aligned with the Page+Render architecture

Intrinsic format-specific page rotation metadata is deliberately not exposed through the generic Page API. Fitz bounds are already in displayed page coordinates; PDF `/Rotate` can be surfaced later through PDF-specific metadata if needed.

TDD / verification evidence:
- each public slice was introduced RED first and then minimally implemented
- exact head `6a877f0c4e7e32c47699d224ed026fc584386626`
- workflow #105 full-ci: Linux ✅ (normal CTest + ASan/UBSan), macOS ✅, Windows DLL build/runtime CTest ✅
- Linux/macOS/Windows vcpkg binary caches all restored successfully at the final checkpoint

Phase 2 is cross-platform complete at this head. PR remains draft pending explicit integration/merge decision.

Tracks #2.