### PR TITLE
feat: add immutable structured text snapshot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(extractpdf
   src/document.c
   src/page.c
   src/render.c
-  src/text.c)
+  src/text.c
+  src/structured_text.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/docs/superpowers/plans/2026-08-27-extractpdf-structured-text.md
+++ b/docs/superpowers/plans/2026-08-27-extractpdf-structured-text.md
@@ -1,0 +1,143 @@
+# ExtractPDF Structured Text Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an immutable, MuPDF-independent structured-text snapshot with indexed block/line/span traversal, stable geometry/style metadata, and internal character quads reserved for later search.
+
+**Architecture:** `extractpdf_extract_structured_text()` asks MuPDF for one `fz_stext_page`, then projects only text blocks into ExtractPDF-owned flat arrays and UTF-8 storage. Public callers traverse opaque snapshot data through count/info/text accessors; no public pointer references MuPDF memory after extraction returns.
+
+**Tech Stack:** C11, MuPDF 1.28.2 Fitz structured text API, CMake/CTest, Linux ASan/UBSan, GitHub Actions Linux-first CI.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-extractpdf-structured-text-design.md`
+
+## Global Constraints
+
+- No MuPDF types or numeric MuPDF flags in `include/extractpdf/extractpdf.h`.
+- Structured-text coordinates use the existing Fitz page-space contract: CropBox top-left origin, points, Y down.
+- Snapshot lifetime is independent of `extractpdf_page` and `extractpdf_document` after successful extraction.
+- V1 exposes text blocks only; image/vector/grid/structure blocks are skipped.
+- V1 extraction uses MuPDF structured-text default options (`flags = 0`).
+- Span style identity is font identity + size + ARGB + bidi + internal character flags.
+- Public `*_info` structs are versioned with `struct_size` and append-only.
+- Linux normal CTest + ASan/UBSan is required for each RED/GREEN slice; Windows/macOS wait for the Phase 3 `full-ci` checkpoint.
+- Search APIs are out of scope, but internal character Unicode/quads must be retained for later reuse.
+
+---
+
+### Task 1: Lock Snapshot Traversal Contract With a Real RED
+
+**Files:**
+- Create: `tests/fixtures/structured-text.pdf`
+- Create: `tests/test_structured_text.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: existing `extractpdf_document`, `extractpdf_page`, `extractpdf_rect`, and page lifecycle.
+- Produces the required public names for Task 2: `extractpdf_text_page`, `extractpdf_text_block_info`, `extractpdf_text_line_info`, `extractpdf_text_span_info`, `extractpdf_extract_structured_text`, block/line/span count/info accessors, `extractpdf_text_span_text`, and `extractpdf_drop_text_page`.
+
+- [ ] **Step 1: Add a deterministic valid PDF fixture**
+
+Create one page containing a single line with two adjacent style runs: `Hello ` in Helvetica 18pt black and `Caf\351` in Helvetica 12pt red using WinAnsi encoding. Author exact stream length and xref offsets; do not rely on MuPDF repair mode.
+
+- [ ] **Step 2: Add the first contract test**
+
+The test must assert successful extraction, exactly one text block, one line, two spans, exact UTF-8 text (`Hello ` and `Caf\xC3\xA9`), 18/12 pt span sizes, black/red ARGB, horizontal writing mode, LTR bidi, finite/ordered geometry, and snapshot validity after dropping page/document.
+
+- [ ] **Step 3: Wire the test into CTest**
+
+Add `extractpdf.structured_text` with a 30-second timeout and the fixture path compile definition. Include the target in Windows DLL staging even though Windows will remain skipped during Linux-first development.
+
+- [ ] **Step 4: Verify RED**
+
+Run the PR Linux workflow. Expected failure: compile/link errors only because the structured-text public types/functions do not exist. Any PDF repair warning, fixture parse failure, or unrelated syntax error must be fixed before production code is written.
+
+- [ ] **Step 5: Commit the RED**
+
+Commit only the fixture/test/CMake wiring with message `test: define structured text snapshot contract`.
+
+---
+
+### Task 2: Implement Immutable Snapshot and Style Spans
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Create: `src/structured_text.c`
+- Modify: `src/internal.h`
+- Modify: `CMakeLists.txt`
+- Test: `tests/test_structured_text.c`
+
+**Interfaces:**
+- Consumes: MuPDF `fz_new_stext_page_from_page`, `fz_stext_page` text blocks/lines/chars, existing status mapping.
+- Produces: the full V1 structured-text API from the design spec.
+
+- [ ] **Step 1: Add only the public declarations demanded by the RED**
+
+Add `<stdint.h>`, opaque `extractpdf_text_page`, and the three versioned info structs. Add the extraction, count/info/text, and drop declarations exactly as specified.
+
+- [ ] **Step 2: Define focused internal storage**
+
+Use flat ExtractPDF-owned arrays for blocks, lines, spans, and chars. Store array ranges by index/count, not linked pointers. Store UTF-8 span strings in snapshot-owned allocations or one snapshot-owned string arena. Internal chars retain Unicode code point plus four-point quad even though no V1 character accessor exists.
+
+- [ ] **Step 3: Project MuPDF text blocks into the snapshot**
+
+Create an `fz_stext_page` with default options inside `fz_try/fz_catch`. Count text blocks/lines/chars, allocate with overflow checks, then copy block and line metadata. Skip non-text blocks.
+
+- [ ] **Step 4: Build spans while copying characters**
+
+Start a new span whenever font pointer, size, ARGB, bidi, or character flags changes. Append each Unicode code point as UTF-8. Span bounds are the axis-aligned union of character quads. Preserve the character Unicode/quad/style association internally for later search reuse.
+
+- [ ] **Step 5: Implement indexed accessors**
+
+Count accessors return `size_t`. Info accessors validate indices and `struct_size`, preserve the input `struct_size`, and fill the V1 fields. `extractpdf_text_span_text` returns a borrowed NUL-terminated snapshot-owned pointer with size excluding NUL.
+
+- [ ] **Step 6: Implement cleanup and exception unwinding**
+
+`extractpdf_drop_text_page(NULL)` is safe. Any allocation failure or caught MuPDF exception drops the upstream structured text and all partial ExtractPDF allocations. After successful return, the snapshot contains no pointer into MuPDF memory.
+
+- [ ] **Step 7: Verify GREEN**
+
+Run Linux build, full CTest, sanitizer build, and sanitizer CTest. Expected: `extractpdf.structured_text` and all existing tests pass with no sanitizer findings.
+
+- [ ] **Step 8: Commit**
+
+Commit with message `feat: add immutable structured text snapshot`.
+
+---
+
+### Task 3: Harden Error, Empty-Page, and Versioned-Struct Behavior
+
+**Files:**
+- Modify: `tests/test_structured_text.c`
+- Modify only if required by RED: `src/structured_text.c`
+
+**Interfaces:**
+- Consumes: Task 2 public API.
+- Produces: locked failure/reset/lifetime semantics suitable for reuse by later search code.
+
+- [ ] **Step 1: Add a second RED for failure semantics**
+
+Test NULL snapshot/output arguments, out-of-range block/line/span indices, undersized `struct_size`, output resets (`count=0`, text pointer `NULL`, text size `0`), and `extractpdf_drop_text_page(NULL)`.
+
+- [ ] **Step 2: Add empty-page snapshot coverage**
+
+Extract from the existing blank one-page fixture; require success with a non-NULL snapshot and zero text blocks.
+
+- [ ] **Step 3: Add V1 struct-size compatibility coverage**
+
+For every info struct, initialize `struct_size` to exactly the V1 minimum, fill the remainder with sentinel bytes, call the accessor, and prove only fields covered by the supplied size are written. Future appended fields must therefore remain safe.
+
+- [ ] **Step 4: Verify the new test fails for any missing behavior**
+
+If all behavior already passes from Task 2, introduce no production change merely to force a failure; instead isolate the first unimplemented reset/versioning case before proceeding. The TDD requirement is that every production correction has a demonstrated failing assertion first.
+
+- [ ] **Step 5: Make only the minimal corrections required by the RED**
+
+Do not add search, font names, image blocks, options, or public character accessors.
+
+- [ ] **Step 6: Run final Linux proof**
+
+Require build + all CTest + ASan/UBSan build + sanitizer CTest on the exact head.
+
+- [ ] **Step 7: Update tracking records**
+
+Update Issue #9 and the stacked PR body with RED/GREEN workflow IDs and exact head. Do not run Windows/macOS yet; defer them to the Phase 3 Content checkpoint.

--- a/docs/superpowers/specs/2026-08-27-extractpdf-structured-text-design.md
+++ b/docs/superpowers/specs/2026-08-27-extractpdf-structured-text-design.md
@@ -44,6 +44,10 @@ typedef struct extractpdf_text_span_info {
 
 `extractpdf.h` therefore adds `<stdint.h>` but no MuPDF header or type.
 
+### C identifier rule
+
+C typedef names and function names share the ordinary identifier namespace. Therefore the accessor functions deliberately use `get_*_info` names rather than colliding with the `extractpdf_text_*_info` typedefs.
+
 ### Versioned output structs
 
 Each `*_info` call treats `struct_size` as caller input. V1 requires at least the V1 size (`offsetof(last_field) + sizeof(last_field)`). On success the library fills only fields known to its version and preserves `struct_size`. Future fields may be appended; future libraries must continue accepting the V1 size and only write fields present in the caller-provided size.
@@ -61,7 +65,7 @@ EXTRACTPDF_API extractpdf_status extractpdf_text_block_count(
     const extractpdf_text_page *text,
     size_t *out_count);
 
-EXTRACTPDF_API extractpdf_status extractpdf_text_block_info(
+EXTRACTPDF_API extractpdf_status extractpdf_text_get_block_info(
     const extractpdf_text_page *text,
     size_t block_index,
     extractpdf_text_block_info *out_info);
@@ -71,7 +75,7 @@ EXTRACTPDF_API extractpdf_status extractpdf_text_line_count(
     size_t block_index,
     size_t *out_count);
 
-EXTRACTPDF_API extractpdf_status extractpdf_text_line_info(
+EXTRACTPDF_API extractpdf_status extractpdf_text_get_line_info(
     const extractpdf_text_page *text,
     size_t block_index,
     size_t line_index,
@@ -83,7 +87,7 @@ EXTRACTPDF_API extractpdf_status extractpdf_text_span_count(
     size_t line_index,
     size_t *out_count);
 
-EXTRACTPDF_API extractpdf_status extractpdf_text_span_info(
+EXTRACTPDF_API extractpdf_status extractpdf_text_get_span_info(
     const extractpdf_text_page *text,
     size_t block_index,
     size_t line_index,

--- a/docs/superpowers/specs/2026-08-27-extractpdf-structured-text-design.md
+++ b/docs/superpowers/specs/2026-08-27-extractpdf-structured-text-design.md
@@ -1,0 +1,232 @@
+# ExtractPDF Structured Text Snapshot Design
+
+Date: 2026-08-27  
+Status: approved design, implementation not started  
+Tracks: #9, umbrella #2  
+Stacked base: plain-text head `2eef49e06c744071897cf44265a47863aa7720cd`
+
+## Goal
+
+Add a stable, MuPDF-independent structured-text ABI for blocks, lines, and style spans. The snapshot must reuse the Page+Render coordinate contract, survive page/document destruction, and become the shared source for later search geometry without exposing MuPDF's in-development `fz_stext_*` layouts.
+
+## Why an ExtractPDF-owned snapshot
+
+MuPDF 1.28.2 explicitly describes the structured-text data structures as in development and subject to change. Returning or mirroring `fz_stext_page`, `fz_stext_block`, `fz_stext_line`, or `fz_stext_char` would therefore couple the public ABI to an unstable upstream implementation.
+
+The V1 API instead copies the relevant content into one opaque immutable `extractpdf_text_page` snapshot. Public traversal is index-based, which is straightforward for C and .NET/PInvoke and leaves storage/layout free to change internally.
+
+## Public types
+
+```c
+typedef struct extractpdf_text_page extractpdf_text_page;
+
+typedef struct extractpdf_text_block_info {
+    size_t struct_size;
+    extractpdf_rect bounds;
+} extractpdf_text_block_info;
+
+typedef struct extractpdf_text_line_info {
+    size_t struct_size;
+    extractpdf_rect bounds;
+    float direction_x;
+    float direction_y;
+    int writing_mode;
+} extractpdf_text_line_info;
+
+typedef struct extractpdf_text_span_info {
+    size_t struct_size;
+    extractpdf_rect bounds;
+    float font_size;
+    uint32_t argb;
+    uint32_t bidi_level;
+} extractpdf_text_span_info;
+```
+
+`extractpdf.h` therefore adds `<stdint.h>` but no MuPDF header or type.
+
+### Versioned output structs
+
+Each `*_info` call treats `struct_size` as caller input. V1 requires at least the V1 size (`offsetof(last_field) + sizeof(last_field)`). On success the library fills only fields known to its version and preserves `struct_size`. Future fields may be appended; future libraries must continue accepting the V1 size and only write fields present in the caller-provided size.
+
+On an argument/index failure, known output fields are reset to zero while preserving the caller's `struct_size` when a non-NULL info pointer was supplied.
+
+## Public API
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_extract_structured_text(
+    extractpdf_page *page,
+    extractpdf_text_page **out_text);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_block_count(
+    const extractpdf_text_page *text,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_block_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    extractpdf_text_block_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_line_count(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_line_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    extractpdf_text_line_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_span_count(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_span_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index,
+    extractpdf_text_span_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_span_text(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index,
+    const char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API void extractpdf_drop_text_page(
+    extractpdf_text_page *text);
+```
+
+## Lifetime and ownership
+
+- `extractpdf_extract_structured_text` sets `*out_text = NULL` on every failure.
+- A successful snapshot owns all arrays and strings it exposes and no longer depends on `extractpdf_page`, `extractpdf_document`, `fz_context`, or any MuPDF object.
+- The source page and document may be dropped immediately after extraction.
+- `extractpdf_text_span_text` returns a borrowed NUL-terminated UTF-8 pointer owned by the snapshot. `out_size` excludes the trailing NUL.
+- Borrowed span pointers remain valid until `extractpdf_drop_text_page`.
+- `extractpdf_drop_text_page(NULL)` is safe.
+- V1 does not broaden the existing single-thread contract.
+
+## Content semantics
+
+### Scope
+
+V1 structured text contains only MuPDF `FZ_STEXT_BLOCK_TEXT` blocks. Image, vector, grid, and structure-tree blocks are deliberately not projected into this API; page-observed image extraction remains its own Phase 3 feature.
+
+Block order and line order follow MuPDF's extracted structured-text order. ExtractPDF does not claim to reconstruct a higher-level semantic reading order beyond what MuPDF returns.
+
+### Extraction options
+
+V1 calls MuPDF structured-text extraction with default options (`flags = 0`):
+
+- ligatures are expanded;
+- horizontal whitespace is normalized by MuPDF;
+- images are ignored;
+- no dehyphenation is requested;
+- no structure/vector/table collection is requested.
+
+A future options-bearing API can be added separately without changing the V1 function.
+
+### Coordinates
+
+Every rectangle uses the Phase 2 Fitz page-space contract:
+
+- CropBox top-left is the displayed-page origin;
+- coordinates are points (72 points/inch);
+- Y increases downward;
+- geometry is independent of render DPI/zoom.
+
+Block and line bounds copy MuPDF's structured-text bounds. Span bounds are the axis-aligned union of the quads of the characters contained in that span.
+
+### Lines
+
+`direction_x` / `direction_y` copy MuPDF's normalized line baseline direction. `writing_mode` is `0` for horizontal and `1` for vertical, matching the semantic meaning of MuPDF's line mode without exporting a MuPDF enum.
+
+### Spans
+
+ExtractPDF forms a new span whenever consecutive characters differ in style identity. V1 style identity consists of:
+
+- MuPDF font identity;
+- font size;
+- sRGB ARGB color;
+- bidi level;
+- MuPDF character flags (used internally only).
+
+The public span exposes font size, ARGB (`0xAARRGGBB`), and bidi level. Font names and MuPDF character flags are intentionally not part of V1; they can be added later through append-only info fields or separate accessors if a real caller requires them.
+
+Span text is UTF-8 generated from the Unicode code points in the structured-text characters. It does not include an artificial line break.
+
+## Internal snapshot model
+
+`src/structured_text.c` owns the projection from MuPDF into ExtractPDF storage. The opaque snapshot contains compact arrays conceptually equivalent to:
+
+```text
+extractpdf_text_page
+  blocks[]  -> first_line + line_count + bounds
+  lines[]   -> first_span + span_count + bounds + direction + writing_mode
+  spans[]   -> first_char + char_count + text offset/size + bounds + style
+  chars[]   -> Unicode code point + Fitz quad + span/text byte metadata
+  strings   -> NUL-terminated UTF-8 span strings
+```
+
+The internal `chars[]` array is intentionally retained even though V1 has no character accessor. Later search can operate on the same snapshot and return exact character/search quads without re-running MuPDF extraction.
+
+No internal pointer in the snapshot points back into MuPDF memory after `extractpdf_extract_structured_text` returns.
+
+## Error handling
+
+- NULL handles/output pointers, undersized `struct_size`, and out-of-range indices return `EXTRACTPDF_ERROR_ARGUMENT`.
+- Count outputs are reset to `0` on failure when supplied.
+- Span text outputs are reset to `NULL` / `0` on failure when supplied.
+- Allocation/overflow failures return `EXTRACTPDF_ERROR_NOMEM` and unwind all partially built arrays/strings.
+- MuPDF exceptions are caught before the C ABI boundary and translated through the existing status mapping.
+- No global/TLS last-error state is added.
+
+## Deterministic TDD fixture
+
+Add an ASCII PDF fixture whose single text line contains two adjacent style runs:
+
+1. `Hello ` — Helvetica, 18 pt, opaque black;
+2. `Caf\351` — Helvetica, 12 pt, opaque red, where WinAnsi `\351` must surface as UTF-8 `é` (`C3 A9`).
+
+The fixture is authored with exact stream length/xref offsets rather than relying on MuPDF repair mode.
+
+The contract tests lock:
+
+- successful immutable snapshot creation;
+- one text block / one line / two spans for the fixture;
+- block/line/span geometry is finite, ordered, and contained consistently;
+- line direction and writing mode;
+- exact span font sizes and ARGB colors;
+- UTF-8 span text and byte lengths;
+- LTR bidi level for the fixture;
+- invalid/NULL arguments and out-of-range indices;
+- `struct_size` validation/output reset;
+- empty page produces a valid snapshot with zero text blocks;
+- snapshot data remains valid after page/document destruction;
+- `drop_text_page(NULL)` safety.
+
+## CI policy
+
+Follow the repository's Linux-first development policy:
+
+- each structured-text slice runs Linux build + CTest + ASan/UBSan;
+- Windows/macOS stay skipped during small RED/GREEN iterations;
+- Phase 3 gets one exact-head Linux/macOS/Windows `full-ci` checkpoint after the related Content features are assembled.
+
+## Non-goals
+
+This slice does not add:
+
+- public character-level accessors;
+- font-name/font-file APIs;
+- search APIs;
+- image/vector/structure-tree blocks;
+- reading-order reconstruction beyond MuPDF's order;
+- structured-text extraction options;
+- concurrency guarantees.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -2,6 +2,7 @@
 #define EXTRACTPDF_EXTRACTPDF_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +21,7 @@ extern "C" {
 typedef struct extractpdf_document extractpdf_document;
 typedef struct extractpdf_page extractpdf_page;
 typedef struct extractpdf_bitmap extractpdf_bitmap;
+typedef struct extractpdf_text_page extractpdf_text_page;
 
 typedef struct extractpdf_rect {
     float x0;
@@ -41,6 +43,27 @@ typedef struct extractpdf_render_options {
     extractpdf_rect clip;
     int alpha;
 } extractpdf_render_options;
+
+typedef struct extractpdf_text_block_info {
+    size_t struct_size;
+    extractpdf_rect bounds;
+} extractpdf_text_block_info;
+
+typedef struct extractpdf_text_line_info {
+    size_t struct_size;
+    extractpdf_rect bounds;
+    float direction_x;
+    float direction_y;
+    int writing_mode;
+} extractpdf_text_line_info;
+
+typedef struct extractpdf_text_span_info {
+    size_t struct_size;
+    extractpdf_rect bounds;
+    float font_size;
+    uint32_t argb;
+    uint32_t bidi_level;
+} extractpdf_text_span_info;
 
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
@@ -108,11 +131,59 @@ EXTRACTPDF_API extractpdf_status extractpdf_extract_text(
     char **out_utf8,
     size_t *out_size);
 
+EXTRACTPDF_API extractpdf_status extractpdf_extract_structured_text(
+    extractpdf_page *page,
+    extractpdf_text_page **out_text);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_block_count(
+    const extractpdf_text_page *text,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_get_block_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    extractpdf_text_block_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_line_count(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_get_line_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    extractpdf_text_line_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_span_count(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_get_span_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index,
+    extractpdf_text_span_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_span_text(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index,
+    const char **out_utf8,
+    size_t *out_size);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
 
 EXTRACTPDF_API void extractpdf_free(
     void *memory);
+
+EXTRACTPDF_API void extractpdf_drop_text_page(
+    extractpdf_text_page *text);
 
 EXTRACTPDF_API void extractpdf_drop_bitmap(
     extractpdf_bitmap *bitmap);

--- a/src/internal.h
+++ b/src/internal.h
@@ -19,6 +19,54 @@ struct extractpdf_bitmap {
     fz_pixmap *pixmap;
 };
 
+typedef struct extractpdf_text_block_internal {
+    extractpdf_rect bounds;
+    size_t first_line;
+    size_t line_count;
+} extractpdf_text_block_internal;
+
+typedef struct extractpdf_text_line_internal {
+    extractpdf_rect bounds;
+    float direction_x;
+    float direction_y;
+    int writing_mode;
+    size_t first_span;
+    size_t span_count;
+} extractpdf_text_line_internal;
+
+typedef struct extractpdf_text_span_internal {
+    extractpdf_rect bounds;
+    float font_size;
+    uint32_t argb;
+    uint32_t bidi_level;
+    uint16_t flags;
+    size_t first_char;
+    size_t char_count;
+    size_t text_offset;
+    size_t text_size;
+} extractpdf_text_span_internal;
+
+typedef struct extractpdf_text_char_internal {
+    uint32_t codepoint;
+    uint16_t bidi;
+    uint16_t flags;
+    fz_quad quad;
+    size_t span_index;
+} extractpdf_text_char_internal;
+
+struct extractpdf_text_page {
+    extractpdf_text_block_internal *blocks;
+    extractpdf_text_line_internal *lines;
+    extractpdf_text_span_internal *spans;
+    extractpdf_text_char_internal *chars;
+    char *strings;
+    size_t block_count;
+    size_t line_count;
+    size_t span_count;
+    size_t char_count;
+    size_t string_size;
+};
+
 extractpdf_status extractpdf_status_from_mupdf(int code);
 
 #endif

--- a/src/structured_text.c
+++ b/src/structured_text.c
@@ -526,10 +526,12 @@ extractpdf_status extractpdf_text_span_text(
 {
     const extractpdf_text_span_internal *span;
 
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
     if (out_utf8 == NULL || out_size == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
-    *out_utf8 = NULL;
-    *out_size = 0;
 
     span = extractpdf_lookup_span(text, block_index, line_index, span_index);
     if (span == NULL)

--- a/src/structured_text.c
+++ b/src/structured_text.c
@@ -389,8 +389,11 @@ extractpdf_status extractpdf_text_get_block_info(
         return EXTRACTPDF_ERROR_ARGUMENT;
     minimum_size = offsetof(extractpdf_text_block_info, bounds) +
         sizeof(out_info->bounds);
-    if (out_info->struct_size < minimum_size ||
-        text == NULL || block_index >= text->block_count)
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->bounds = (extractpdf_rect){ 0 };
+    if (text == NULL || block_index >= text->block_count)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
     out_info->bounds = text->blocks[block_index].bounds;
@@ -442,6 +445,11 @@ extractpdf_status extractpdf_text_get_line_info(
         sizeof(out_info->writing_mode);
     if (out_info->struct_size < minimum_size)
         return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->bounds = (extractpdf_rect){ 0 };
+    out_info->direction_x = 0.0f;
+    out_info->direction_y = 0.0f;
+    out_info->writing_mode = 0;
 
     line = extractpdf_lookup_line(text, block_index, line_index);
     if (line == NULL)
@@ -504,6 +512,11 @@ extractpdf_status extractpdf_text_get_span_info(
         sizeof(out_info->bidi_level);
     if (out_info->struct_size < minimum_size)
         return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->bounds = (extractpdf_rect){ 0 };
+    out_info->font_size = 0.0f;
+    out_info->argb = 0;
+    out_info->bidi_level = 0;
 
     span = extractpdf_lookup_span(text, block_index, line_index, span_index);
     if (span == NULL)

--- a/src/structured_text.c
+++ b/src/structured_text.c
@@ -1,0 +1,546 @@
+#include "internal.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void extractpdf_copy_rect(extractpdf_rect *out, fz_rect in)
+{
+    out->x0 = in.x0;
+    out->y0 = in.y0;
+    out->x1 = in.x1;
+    out->y1 = in.y1;
+}
+
+static void extractpdf_union_rect(extractpdf_rect *dst, fz_rect in)
+{
+    if (in.x0 < dst->x0)
+        dst->x0 = in.x0;
+    if (in.y0 < dst->y0)
+        dst->y0 = in.y0;
+    if (in.x1 > dst->x1)
+        dst->x1 = in.x1;
+    if (in.y1 > dst->y1)
+        dst->y1 = in.y1;
+}
+
+static void *extractpdf_calloc_array(size_t count, size_t element_size)
+{
+    if (count == 0)
+        return NULL;
+    if (element_size != 0 && count > SIZE_MAX / element_size)
+        return NULL;
+    return calloc(count, element_size);
+}
+
+static int extractpdf_increment_size(size_t *value)
+{
+    if (*value == SIZE_MAX)
+        return 0;
+    ++*value;
+    return 1;
+}
+
+static size_t extractpdf_utf8_encode(int value, char out[4])
+{
+    uint32_t rune;
+
+    if (value < 0 || value > 0x10ffff ||
+        (value >= 0xd800 && value <= 0xdfff))
+        rune = UINT32_C(0xfffd);
+    else
+        rune = (uint32_t)value;
+
+    if (rune <= UINT32_C(0x7f)) {
+        out[0] = (char)rune;
+        return 1;
+    }
+    if (rune <= UINT32_C(0x7ff)) {
+        out[0] = (char)(UINT32_C(0xc0) | (rune >> 6));
+        out[1] = (char)(UINT32_C(0x80) | (rune & UINT32_C(0x3f)));
+        return 2;
+    }
+    if (rune <= UINT32_C(0xffff)) {
+        out[0] = (char)(UINT32_C(0xe0) | (rune >> 12));
+        out[1] = (char)(UINT32_C(0x80) | ((rune >> 6) & UINT32_C(0x3f)));
+        out[2] = (char)(UINT32_C(0x80) | (rune & UINT32_C(0x3f)));
+        return 3;
+    }
+
+    out[0] = (char)(UINT32_C(0xf0) | (rune >> 18));
+    out[1] = (char)(UINT32_C(0x80) | ((rune >> 12) & UINT32_C(0x3f)));
+    out[2] = (char)(UINT32_C(0x80) | ((rune >> 6) & UINT32_C(0x3f)));
+    out[3] = (char)(UINT32_C(0x80) | (rune & UINT32_C(0x3f)));
+    return 4;
+}
+
+static uint32_t extractpdf_normalize_codepoint(int value)
+{
+    if (value < 0 || value > 0x10ffff ||
+        (value >= 0xd800 && value <= 0xdfff))
+        return UINT32_C(0xfffd);
+    return (uint32_t)value;
+}
+
+static void extractpdf_dispose_text_page(extractpdf_text_page *text)
+{
+    if (text == NULL)
+        return;
+
+    free(text->blocks);
+    free(text->lines);
+    free(text->spans);
+    free(text->chars);
+    free(text->strings);
+    free(text);
+}
+
+static int extractpdf_count_structured_text(
+    const fz_stext_page *source,
+    size_t *out_blocks,
+    size_t *out_lines,
+    size_t *out_chars)
+{
+    const fz_stext_block *block;
+    size_t blocks = 0;
+    size_t lines = 0;
+    size_t chars = 0;
+
+    for (block = source->first_block; block != NULL; block = block->next) {
+        const fz_stext_line *line;
+
+        if (block->type != FZ_STEXT_BLOCK_TEXT)
+            continue;
+        if (!extractpdf_increment_size(&blocks))
+            return 0;
+
+        for (line = block->u.t.first_line; line != NULL; line = line->next) {
+            const fz_stext_char *ch;
+
+            if (!extractpdf_increment_size(&lines))
+                return 0;
+            for (ch = line->first_char; ch != NULL; ch = ch->next) {
+                if (!extractpdf_increment_size(&chars))
+                    return 0;
+            }
+        }
+    }
+
+    *out_blocks = blocks;
+    *out_lines = lines;
+    *out_chars = chars;
+    return 1;
+}
+
+static extractpdf_text_page *extractpdf_allocate_text_page(
+    size_t block_count,
+    size_t line_count,
+    size_t char_count)
+{
+    extractpdf_text_page *text;
+    size_t string_capacity;
+
+    if (char_count > (SIZE_MAX - 1) / 5)
+        return NULL;
+    string_capacity = char_count * 5 + 1;
+
+    text = (extractpdf_text_page *)calloc(1, sizeof(*text));
+    if (text == NULL)
+        return NULL;
+
+    text->blocks = (extractpdf_text_block_internal *)extractpdf_calloc_array(
+        block_count, sizeof(*text->blocks));
+    text->lines = (extractpdf_text_line_internal *)extractpdf_calloc_array(
+        line_count, sizeof(*text->lines));
+    text->spans = (extractpdf_text_span_internal *)extractpdf_calloc_array(
+        char_count, sizeof(*text->spans));
+    text->chars = (extractpdf_text_char_internal *)extractpdf_calloc_array(
+        char_count, sizeof(*text->chars));
+    text->strings = (char *)malloc(string_capacity);
+
+    if ((block_count != 0 && text->blocks == NULL) ||
+        (line_count != 0 && text->lines == NULL) ||
+        (char_count != 0 && (text->spans == NULL || text->chars == NULL)) ||
+        text->strings == NULL) {
+        extractpdf_dispose_text_page(text);
+        return NULL;
+    }
+
+    text->block_count = block_count;
+    text->line_count = line_count;
+    text->char_count = char_count;
+    text->strings[0] = '\0';
+    return text;
+}
+
+static int extractpdf_same_style(
+    const fz_stext_char *ch,
+    fz_font *font,
+    float size,
+    uint32_t argb,
+    uint16_t bidi,
+    uint16_t flags)
+{
+    return ch->font == font &&
+        ch->size == size &&
+        ch->argb == argb &&
+        ch->bidi == bidi &&
+        ch->flags == flags;
+}
+
+static void extractpdf_project_structured_text(
+    extractpdf_text_page *text,
+    const fz_stext_page *source)
+{
+    const fz_stext_block *source_block;
+    size_t block_index = 0;
+    size_t line_index = 0;
+    size_t span_index = 0;
+    size_t char_index = 0;
+    size_t string_pos = 0;
+
+    for (source_block = source->first_block;
+         source_block != NULL;
+         source_block = source_block->next) {
+        const fz_stext_line *source_line;
+        extractpdf_text_block_internal *block;
+
+        if (source_block->type != FZ_STEXT_BLOCK_TEXT)
+            continue;
+
+        block = &text->blocks[block_index++];
+        extractpdf_copy_rect(&block->bounds, source_block->bbox);
+        block->first_line = line_index;
+
+        for (source_line = source_block->u.t.first_line;
+             source_line != NULL;
+             source_line = source_line->next) {
+            const fz_stext_char *source_char;
+            extractpdf_text_line_internal *line = &text->lines[line_index++];
+            fz_font *style_font = NULL;
+            float style_size = 0.0f;
+            uint32_t style_argb = 0;
+            uint16_t style_bidi = 0;
+            uint16_t style_flags = 0;
+            size_t current_span_index = 0;
+            int have_span = 0;
+
+            extractpdf_copy_rect(&line->bounds, source_line->bbox);
+            line->direction_x = source_line->dir.x;
+            line->direction_y = source_line->dir.y;
+            line->writing_mode = source_line->wmode;
+            line->first_span = span_index;
+
+            for (source_char = source_line->first_char;
+                 source_char != NULL;
+                 source_char = source_char->next) {
+                extractpdf_text_span_internal *span;
+                extractpdf_text_char_internal *ch;
+                fz_rect char_bounds;
+                char encoded[4];
+                size_t encoded_size;
+
+                if (!have_span ||
+                    !extractpdf_same_style(
+                        source_char,
+                        style_font,
+                        style_size,
+                        style_argb,
+                        style_bidi,
+                        style_flags)) {
+                    if (have_span)
+                        text->strings[string_pos++] = '\0';
+
+                    current_span_index = span_index++;
+                    span = &text->spans[current_span_index];
+                    char_bounds = fz_rect_from_quad(source_char->quad);
+                    extractpdf_copy_rect(&span->bounds, char_bounds);
+                    span->font_size = source_char->size;
+                    span->argb = source_char->argb;
+                    span->bidi_level = source_char->bidi;
+                    span->flags = source_char->flags;
+                    span->first_char = char_index;
+                    span->text_offset = string_pos;
+
+                    style_font = source_char->font;
+                    style_size = source_char->size;
+                    style_argb = source_char->argb;
+                    style_bidi = source_char->bidi;
+                    style_flags = source_char->flags;
+                    have_span = 1;
+                }
+                else {
+                    span = &text->spans[current_span_index];
+                    char_bounds = fz_rect_from_quad(source_char->quad);
+                    extractpdf_union_rect(&span->bounds, char_bounds);
+                }
+
+                span = &text->spans[current_span_index];
+                ch = &text->chars[char_index];
+                ch->codepoint = extractpdf_normalize_codepoint(source_char->c);
+                ch->bidi = source_char->bidi;
+                ch->flags = source_char->flags;
+                ch->quad = source_char->quad;
+                ch->span_index = current_span_index;
+
+                encoded_size = extractpdf_utf8_encode(source_char->c, encoded);
+                memcpy(text->strings + string_pos, encoded, encoded_size);
+                string_pos += encoded_size;
+                span->text_size += encoded_size;
+                ++span->char_count;
+                ++char_index;
+            }
+
+            if (have_span)
+                text->strings[string_pos++] = '\0';
+            line->span_count = span_index - line->first_span;
+        }
+
+        block->line_count = line_index - block->first_line;
+    }
+
+    text->span_count = span_index;
+    text->char_count = char_index;
+    text->string_size = string_pos;
+    if (string_pos == 0)
+        text->strings[0] = '\0';
+}
+
+extractpdf_status extractpdf_extract_structured_text(
+    extractpdf_page *page,
+    extractpdf_text_page **out_text)
+{
+    fz_context *ctx;
+    fz_stext_page *source = NULL;
+    extractpdf_text_page *text = NULL;
+    size_t block_count = 0;
+    size_t line_count = 0;
+    size_t char_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_text == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_text = NULL;
+
+    if (page == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = page->document->ctx;
+    fz_var(source);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        source = fz_new_stext_page_from_page(ctx, page->page, NULL);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (source == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    if (!extractpdf_count_structured_text(
+            source, &block_count, &line_count, &char_count)) {
+        fz_drop_stext_page(ctx, source);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    text = extractpdf_allocate_text_page(block_count, line_count, char_count);
+    if (text == NULL) {
+        fz_drop_stext_page(ctx, source);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    extractpdf_project_structured_text(text, source);
+    fz_drop_stext_page(ctx, source);
+
+    *out_text = text;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_text_block_count(
+    const extractpdf_text_page *text,
+    size_t *out_count)
+{
+    if (out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_count = 0;
+    if (text == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_count = text->block_count;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_text_get_block_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    extractpdf_text_block_info *out_info)
+{
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    minimum_size = offsetof(extractpdf_text_block_info, bounds) +
+        sizeof(out_info->bounds);
+    if (out_info->struct_size < minimum_size ||
+        text == NULL || block_index >= text->block_count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->bounds = text->blocks[block_index].bounds;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_text_line_count(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t *out_count)
+{
+    if (out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_count = 0;
+    if (text == NULL || block_index >= text->block_count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_count = text->blocks[block_index].line_count;
+    return EXTRACTPDF_OK;
+}
+
+static const extractpdf_text_line_internal *extractpdf_lookup_line(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index)
+{
+    const extractpdf_text_block_internal *block;
+
+    if (text == NULL || block_index >= text->block_count)
+        return NULL;
+    block = &text->blocks[block_index];
+    if (line_index >= block->line_count)
+        return NULL;
+    return &text->lines[block->first_line + line_index];
+}
+
+extractpdf_status extractpdf_text_get_line_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    extractpdf_text_line_info *out_info)
+{
+    const extractpdf_text_line_internal *line;
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    minimum_size = offsetof(extractpdf_text_line_info, writing_mode) +
+        sizeof(out_info->writing_mode);
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    line = extractpdf_lookup_line(text, block_index, line_index);
+    if (line == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->bounds = line->bounds;
+    out_info->direction_x = line->direction_x;
+    out_info->direction_y = line->direction_y;
+    out_info->writing_mode = line->writing_mode;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_text_span_count(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t *out_count)
+{
+    const extractpdf_text_line_internal *line;
+
+    if (out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_count = 0;
+
+    line = extractpdf_lookup_line(text, block_index, line_index);
+    if (line == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_count = line->span_count;
+    return EXTRACTPDF_OK;
+}
+
+static const extractpdf_text_span_internal *extractpdf_lookup_span(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index)
+{
+    const extractpdf_text_line_internal *line;
+
+    line = extractpdf_lookup_line(text, block_index, line_index);
+    if (line == NULL || span_index >= line->span_count)
+        return NULL;
+    return &text->spans[line->first_span + span_index];
+}
+
+extractpdf_status extractpdf_text_get_span_info(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index,
+    extractpdf_text_span_info *out_info)
+{
+    const extractpdf_text_span_internal *span;
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    minimum_size = offsetof(extractpdf_text_span_info, bidi_level) +
+        sizeof(out_info->bidi_level);
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    span = extractpdf_lookup_span(text, block_index, line_index, span_index);
+    if (span == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->bounds = span->bounds;
+    out_info->font_size = span->font_size;
+    out_info->argb = span->argb;
+    out_info->bidi_level = span->bidi_level;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_text_span_text(
+    const extractpdf_text_page *text,
+    size_t block_index,
+    size_t line_index,
+    size_t span_index,
+    const char **out_utf8,
+    size_t *out_size)
+{
+    const extractpdf_text_span_internal *span;
+
+    if (out_utf8 == NULL || out_size == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_utf8 = NULL;
+    *out_size = 0;
+
+    span = extractpdf_lookup_span(text, block_index, line_index, span_index);
+    if (span == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_utf8 = text->strings + span->text_offset;
+    *out_size = span->text_size;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_text_page(extractpdf_text_page *text)
+{
+    extractpdf_dispose_text_page(text);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ set_tests_properties(extractpdf.text PROPERTIES TIMEOUT 30)
 add_executable(extractpdf_test_structured_text test_structured_text.c)
 target_link_libraries(extractpdf_test_structured_text PRIVATE ExtractPDF::ExtractPDF)
 target_compile_definitions(extractpdf_test_structured_text PRIVATE
+  ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
   STRUCTURED_TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/structured-text.pdf")
 add_test(NAME extractpdf.structured_text COMMAND extractpdf_test_structured_text)
 set_tests_properties(extractpdf.structured_text PROPERTIES TIMEOUT 30)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,12 +41,20 @@ target_compile_definitions(extractpdf_test_text PRIVATE
 add_test(NAME extractpdf.text COMMAND extractpdf_test_text)
 set_tests_properties(extractpdf.text PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_structured_text test_structured_text.c)
+target_link_libraries(extractpdf_test_structured_text PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_structured_text PRIVATE
+  STRUCTURED_TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/structured-text.pdf")
+add_test(NAME extractpdf.structured_text COMMAND extractpdf_test_structured_text)
+set_tests_properties(extractpdf.structured_text PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
       extractpdf_test_document
       extractpdf_test_render
-      extractpdf_test_text)
+      extractpdf_test_text
+      extractpdf_test_structured_text)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/structured-text.pdf
+++ b/tests/fixtures/structured-text.pdf
@@ -1,0 +1,41 @@
+%PDF-1.4
+%ExtractPDF structured text fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Length 78 >>
+stream
+BT
+/F1 18 Tf
+0 0 0 rg
+12 60 Td
+(Hello ) Tj
+1 0 0 rg
+/F1 12 Tf
+(Caf\351) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000045 00000 n 
+0000000094 00000 n 
+0000000151 00000 n 
+0000000277 00000 n 
+0000000374 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+501
+%%EOF

--- a/tests/test_structured_text.c
+++ b/tests/test_structured_text.c
@@ -34,21 +34,47 @@ static void check_rect(const extractpdf_rect *rect)
     CHECK(rect->y1 > rect->y0);
 }
 
+static void check_zero_rect(const extractpdf_rect *rect)
+{
+    CHECK(rect->x0 == 0.0f);
+    CHECK(rect->y0 == 0.0f);
+    CHECK(rect->x1 == 0.0f);
+    CHECK(rect->y1 == 0.0f);
+}
+
+static void check_tail_bytes(const void *object, size_t start, size_t size, unsigned char expected)
+{
+    const unsigned char *bytes = (const unsigned char *)object;
+    size_t i;
+
+    for (i = start; i < size; ++i)
+        CHECK(bytes[i] == expected);
+}
+
 int main(void)
 {
+    const unsigned char sentinel_byte = 0xa5;
+    int sentinel = 0;
     extractpdf_document *document = NULL;
     extractpdf_page *page = NULL;
-    extractpdf_text_page *text = NULL;
+    extractpdf_text_page *text = (extractpdf_text_page *)&sentinel;
     extractpdf_text_block_info block = { sizeof(block), { 0 } };
     extractpdf_text_line_info line = { sizeof(line), { 0 }, 0.0f, 0.0f, 0 };
     extractpdf_text_span_info span0 = { sizeof(span0), { 0 }, 0.0f, 0, 0 };
     extractpdf_text_span_info span1 = { sizeof(span1), { 0 }, 0.0f, 0, 0 };
     const char *span_text = NULL;
+    size_t block_min = offsetof(extractpdf_text_block_info, bounds) + sizeof(block.bounds);
+    size_t line_min = offsetof(extractpdf_text_line_info, writing_mode) + sizeof(line.writing_mode);
+    size_t span_min = offsetof(extractpdf_text_span_info, bidi_level) + sizeof(span0.bidi_level);
     size_t count = 0;
     size_t size = 0;
 
+    CHECK(extractpdf_extract_structured_text(NULL, &text) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+
     CHECK(extractpdf_open(STRUCTURED_TEXT_PDF, NULL, &document) == EXTRACTPDF_OK);
     CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_structured_text(page, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
     CHECK(extractpdf_extract_structured_text(page, &text) == EXTRACTPDF_OK);
     CHECK(text != NULL);
 
@@ -101,7 +127,117 @@ int main(void)
     CHECK(memcmp(span_text, "Caf\xc3\xa9", 5) == 0);
     CHECK(span_text[5] == '\0');
 
+    /* Count and text outputs reset whenever they are supplied on failure. */
+    count = 123;
+    CHECK(extractpdf_text_block_count(NULL, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_text_block_count(text, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    count = 123;
+    CHECK(extractpdf_text_line_count(text, 1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    count = 123;
+    CHECK(extractpdf_text_span_count(text, 0, 1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    span_text = (const char *)&sentinel;
+    size = 123;
+    CHECK(extractpdf_text_span_text(text, 0, 0, 2, &span_text, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(span_text == NULL);
+    CHECK(size == 0);
+
+    size = 123;
+    CHECK(extractpdf_text_span_text(text, 0, 0, 0, NULL, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(size == 0);
+    span_text = (const char *)&sentinel;
+    CHECK(extractpdf_text_span_text(text, 0, 0, 0, &span_text, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(span_text == NULL);
+
+    /* A valid-sized info object is zeroed on an invalid handle/index. */
+    memset(&block, sentinel_byte, sizeof(block));
+    block.struct_size = sizeof(block);
+    CHECK(extractpdf_text_get_block_info(text, 1, &block) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(block.struct_size == sizeof(block));
+    check_zero_rect(&block.bounds);
+
+    memset(&line, sentinel_byte, sizeof(line));
+    line.struct_size = sizeof(line);
+    CHECK(extractpdf_text_get_line_info(text, 0, 1, &line) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(line.struct_size == sizeof(line));
+    check_zero_rect(&line.bounds);
+    CHECK(line.direction_x == 0.0f);
+    CHECK(line.direction_y == 0.0f);
+    CHECK(line.writing_mode == 0);
+
+    memset(&span0, sentinel_byte, sizeof(span0));
+    span0.struct_size = sizeof(span0);
+    CHECK(extractpdf_text_get_span_info(NULL, 0, 0, 0, &span0) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(span0.struct_size == sizeof(span0));
+    check_zero_rect(&span0.bounds);
+    CHECK(span0.font_size == 0.0f);
+    CHECK(span0.argb == 0);
+    CHECK(span0.bidi_level == 0);
+
+    /* Undersized structs are rejected without writing beyond caller-authorized bytes. */
+    memset(&block, sentinel_byte, sizeof(block));
+    block.struct_size = block_min - 1;
+    CHECK(extractpdf_text_get_block_info(text, 0, &block) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(block.struct_size == block_min - 1);
+    check_tail_bytes(&block, sizeof(block.struct_size), sizeof(block), sentinel_byte);
+
+    memset(&line, sentinel_byte, sizeof(line));
+    line.struct_size = line_min - 1;
+    CHECK(extractpdf_text_get_line_info(text, 0, 0, &line) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(line.struct_size == line_min - 1);
+    check_tail_bytes(&line, sizeof(line.struct_size), sizeof(line), sentinel_byte);
+
+    memset(&span0, sentinel_byte, sizeof(span0));
+    span0.struct_size = span_min - 1;
+    CHECK(extractpdf_text_get_span_info(text, 0, 0, 0, &span0) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(span0.struct_size == span_min - 1);
+    check_tail_bytes(&span0, sizeof(span0.struct_size), sizeof(span0), sentinel_byte);
+
+    /* Exact V1 minimum sizes are accepted; tail padding remains untouched. */
+    memset(&block, sentinel_byte, sizeof(block));
+    block.struct_size = block_min;
+    CHECK(extractpdf_text_get_block_info(text, 0, &block) == EXTRACTPDF_OK);
+    check_rect(&block.bounds);
+    check_tail_bytes(&block, block_min, sizeof(block), sentinel_byte);
+
+    memset(&line, sentinel_byte, sizeof(line));
+    line.struct_size = line_min;
+    CHECK(extractpdf_text_get_line_info(text, 0, 0, &line) == EXTRACTPDF_OK);
+    check_rect(&line.bounds);
+    CHECK(line.writing_mode == 0);
+    check_tail_bytes(&line, line_min, sizeof(line), sentinel_byte);
+
+    memset(&span0, sentinel_byte, sizeof(span0));
+    span0.struct_size = span_min;
+    CHECK(extractpdf_text_get_span_info(text, 0, 0, 0, &span0) == EXTRACTPDF_OK);
+    check_rect(&span0.bounds);
+    CHECK(close_float(span0.font_size, 18.0f));
+    CHECK(span0.argb == UINT32_C(0xff000000));
+    CHECK(span0.bidi_level == 0);
+    check_tail_bytes(&span0, span_min, sizeof(span0), sentinel_byte);
+
     extractpdf_drop_text_page(text);
     extractpdf_drop_text_page(NULL);
+
+    /* Empty pages still produce a valid immutable snapshot. */
+    text = NULL;
+    CHECK(extractpdf_open(ONE_PAGE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_structured_text(page, &text) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    page = NULL;
+    document = NULL;
+
+    count = 123;
+    CHECK(extractpdf_text_block_count(text, &count) == EXTRACTPDF_OK);
+    CHECK(count == 0);
+    extractpdf_drop_text_page(text);
+
     return EXIT_SUCCESS;
 }

--- a/tests/test_structured_text.c
+++ b/tests/test_structured_text.c
@@ -60,13 +60,13 @@ int main(void)
 
     CHECK(extractpdf_text_block_count(text, &count) == EXTRACTPDF_OK);
     CHECK(count == 1);
-    CHECK(extractpdf_text_block_info(text, 0, &block) == EXTRACTPDF_OK);
+    CHECK(extractpdf_text_get_block_info(text, 0, &block) == EXTRACTPDF_OK);
     CHECK(block.struct_size == sizeof(block));
     check_rect(&block.bounds);
 
     CHECK(extractpdf_text_line_count(text, 0, &count) == EXTRACTPDF_OK);
     CHECK(count == 1);
-    CHECK(extractpdf_text_line_info(text, 0, 0, &line) == EXTRACTPDF_OK);
+    CHECK(extractpdf_text_get_line_info(text, 0, 0, &line) == EXTRACTPDF_OK);
     CHECK(line.struct_size == sizeof(line));
     check_rect(&line.bounds);
     CHECK(close_float(line.direction_x, 1.0f));
@@ -76,8 +76,8 @@ int main(void)
     CHECK(extractpdf_text_span_count(text, 0, 0, &count) == EXTRACTPDF_OK);
     CHECK(count == 2);
 
-    CHECK(extractpdf_text_span_info(text, 0, 0, 0, &span0) == EXTRACTPDF_OK);
-    CHECK(extractpdf_text_span_info(text, 0, 0, 1, &span1) == EXTRACTPDF_OK);
+    CHECK(extractpdf_text_get_span_info(text, 0, 0, 0, &span0) == EXTRACTPDF_OK);
+    CHECK(extractpdf_text_get_span_info(text, 0, 0, 1, &span1) == EXTRACTPDF_OK);
     check_rect(&span0.bounds);
     check_rect(&span1.bounds);
     CHECK(close_float(span0.font_size, 18.0f));

--- a/tests/test_structured_text.c
+++ b/tests/test_structured_text.c
@@ -1,0 +1,107 @@
+#include <extractpdf/extractpdf.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    if (d < 0.0f)
+        d = -d;
+    return d < 0.01f;
+}
+
+static void check_rect(const extractpdf_rect *rect)
+{
+    CHECK(isfinite(rect->x0));
+    CHECK(isfinite(rect->y0));
+    CHECK(isfinite(rect->x1));
+    CHECK(isfinite(rect->y1));
+    CHECK(rect->x1 > rect->x0);
+    CHECK(rect->y1 > rect->y0);
+}
+
+int main(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_text_page *text = NULL;
+    extractpdf_text_block_info block = { sizeof(block), { 0 } };
+    extractpdf_text_line_info line = { sizeof(line), { 0 }, 0.0f, 0.0f, 0 };
+    extractpdf_text_span_info span0 = { sizeof(span0), { 0 }, 0.0f, 0, 0 };
+    extractpdf_text_span_info span1 = { sizeof(span1), { 0 }, 0.0f, 0, 0 };
+    const char *span_text = NULL;
+    size_t count = 0;
+    size_t size = 0;
+
+    CHECK(extractpdf_open(STRUCTURED_TEXT_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_structured_text(page, &text) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+
+    /* The snapshot must own everything needed by all later accessors. */
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    page = NULL;
+    document = NULL;
+
+    CHECK(extractpdf_text_block_count(text, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(extractpdf_text_block_info(text, 0, &block) == EXTRACTPDF_OK);
+    CHECK(block.struct_size == sizeof(block));
+    check_rect(&block.bounds);
+
+    CHECK(extractpdf_text_line_count(text, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(extractpdf_text_line_info(text, 0, 0, &line) == EXTRACTPDF_OK);
+    CHECK(line.struct_size == sizeof(line));
+    check_rect(&line.bounds);
+    CHECK(close_float(line.direction_x, 1.0f));
+    CHECK(close_float(line.direction_y, 0.0f));
+    CHECK(line.writing_mode == 0);
+
+    CHECK(extractpdf_text_span_count(text, 0, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 2);
+
+    CHECK(extractpdf_text_span_info(text, 0, 0, 0, &span0) == EXTRACTPDF_OK);
+    CHECK(extractpdf_text_span_info(text, 0, 0, 1, &span1) == EXTRACTPDF_OK);
+    check_rect(&span0.bounds);
+    check_rect(&span1.bounds);
+    CHECK(close_float(span0.font_size, 18.0f));
+    CHECK(close_float(span1.font_size, 12.0f));
+    CHECK(span0.argb == UINT32_C(0xff000000));
+    CHECK(span1.argb == UINT32_C(0xffff0000));
+    CHECK(span0.bidi_level == 0);
+    CHECK(span1.bidi_level == 0);
+    CHECK(span0.bounds.x0 >= line.bounds.x0 - 0.01f);
+    CHECK(span1.bounds.x1 <= line.bounds.x1 + 0.01f);
+    CHECK(span1.bounds.x0 >= span0.bounds.x0);
+
+    CHECK(extractpdf_text_span_text(text, 0, 0, 0, &span_text, &size) == EXTRACTPDF_OK);
+    CHECK(size == 6);
+    CHECK(strcmp(span_text, "Hello ") == 0);
+
+    span_text = NULL;
+    size = 0;
+    CHECK(extractpdf_text_span_text(text, 0, 0, 1, &span_text, &size) == EXTRACTPDF_OK);
+    CHECK(size == 5);
+    CHECK(memcmp(span_text, "Caf\xc3\xa9", 5) == 0);
+    CHECK(span_text[5] == '\0');
+
+    extractpdf_drop_text_page(text);
+    extractpdf_drop_text_page(NULL);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 3 Content structured-text slice from #9 / #2, stacked on plain UTF-8 extraction.

Implemented architecture:
- opaque immutable `extractpdf_text_page`
- indexed text block -> line -> span traversal
- versioned public `*_info` structs using non-colliding `get_*_info` accessor names
- Fitz page-space geometry shared with Page+Render
- snapshot owns copied UTF-8/style/geometry and can outlive page/document
- V1 surfaces text blocks only
- internal per-character Unicode/quads retained for later search reuse
- no MuPDF structured-text types cross the public ABI
- empty page -> valid zero-block snapshot
- output-reset and caller-provided `struct_size` bounds are tested

TDD evidence:
- initial RED: corrected contract compiled against the pre-feature header and failed on missing structured-text types/functions
- workflow #113 at `b455423a8bc2635af43c6822520e4bc297da4850`: initial implementation passed Linux build, all CTest, ASan/UBSan build/test
- Task 3 RED #115 at `cc7e4cbb25b9a3923c8daef03cdf3a982b91d0a1`: partial output reset failure
- minimal fix `7504d92e216a8a70ede2bd8a21f7a21e483105c8`; #116 advanced to info-reset RED
- exact head `76b629ef7d026573afffd8b55ebcb29fc24621a9`
- workflow #117: Linux build ✅, all 5 CTests ✅, ASan/UBSan build ✅, sanitizer CTest ✅

Committed design/spec:
- `docs/superpowers/specs/2026-08-27-extractpdf-structured-text-design.md`
- `docs/superpowers/plans/2026-08-27-extractpdf-structured-text.md`

Deferred cross-platform verification is now complete on the cumulative Phase 3 exact head `204aa90349256e323685ef34ad564032dd4aac52`: `full-ci` workflow #130 passed Linux static + ASan/UBSan, macOS native build/test, and Windows DLL build/test.

PR remains draft for stacked integration. Tracks #9 and #2.