### PR TITLE
feat: add page bounds and rotation

### DIFF
--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -20,6 +20,18 @@ extern "C" {
 typedef struct extractpdf_document extractpdf_document;
 typedef struct extractpdf_page extractpdf_page;
 
+typedef struct extractpdf_rect {
+    float x0;
+    float y0;
+    float x1;
+    float y1;
+} extractpdf_rect;
+
+typedef enum extractpdf_page_box {
+    EXTRACTPDF_PAGE_BOX_MEDIA = 0,
+    EXTRACTPDF_PAGE_BOX_CROP = 1
+} extractpdf_page_box;
+
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
     EXTRACTPDF_ERROR_ARGUMENT = 1,
@@ -44,6 +56,23 @@ EXTRACTPDF_API extractpdf_status extractpdf_load_page(
     extractpdf_document *document,
     int page_index,
     extractpdf_page **out_page);
+
+/*
+ * Return a page box in ExtractPDF page space. The transformed CropBox
+ * top-left is (0, 0), +x points right, +y points down, and PDF /Rotate
+ * and /UserUnit are already reflected in the returned coordinates.
+ * MediaBox coordinates may therefore extend outside the CropBox and be
+ * negative.
+ */
+EXTRACTPDF_API extractpdf_status extractpdf_page_bounds(
+    extractpdf_page *page,
+    extractpdf_page_box box,
+    extractpdf_rect *out_bounds);
+
+/* Return the PDF page rotation normalized to 0, 90, 180, or 270 degrees. */
+EXTRACTPDF_API extractpdf_status extractpdf_page_rotation(
+    extractpdf_page *page,
+    int *out_rotation_degrees);
 
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);

--- a/src/page.c
+++ b/src/page.c
@@ -95,6 +95,7 @@ extractpdf_status extractpdf_page_bounds(
     extractpdf_page_box box,
     extractpdf_rect *out_bounds)
 {
+    pdf_page *pdf = NULL;
     fz_box_type mupdf_box;
     fz_rect bounds = fz_empty_rect;
     int caught_code = FZ_ERROR_NONE;
@@ -104,12 +105,15 @@ extractpdf_status extractpdf_page_bounds(
     if (!extractpdf_box_to_mupdf(box, &mupdf_box))
         return EXTRACTPDF_ERROR_ARGUMENT;
 
+    fz_var(pdf);
     fz_var(bounds);
     fz_var(caught_code);
 
     fz_try(page->document->ctx)
     {
-        bounds = fz_bound_page(page->document->ctx, page->page, mupdf_box);
+        pdf = pdf_page_from_fz_page(page->document->ctx, page->page);
+        if (pdf != NULL)
+            bounds = pdf_bound_page(page->document->ctx, pdf, mupdf_box);
     }
     fz_catch(page->document->ctx)
     {
@@ -119,6 +123,8 @@ extractpdf_status extractpdf_page_bounds(
 
     if (caught_code != FZ_ERROR_NONE)
         return extractpdf_status_from_mupdf(caught_code);
+    if (pdf == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
 
     out_bounds->x0 = bounds.x0;
     out_bounds->y0 = bounds.y0;

--- a/src/page.c
+++ b/src/page.c
@@ -1,6 +1,34 @@
 #include "internal.h"
 
+#include <mupdf/pdf.h>
 #include <stdlib.h>
+
+static int extractpdf_box_to_mupdf(
+    extractpdf_page_box box,
+    fz_box_type *out_box)
+{
+    switch (box) {
+    case EXTRACTPDF_PAGE_BOX_MEDIA:
+        *out_box = FZ_MEDIA_BOX;
+        return 1;
+    case EXTRACTPDF_PAGE_BOX_CROP:
+        *out_box = FZ_CROP_BOX;
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static int extractpdf_normalize_rotation(int rotation)
+{
+    rotation %= 360;
+    if (rotation < 0)
+        rotation += 360;
+    rotation = 90 * ((rotation + 45) / 90);
+    if (rotation >= 360)
+        rotation = 0;
+    return rotation;
+}
 
 extractpdf_status extractpdf_load_page(
     extractpdf_document *document,
@@ -59,6 +87,82 @@ extractpdf_status extractpdf_load_page(
     }
 
     *out_page = page;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_page_bounds(
+    extractpdf_page *page,
+    extractpdf_page_box box,
+    extractpdf_rect *out_bounds)
+{
+    fz_box_type mupdf_box;
+    fz_rect bounds = fz_empty_rect;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (page == NULL || out_bounds == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (!extractpdf_box_to_mupdf(box, &mupdf_box))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(bounds);
+    fz_var(caught_code);
+
+    fz_try(page->document->ctx)
+    {
+        bounds = fz_bound_page(page->document->ctx, page->page, mupdf_box);
+    }
+    fz_catch(page->document->ctx)
+    {
+        caught_code = fz_caught(page->document->ctx);
+        fz_report_error(page->document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+
+    out_bounds->x0 = bounds.x0;
+    out_bounds->y0 = bounds.y0;
+    out_bounds->x1 = bounds.x1;
+    out_bounds->y1 = bounds.y1;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_page_rotation(
+    extractpdf_page *page,
+    int *out_rotation_degrees)
+{
+    pdf_page *pdf_page = NULL;
+    int rotation = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (page == NULL || out_rotation_degrees == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(pdf_page);
+    fz_var(rotation);
+    fz_var(caught_code);
+
+    fz_try(page->document->ctx)
+    {
+        pdf_page = pdf_page_from_fz_page(page->document->ctx, page->page);
+        if (pdf_page != NULL)
+            rotation = pdf_dict_get_inheritable_int(
+                page->document->ctx,
+                pdf_page->obj,
+                PDF_NAME(Rotate));
+    }
+    fz_catch(page->document->ctx)
+    {
+        caught_code = fz_caught(page->document->ctx);
+        fz_report_error(page->document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (pdf_page == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    *out_rotation_degrees = extractpdf_normalize_rotation(rotation);
     return EXTRACTPDF_OK;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,8 +24,18 @@ endif()
 add_test(NAME extractpdf.document COMMAND extractpdf_test_document)
 set_tests_properties(extractpdf.document PROPERTIES TIMEOUT 60)
 
+add_executable(extractpdf_test_page test_page.c)
+target_link_libraries(extractpdf_test_page PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_page PRIVATE
+  GEOMETRY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/geometry.pdf")
+add_test(NAME extractpdf.page COMMAND extractpdf_test_page)
+set_tests_properties(extractpdf.page PROPERTIES TIMEOUT 20)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
-  foreach(test_target IN ITEMS extractpdf_test_status extractpdf_test_document)
+  foreach(test_target IN ITEMS
+      extractpdf_test_status
+      extractpdf_test_document
+      extractpdf_test_page)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/geometry.pdf
+++ b/tests/fixtures/geometry.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%extractpdf geometry fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 200] /CropBox [50 20 350 180] /Rotate 90 /Resources << >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000038 00000 n 
+0000000087 00000 n 
+0000000144 00000 n 
+0000000284 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+333
+%%EOF

--- a/tests/test_page.c
+++ b/tests/test_page.c
@@ -1,0 +1,65 @@
+#include <extractpdf/extractpdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static void check_rect(
+    extractpdf_rect rect,
+    float x0,
+    float y0,
+    float x1,
+    float y1)
+{
+    CHECK(rect.x0 == x0);
+    CHECK(rect.y0 == y0);
+    CHECK(rect.x1 == x1);
+    CHECK(rect.y1 == y1);
+}
+
+int main(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = { 11.0f, 12.0f, 13.0f, 14.0f };
+    int rotation = -1;
+
+    CHECK(extractpdf_open(GEOMETRY_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_page_bounds(NULL, EXTRACTPDF_PAGE_BOX_CROP, &bounds) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    check_rect(bounds, 11.0f, 12.0f, 13.0f, 14.0f);
+
+    CHECK(extractpdf_page_bounds(page, EXTRACTPDF_PAGE_BOX_CROP, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_page_bounds(page, (extractpdf_page_box)99, &bounds) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    check_rect(bounds, 11.0f, 12.0f, 13.0f, 14.0f);
+
+    CHECK(extractpdf_page_bounds(page, EXTRACTPDF_PAGE_BOX_CROP, &bounds) ==
+          EXTRACTPDF_OK);
+    check_rect(bounds, 0.0f, 0.0f, 160.0f, 300.0f);
+
+    CHECK(extractpdf_page_bounds(page, EXTRACTPDF_PAGE_BOX_MEDIA, &bounds) ==
+          EXTRACTPDF_OK);
+    check_rect(bounds, -20.0f, -50.0f, 180.0f, 350.0f);
+
+    CHECK(extractpdf_page_rotation(NULL, &rotation) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(rotation == -1);
+    CHECK(extractpdf_page_rotation(page, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_page_rotation(page, &rotation) == EXTRACTPDF_OK);
+    CHECK(rotation == 90);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Second implementation slice from #2, stacked on PR #3 (`feat/page-lifecycle`).

Scope:
- introduce public `extractpdf_rect`
- expose MediaBox/CropBox bounds in one shared page-space coordinate system
- expose normalized page rotation
- lock geometry semantics with a deterministic `/MediaBox`, `/CropBox`, `/Rotate 90` PDF fixture
- no rendering, DPI, clip, text, or search yet

Coordinate contract under test:
- page space origin is the transformed CropBox top-left
- +x points right, +y points down
- bounds account for PDF `/Rotate` and `/UserUnit`
- crop bounds for the fixture: `[0, 0, 160, 300]`
- media bounds for the fixture: `[-20, -50, 180, 350]`
- rotation: `90`

TDD sequence:
1. commit only the wished-for geometry tests + fixture
2. verify Linux CI RED because the public geometry API is missing
3. implement the minimal MuPDF-backed API
4. require Linux exact-head GREEN; defer Win/macOS to the Phase 2 `full-ci` checkpoint

Tracks #2.