### PR TITLE
ci: persist Linux vcpkg binary cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/vcpkg/archives
+          key: vcpkg-linux-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-ports/libmupdf/**') }}
+          restore-keys: |
+            vcpkg-linux-${{ env.VCPKG_COMMIT }}-
+
       - name: Bootstrap pinned vcpkg
         shell: bash
         run: |


### PR DESCRIPTION
CI-only slice stacked on PR #5.

Goal: make the Linux PR inner loop actually fast by persisting vcpkg's binary archives between GitHub-hosted runners.

Change:
- cache `~/.cache/vcpkg/archives` with `actions/cache@v4`
- key includes the pinned vcpkg commit plus `vcpkg.json` and the local MuPDF overlay contents
- restore key is restricted to the same pinned vcpkg commit
- no macOS/Windows cadence or build behavior changes

Verification target:
1. first run may be a cold miss and must still pass build/CTest/sanitizers
2. completed job must save the cache
3. the next stacked Linux run must restore packages from the persistent cache instead of rebuilding HarfBuzz/MuPDF from source

Tracks the Linux-first development workflow used by #2.