### PR TITLE
feat: add plain UTF-8 page text extraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ add_library(extractpdf
   src/status.c
   src/document.c
   src/page.c
-  src/render.c)
+  src/render.c
+  src/text.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -103,8 +103,16 @@ EXTRACTPDF_API extractpdf_status extractpdf_bitmap_data(
     const unsigned char **out_data,
     size_t *out_size);
 
+EXTRACTPDF_API extractpdf_status extractpdf_extract_text(
+    extractpdf_page *page,
+    char **out_utf8,
+    size_t *out_size);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
+
+EXTRACTPDF_API void extractpdf_free(
+    void *memory);
 
 EXTRACTPDF_API void extractpdf_drop_bitmap(
     extractpdf_bitmap *bitmap);

--- a/src/text.c
+++ b/src/text.c
@@ -1,0 +1,76 @@
+#include "internal.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+extractpdf_status extractpdf_extract_text(
+    extractpdf_page *page,
+    char **out_utf8,
+    size_t *out_size)
+{
+    fz_context *ctx;
+    fz_buffer *buffer = NULL;
+    unsigned char *storage = NULL;
+    char *copy;
+    size_t size = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
+
+    if (page == NULL || out_utf8 == NULL || out_size == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = page->document->ctx;
+    fz_var(buffer);
+    fz_var(storage);
+    fz_var(size);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        buffer = fz_new_buffer_from_page(ctx, page->page, NULL);
+        if (buffer != NULL)
+            size = fz_buffer_storage(ctx, buffer, &storage);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        fz_drop_buffer(ctx, buffer);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+    if (buffer == NULL) {
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    if (size == SIZE_MAX) {
+        fz_drop_buffer(ctx, buffer);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    copy = (char *)malloc(size + 1);
+    if (copy == NULL) {
+        fz_drop_buffer(ctx, buffer);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    if (size != 0)
+        memcpy(copy, storage, size);
+    copy[size] = '\0';
+    fz_drop_buffer(ctx, buffer);
+
+    *out_utf8 = copy;
+    *out_size = size;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_free(void *memory)
+{
+    free(memory);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,8 +33,20 @@ target_compile_definitions(extractpdf_test_render PRIVATE
 add_test(NAME extractpdf.render COMMAND extractpdf_test_render)
 set_tests_properties(extractpdf.render PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_text test_text.c)
+target_link_libraries(extractpdf_test_text PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_text PRIVATE
+  ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
+  TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/text-one-page.pdf")
+add_test(NAME extractpdf.text COMMAND extractpdf_test_text)
+set_tests_properties(extractpdf.text PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
-  foreach(test_target IN ITEMS extractpdf_test_status extractpdf_test_document extractpdf_test_render)
+  foreach(test_target IN ITEMS
+      extractpdf_test_status
+      extractpdf_test_document
+      extractpdf_test_render
+      extractpdf_test_text)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/text-one-page.pdf
+++ b/tests/fixtures/text-one-page.pdf
@@ -13,7 +13,7 @@ endobj
 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
 endobj
 5 0 obj
-<< /Length 43 >>
+<< /Length 44 >>
 stream
 BT
 /F1 18 Tf
@@ -33,5 +33,5 @@ xref
 trailer
 << /Size 6 /Root 1 0 R >>
 startxref
-455
+456
 %%EOF

--- a/tests/fixtures/text-one-page.pdf
+++ b/tests/fixtures/text-one-page.pdf
@@ -1,0 +1,37 @@
+%PDF-1.4
+%ExtractPDF text fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Length 43 >>
+stream
+BT
+/F1 18 Tf
+12 60 Td
+(Hello Caf\351) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000363 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+455
+%%EOF

--- a/tests/test_text.c
+++ b/tests/test_text.c
@@ -1,0 +1,75 @@
+#include <extractpdf/extractpdf.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+    {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+int main(void)
+{
+    static const unsigned char expected_prefix[] = {
+        'H', 'e', 'l', 'l', 'o', ' ', 'C', 'a', 'f', 0xC3, 0xA9
+    };
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    char *text = (char *)&sentinel;
+    size_t size = 123;
+    size_t i;
+
+    CHECK(extractpdf_open(TEXT_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_extract_text(NULL, &text, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    size = 123;
+    CHECK(extractpdf_extract_text(page, NULL, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(size == 0);
+
+    text = (char *)&sentinel;
+    CHECK(extractpdf_extract_text(page, &text, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+
+    CHECK(extractpdf_extract_text(page, &text, &size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(size >= sizeof(expected_prefix));
+
+    /* The returned text owns its bytes independently of MuPDF handles. */
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    page = NULL;
+    document = NULL;
+
+    CHECK(memcmp(text, expected_prefix, sizeof(expected_prefix)) == 0);
+    for (i = 0; i < size; ++i)
+        CHECK(text[i] != '\0');
+    CHECK(text[size] == '\0');
+    extractpdf_free(text);
+
+    CHECK(extractpdf_open(ONE_PAGE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    text = (char *)&sentinel;
+    size = 123;
+    CHECK(extractpdf_extract_text(page, &text, &size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(size == 0);
+    CHECK(text[0] == '\0');
+    extractpdf_free(text);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    extractpdf_free(NULL);
+    return EXIT_SUCCESS;
+}

--- a/tests/test_text.c
+++ b/tests/test_text.c
@@ -7,7 +7,6 @@
 static void check_impl(int condition, const char *expression, int line)
 {
     if (!condition) {
-    {
         fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Phase 3 Content, first slice from #7 / #2.

Implemented contract:
- `extractpdf_extract_text(extractpdf_page *, char **, size_t *)`
- UTF-8, NUL-terminated output; byte size excludes the trailing NUL
- success always returns owned memory, including an allocated empty string for an empty page
- failure clears provided outputs
- returned text is independent of page/document lifetime
- caller releases with `extractpdf_free`; `extractpdf_free(NULL)` is safe
- implementation obtains MuPDF plain-text bytes through `fz_new_buffer_from_page` / `fz_buffer_storage`, copies them into ExtractPDF-owned memory, and drops the MuPDF buffer before return
- deterministic fixture verifies WinAnsi `é` emerges as UTF-8 bytes `C3 A9`

TDD evidence:
- RED: workflow #102 at `06779fb3d27321dedce5a7ac28531b51437a0fd8` built existing Page+Render code and failed only on missing `extractpdf_extract_text` / `extractpdf_free` declarations and symbols
- GREEN: workflow #108 at exact head `2eef49e06c744071897cf44265a47863aa7720cd` passed Linux build, normal CTest, ASan/UBSan build, and sanitizer CTest

Deferred cross-platform verification is now complete on the cumulative Phase 3 exact head `204aa90349256e323685ef34ad564032dd4aac52`: `full-ci` workflow #130 passed Linux static + ASan/UBSan, macOS native build/test, and Windows DLL build/test.

PR remains draft for stacked integration. Tracks #7 and #2.