### PR TITLE
feat: add page render bitmap primitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ endif()
 add_library(extractpdf
   src/status.c
   src/document.c
-  src/page.c)
+  src/page.c
+  src/render.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -2,6 +2,7 @@
 #define EXTRACTPDF_EXTRACTPDF_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,6 +20,7 @@ extern "C" {
 
 typedef struct extractpdf_document extractpdf_document;
 typedef struct extractpdf_page extractpdf_page;
+typedef struct extractpdf_bitmap extractpdf_bitmap;
 
 typedef struct extractpdf_rect {
     float x0;
@@ -31,6 +33,34 @@ typedef enum extractpdf_page_box {
     EXTRACTPDF_PAGE_BOX_MEDIA = 0,
     EXTRACTPDF_PAGE_BOX_CROP = 1
 } extractpdf_page_box;
+
+typedef enum extractpdf_pixel_format {
+    EXTRACTPDF_PIXEL_FORMAT_RGB8 = 1,
+    EXTRACTPDF_PIXEL_FORMAT_RGBA8 = 2
+} extractpdf_pixel_format;
+
+/*
+ * Version-1 render options prefix. Future versions may append fields.
+ * Callers set struct_size to sizeof(extractpdf_render_options). A NULL
+ * options pointer selects RGB8 at the default 72-DPI page-space scale.
+ */
+typedef struct extractpdf_render_options {
+    uint32_t struct_size;
+    uint32_t pixel_format; /* extractpdf_pixel_format */
+} extractpdf_render_options;
+
+#define EXTRACTPDF_RENDER_OPTIONS_V1_SIZE 8u
+#define EXTRACTPDF_RENDER_OPTIONS_INIT \
+    { (uint32_t)sizeof(extractpdf_render_options), \
+      (uint32_t)EXTRACTPDF_PIXEL_FORMAT_RGB8 }
+
+typedef struct extractpdf_bitmap_info {
+    int width;
+    int height;
+    int stride;
+    extractpdf_pixel_format pixel_format;
+    size_t data_size;
+} extractpdf_bitmap_info;
 
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
@@ -74,8 +104,31 @@ EXTRACTPDF_API extractpdf_status extractpdf_page_rotation(
     extractpdf_page *page,
     int *out_rotation_degrees);
 
+/*
+ * Render a loaded page. RGB8 uses an opaque white background. RGBA8 uses
+ * premultiplied alpha with a transparent background. The returned bitmap
+ * owns a copy of its pixels and remains valid after the source page/document
+ * is released.
+ */
+EXTRACTPDF_API extractpdf_status extractpdf_render_page(
+    extractpdf_page *page,
+    const extractpdf_render_options *options,
+    extractpdf_bitmap **out_bitmap);
+
+EXTRACTPDF_API extractpdf_status extractpdf_bitmap_get_info(
+    const extractpdf_bitmap *bitmap,
+    extractpdf_bitmap_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_bitmap_get_pixels(
+    const extractpdf_bitmap *bitmap,
+    const unsigned char **out_pixels,
+    size_t *out_size);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
+
+EXTRACTPDF_API void extractpdf_drop_bitmap(
+    extractpdf_bitmap *bitmap);
 
 EXTRACTPDF_API void extractpdf_drop_page(
     extractpdf_page *page);

--- a/src/internal.h
+++ b/src/internal.h
@@ -14,6 +14,15 @@ struct extractpdf_page {
     fz_page *page;
 };
 
+struct extractpdf_bitmap {
+    int width;
+    int height;
+    int stride;
+    extractpdf_pixel_format pixel_format;
+    size_t data_size;
+    unsigned char *pixels;
+};
+
 extractpdf_status extractpdf_status_from_mupdf(int code);
 
 #endif

--- a/src/render.c
+++ b/src/render.c
@@ -1,0 +1,163 @@
+#include "internal.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int extractpdf_render_format(
+    const extractpdf_render_options *options,
+    extractpdf_pixel_format *out_format,
+    int *out_alpha)
+{
+    extractpdf_pixel_format format = EXTRACTPDF_PIXEL_FORMAT_RGB8;
+
+    if (options != NULL) {
+        if (options->struct_size < EXTRACTPDF_RENDER_OPTIONS_V1_SIZE)
+            return 0;
+        format = (extractpdf_pixel_format)options->pixel_format;
+    }
+
+    switch (format) {
+    case EXTRACTPDF_PIXEL_FORMAT_RGB8:
+        *out_format = format;
+        *out_alpha = 0;
+        return 1;
+    case EXTRACTPDF_PIXEL_FORMAT_RGBA8:
+        *out_format = format;
+        *out_alpha = 1;
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+extractpdf_status extractpdf_render_page(
+    extractpdf_page *page,
+    const extractpdf_render_options *options,
+    extractpdf_bitmap **out_bitmap)
+{
+    extractpdf_bitmap *bitmap = NULL;
+    extractpdf_pixel_format format;
+    fz_pixmap *pixmap = NULL;
+    int alpha = 0;
+    int caught_code = FZ_ERROR_NONE;
+    int width;
+    int height;
+    int stride;
+    int components;
+    size_t data_size;
+
+    if (out_bitmap == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_bitmap = NULL;
+
+    if (page == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (!extractpdf_render_format(options, &format, &alpha))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(pixmap);
+    fz_var(caught_code);
+
+    fz_try(page->document->ctx)
+    {
+        pixmap = fz_new_pixmap_from_page(
+            page->document->ctx,
+            page->page,
+            fz_identity,
+            fz_device_rgb(page->document->ctx),
+            alpha);
+    }
+    fz_catch(page->document->ctx)
+    {
+        caught_code = fz_caught(page->document->ctx);
+        fz_report_error(page->document->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (pixmap == NULL)
+        return EXTRACTPDF_ERROR_MUPDF;
+
+    width = fz_pixmap_width(page->document->ctx, pixmap);
+    height = fz_pixmap_height(page->document->ctx, pixmap);
+    stride = fz_pixmap_stride(page->document->ctx, pixmap);
+    components = fz_pixmap_components(page->document->ctx, pixmap);
+
+    if (width <= 0 || height <= 0 || stride <= 0 ||
+        components != (alpha ? 4 : 3)) {
+        fz_drop_pixmap(page->document->ctx, pixmap);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+
+    if ((size_t)height > SIZE_MAX / (size_t)stride) {
+        fz_drop_pixmap(page->document->ctx, pixmap);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    data_size = (size_t)height * (size_t)stride;
+
+    bitmap = (extractpdf_bitmap *)calloc(1, sizeof(*bitmap));
+    if (bitmap == NULL) {
+        fz_drop_pixmap(page->document->ctx, pixmap);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    bitmap->pixels = (unsigned char *)malloc(data_size);
+    if (bitmap->pixels == NULL) {
+        free(bitmap);
+        fz_drop_pixmap(page->document->ctx, pixmap);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    memcpy(
+        bitmap->pixels,
+        fz_pixmap_samples(page->document->ctx, pixmap),
+        data_size);
+    fz_drop_pixmap(page->document->ctx, pixmap);
+
+    bitmap->width = width;
+    bitmap->height = height;
+    bitmap->stride = stride;
+    bitmap->pixel_format = format;
+    bitmap->data_size = data_size;
+
+    *out_bitmap = bitmap;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_bitmap_get_info(
+    const extractpdf_bitmap *bitmap,
+    extractpdf_bitmap_info *out_info)
+{
+    if (bitmap == NULL || out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->width = bitmap->width;
+    out_info->height = bitmap->height;
+    out_info->stride = bitmap->stride;
+    out_info->pixel_format = bitmap->pixel_format;
+    out_info->data_size = bitmap->data_size;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_bitmap_get_pixels(
+    const extractpdf_bitmap *bitmap,
+    const unsigned char **out_pixels,
+    size_t *out_size)
+{
+    if (bitmap == NULL || out_pixels == NULL || out_size == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_pixels = bitmap->pixels;
+    *out_size = bitmap->data_size;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_bitmap(extractpdf_bitmap *bitmap)
+{
+    if (bitmap == NULL)
+        return;
+
+    free(bitmap->pixels);
+    free(bitmap);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,11 +31,19 @@ target_compile_definitions(extractpdf_test_page PRIVATE
 add_test(NAME extractpdf.page COMMAND extractpdf_test_page)
 set_tests_properties(extractpdf.page PROPERTIES TIMEOUT 20)
 
+add_executable(extractpdf_test_render test_render.c)
+target_link_libraries(extractpdf_test_render PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_render PRIVATE
+  RENDER_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/render.pdf")
+add_test(NAME extractpdf.render COMMAND extractpdf_test_render)
+set_tests_properties(extractpdf.render PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
       extractpdf_test_document
-      extractpdf_test_page)
+      extractpdf_test_page
+      extractpdf_test_render)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/render.pdf
+++ b/tests/fixtures/render.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+%extractpdf render fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 50] /CropBox [0 0 100 50] /Resources << >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 26 >>
+stream
+0 0 0 rg
+10 10 20 30 re
+f
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000036 00000 n 
+0000000085 00000 n 
+0000000142 00000 n 
+0000000267 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+342
+%%EOF

--- a/tests/test_render.c
+++ b/tests/test_render.c
@@ -1,0 +1,129 @@
+#include <extractpdf/extractpdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static void check_rgb_pixel(
+    const unsigned char *pixels,
+    int stride,
+    int x,
+    int y,
+    unsigned char r,
+    unsigned char g,
+    unsigned char b)
+{
+    const unsigned char *pixel = pixels + (size_t)y * (size_t)stride +
+                                 (size_t)x * 3u;
+    CHECK(pixel[0] == r);
+    CHECK(pixel[1] == g);
+    CHECK(pixel[2] == b);
+}
+
+static void check_rgba_pixel(
+    const unsigned char *pixels,
+    int stride,
+    int x,
+    int y,
+    unsigned char r,
+    unsigned char g,
+    unsigned char b,
+    unsigned char a)
+{
+    const unsigned char *pixel = pixels + (size_t)y * (size_t)stride +
+                                 (size_t)x * 4u;
+    CHECK(pixel[0] == r);
+    CHECK(pixel[1] == g);
+    CHECK(pixel[2] == b);
+    CHECK(pixel[3] == a);
+}
+
+int main(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_bitmap *rgb = (extractpdf_bitmap *)&sentinel;
+    extractpdf_bitmap *rgba = NULL;
+    extractpdf_bitmap_info info = { 0 };
+    extractpdf_render_options options;
+    const unsigned char *pixels = NULL;
+    size_t size = 0;
+
+    CHECK(extractpdf_open(RENDER_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_render_page(NULL, NULL, &rgb) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(rgb == NULL);
+    CHECK(extractpdf_render_page(page, NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    options.struct_size = 0;
+    options.pixel_format = EXTRACTPDF_PIXEL_FORMAT_RGB8;
+    rgb = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page(page, &options, &rgb) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(rgb == NULL);
+
+    options.struct_size = sizeof(options);
+    options.pixel_format = (extractpdf_pixel_format)99;
+    rgb = (extractpdf_bitmap *)&sentinel;
+    CHECK(extractpdf_render_page(page, &options, &rgb) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(rgb == NULL);
+
+    rgb = NULL;
+    CHECK(extractpdf_render_page(page, NULL, &rgb) == EXTRACTPDF_OK);
+    CHECK(rgb != NULL);
+    CHECK(extractpdf_bitmap_get_info(rgb, &info) == EXTRACTPDF_OK);
+    CHECK(info.width == 100);
+    CHECK(info.height == 50);
+    CHECK(info.stride == 300);
+    CHECK(info.pixel_format == EXTRACTPDF_PIXEL_FORMAT_RGB8);
+    CHECK(info.data_size == 15000u);
+    CHECK(extractpdf_bitmap_get_pixels(rgb, &pixels, &size) == EXTRACTPDF_OK);
+    CHECK(pixels != NULL);
+    CHECK(size == info.data_size);
+    check_rgb_pixel(pixels, info.stride, 0, 0, 255, 255, 255);
+    check_rgb_pixel(pixels, info.stride, 20, 25, 0, 0, 0);
+
+    options.struct_size = sizeof(options);
+    options.pixel_format = EXTRACTPDF_PIXEL_FORMAT_RGBA8;
+    CHECK(extractpdf_render_page(page, &options, &rgba) == EXTRACTPDF_OK);
+    CHECK(rgba != NULL);
+    CHECK(extractpdf_bitmap_get_info(rgba, &info) == EXTRACTPDF_OK);
+    CHECK(info.width == 100);
+    CHECK(info.height == 50);
+    CHECK(info.stride == 400);
+    CHECK(info.pixel_format == EXTRACTPDF_PIXEL_FORMAT_RGBA8);
+    CHECK(info.data_size == 20000u);
+    CHECK(extractpdf_bitmap_get_pixels(rgba, &pixels, &size) == EXTRACTPDF_OK);
+    CHECK(size == info.data_size);
+    check_rgba_pixel(pixels, info.stride, 0, 0, 0, 0, 0, 0);
+    check_rgba_pixel(pixels, info.stride, 20, 25, 0, 0, 0, 255);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+
+    /* Rendered bitmaps own their pixels and outlive the source page/document. */
+    CHECK(extractpdf_bitmap_get_info(rgb, &info) == EXTRACTPDF_OK);
+    CHECK(info.width == 100);
+    CHECK(extractpdf_bitmap_get_pixels(rgb, &pixels, &size) == EXTRACTPDF_OK);
+    check_rgb_pixel(pixels, info.stride, 20, 25, 0, 0, 0);
+
+    CHECK(extractpdf_bitmap_get_info(NULL, &info) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_get_info(rgb, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_get_pixels(NULL, &pixels, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_get_pixels(rgb, NULL, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_bitmap_get_pixels(rgb, &pixels, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    extractpdf_drop_bitmap(rgb);
+    extractpdf_drop_bitmap(rgba);
+    extractpdf_drop_bitmap(NULL);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Third implementation slice from #2, stacked on PR #4 (`feat/page-bounds`).

Scope:
- render a loaded page at the existing 72-DPI page-space scale
- support RGB8 (opaque white background) and RGBA8 (premultiplied alpha / transparent background)
- return an opaque ExtractPDF-owned bitmap, not an MuPDF pixmap
- bitmap owns a copied pixel buffer and remains valid after its source page/document is dropped
- expose bitmap metadata and read-only pixel bytes
- no zoom/DPI scaling, extra rotation, clip, thumbnail, encoding, text, or search yet

The render-options prefix is intentionally size-tagged so later slices can append DPI/rotation/clip fields without breaking callers compiled against this first version.

TDD sequence:
1. RED commit adds deterministic 100x50 PDF content fixture and render contract tests only
2. local compiler RED proves the bitmap/render ABI is absent
3. implement the minimal MuPDF-backed render/copy wrapper
4. require exact-head Linux build + CTest + ASan/UBSan GREEN; defer Win/macOS to the Phase 2 `full-ci` checkpoint

Tracks #2.