### PR TITLE
feat: search immutable text snapshots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library(extractpdf
   src/page.c
   src/render.c
   src/text.c
-  src/structured_text.c)
+  src/structured_text.c
+  src/search.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -23,12 +23,24 @@ typedef struct extractpdf_page extractpdf_page;
 typedef struct extractpdf_bitmap extractpdf_bitmap;
 typedef struct extractpdf_text_page extractpdf_text_page;
 
+typedef struct extractpdf_point {
+    float x;
+    float y;
+} extractpdf_point;
+
 typedef struct extractpdf_rect {
     float x0;
     float y0;
     float x1;
     float y1;
 } extractpdf_rect;
+
+typedef struct extractpdf_quad {
+    extractpdf_point ul;
+    extractpdf_point ur;
+    extractpdf_point ll;
+    extractpdf_point lr;
+} extractpdf_quad;
 
 typedef enum extractpdf_page_box {
     EXTRACTPDF_PAGE_BOX_MEDIA = 0,
@@ -64,6 +76,11 @@ typedef struct extractpdf_text_span_info {
     uint32_t argb;
     uint32_t bidi_level;
 } extractpdf_text_span_info;
+
+typedef struct extractpdf_search_result {
+    size_t struct_size;
+    extractpdf_quad quad;
+} extractpdf_search_result;
 
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
@@ -175,6 +192,13 @@ EXTRACTPDF_API extractpdf_status extractpdf_text_span_text(
     size_t span_index,
     const char **out_utf8,
     size_t *out_size);
+
+EXTRACTPDF_API extractpdf_status extractpdf_text_search(
+    const extractpdf_text_page *text,
+    const char *needle_utf8,
+    extractpdf_search_result *results,
+    size_t capacity,
+    size_t *out_count);
 
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);

--- a/src/search.c
+++ b/src/search.c
@@ -1,0 +1,408 @@
+#include "internal.h"
+
+#include <float.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int extractpdf_is_continuation(unsigned char byte)
+{
+    return (byte & 0xc0u) == 0x80u;
+}
+
+static int extractpdf_decode_one_utf8(
+    const unsigned char *data,
+    size_t remaining,
+    uint32_t *out_codepoint,
+    size_t *out_size)
+{
+    unsigned char b0;
+
+    if (remaining == 0)
+        return 0;
+
+    b0 = data[0];
+    if (b0 <= 0x7fu) {
+        *out_codepoint = b0;
+        *out_size = 1;
+        return 1;
+    }
+
+    if (b0 >= 0xc2u && b0 <= 0xdfu) {
+        if (remaining < 2 || !extractpdf_is_continuation(data[1]))
+            return 0;
+        *out_codepoint = ((uint32_t)(b0 & 0x1fu) << 6) |
+            (uint32_t)(data[1] & 0x3fu);
+        *out_size = 2;
+        return 1;
+    }
+
+    if (b0 >= 0xe0u && b0 <= 0xefu) {
+        unsigned char b1;
+        unsigned char b2;
+
+        if (remaining < 3)
+            return 0;
+        b1 = data[1];
+        b2 = data[2];
+        if (!extractpdf_is_continuation(b1) ||
+            !extractpdf_is_continuation(b2))
+            return 0;
+        if (b0 == 0xe0u && b1 < 0xa0u)
+            return 0;
+        if (b0 == 0xedu && b1 >= 0xa0u)
+            return 0;
+
+        *out_codepoint = ((uint32_t)(b0 & 0x0fu) << 12) |
+            ((uint32_t)(b1 & 0x3fu) << 6) |
+            (uint32_t)(b2 & 0x3fu);
+        *out_size = 3;
+        return 1;
+    }
+
+    if (b0 >= 0xf0u && b0 <= 0xf4u) {
+        unsigned char b1;
+        unsigned char b2;
+        unsigned char b3;
+
+        if (remaining < 4)
+            return 0;
+        b1 = data[1];
+        b2 = data[2];
+        b3 = data[3];
+        if (!extractpdf_is_continuation(b1) ||
+            !extractpdf_is_continuation(b2) ||
+            !extractpdf_is_continuation(b3))
+            return 0;
+        if (b0 == 0xf0u && b1 < 0x90u)
+            return 0;
+        if (b0 == 0xf4u && b1 >= 0x90u)
+            return 0;
+
+        *out_codepoint = ((uint32_t)(b0 & 0x07u) << 18) |
+            ((uint32_t)(b1 & 0x3fu) << 12) |
+            ((uint32_t)(b2 & 0x3fu) << 6) |
+            (uint32_t)(b3 & 0x3fu);
+        *out_size = 4;
+        return 1;
+    }
+
+    return 0;
+}
+
+static extractpdf_status extractpdf_decode_search_needle(
+    const char *needle_utf8,
+    uint32_t **out_codepoints,
+    size_t *out_count)
+{
+    const unsigned char *bytes;
+    uint32_t *codepoints;
+    size_t byte_count;
+    size_t byte_index = 0;
+    size_t codepoint_count = 0;
+
+    *out_codepoints = NULL;
+    *out_count = 0;
+
+    if (needle_utf8 == NULL || needle_utf8[0] == '\0')
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    byte_count = strlen(needle_utf8);
+    if (byte_count > SIZE_MAX / sizeof(*codepoints))
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    codepoints = (uint32_t *)malloc(byte_count * sizeof(*codepoints));
+    if (codepoints == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    bytes = (const unsigned char *)needle_utf8;
+    while (byte_index < byte_count) {
+        uint32_t codepoint;
+        size_t encoded_size;
+
+        if (!extractpdf_decode_one_utf8(
+                bytes + byte_index,
+                byte_count - byte_index,
+                &codepoint,
+                &encoded_size)) {
+            free(codepoints);
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        }
+
+        codepoints[codepoint_count++] = codepoint;
+        byte_index += encoded_size;
+    }
+
+    *out_codepoints = codepoints;
+    *out_count = codepoint_count;
+    return EXTRACTPDF_OK;
+}
+
+static void extractpdf_line_char_range(
+    const extractpdf_text_page *text,
+    const extractpdf_text_line_internal *line,
+    size_t *out_first_char,
+    size_t *out_char_count)
+{
+    const extractpdf_text_span_internal *first_span;
+    const extractpdf_text_span_internal *last_span;
+    size_t end_char;
+
+    if (line->span_count == 0) {
+        *out_first_char = 0;
+        *out_char_count = 0;
+        return;
+    }
+
+    first_span = &text->spans[line->first_span];
+    last_span = &text->spans[line->first_span + line->span_count - 1];
+    end_char = last_span->first_char + last_span->char_count;
+
+    *out_first_char = first_span->first_char;
+    *out_char_count = end_char - first_span->first_char;
+}
+
+static int extractpdf_chars_match(
+    const extractpdf_text_page *text,
+    size_t first_char,
+    const uint32_t *needle,
+    size_t needle_count)
+{
+    size_t i;
+
+    for (i = 0; i < needle_count; ++i) {
+        if (text->chars[first_char + i].codepoint != needle[i])
+            return 0;
+    }
+    return 1;
+}
+
+static extractpdf_status extractpdf_count_search_results(
+    const extractpdf_text_page *text,
+    const uint32_t *needle,
+    size_t needle_count,
+    size_t *out_required)
+{
+    size_t required = 0;
+    size_t line_index;
+
+    for (line_index = 0; line_index < text->line_count; ++line_index) {
+        const extractpdf_text_line_internal *line = &text->lines[line_index];
+        size_t first_char;
+        size_t char_count;
+        size_t offset;
+
+        extractpdf_line_char_range(text, line, &first_char, &char_count);
+        if (needle_count > char_count)
+            continue;
+
+        for (offset = 0; offset <= char_count - needle_count; ++offset) {
+            if (!extractpdf_chars_match(
+                    text, first_char + offset, needle, needle_count))
+                continue;
+            if (required == SIZE_MAX)
+                return EXTRACTPDF_ERROR_NOMEM;
+            ++required;
+        }
+    }
+
+    *out_required = required;
+    return EXTRACTPDF_OK;
+}
+
+static float extractpdf_project_point(fz_point point, float x, float y)
+{
+    return point.x * x + point.y * y;
+}
+
+static void extractpdf_include_quad_projection(
+    fz_quad quad,
+    float dx,
+    float dy,
+    float nx,
+    float ny,
+    float *min_u,
+    float *max_u,
+    float *min_v,
+    float *max_v)
+{
+    fz_point points[4];
+    size_t i;
+
+    points[0] = quad.ul;
+    points[1] = quad.ur;
+    points[2] = quad.ll;
+    points[3] = quad.lr;
+
+    for (i = 0; i < 4; ++i) {
+        float u = extractpdf_project_point(points[i], dx, dy);
+        float v = extractpdf_project_point(points[i], nx, ny);
+
+        if (u < *min_u)
+            *min_u = u;
+        if (u > *max_u)
+            *max_u = u;
+        if (v < *min_v)
+            *min_v = v;
+        if (v > *max_v)
+            *max_v = v;
+    }
+}
+
+static extractpdf_point extractpdf_point_from_basis(
+    float u,
+    float v,
+    float dx,
+    float dy,
+    float nx,
+    float ny)
+{
+    extractpdf_point point;
+
+    point.x = dx * u + nx * v;
+    point.y = dy * u + ny * v;
+    return point;
+}
+
+static void extractpdf_make_search_quad(
+    const extractpdf_text_page *text,
+    const extractpdf_text_line_internal *line,
+    size_t first_char,
+    size_t char_count,
+    extractpdf_quad *out_quad)
+{
+    float dx = line->direction_x;
+    float dy = line->direction_y;
+    float nx;
+    float ny;
+    float min_u = FLT_MAX;
+    float max_u = -FLT_MAX;
+    float min_v = FLT_MAX;
+    float max_v = -FLT_MAX;
+    size_t i;
+
+    if (dx == 0.0f && dy == 0.0f) {
+        dx = 1.0f;
+        dy = 0.0f;
+    }
+    nx = -dy;
+    ny = dx;
+
+    for (i = 0; i < char_count; ++i) {
+        extractpdf_include_quad_projection(
+            text->chars[first_char + i].quad,
+            dx,
+            dy,
+            nx,
+            ny,
+            &min_u,
+            &max_u,
+            &min_v,
+            &max_v);
+    }
+
+    out_quad->ul = extractpdf_point_from_basis(
+        min_u, min_v, dx, dy, nx, ny);
+    out_quad->ur = extractpdf_point_from_basis(
+        max_u, min_v, dx, dy, nx, ny);
+    out_quad->ll = extractpdf_point_from_basis(
+        min_u, max_v, dx, dy, nx, ny);
+    out_quad->lr = extractpdf_point_from_basis(
+        max_u, max_v, dx, dy, nx, ny);
+}
+
+static void extractpdf_fill_search_results(
+    const extractpdf_text_page *text,
+    const uint32_t *needle,
+    size_t needle_count,
+    extractpdf_search_result *results)
+{
+    size_t result_index = 0;
+    size_t line_index;
+
+    for (line_index = 0; line_index < text->line_count; ++line_index) {
+        const extractpdf_text_line_internal *line = &text->lines[line_index];
+        size_t first_char;
+        size_t char_count;
+        size_t offset;
+
+        extractpdf_line_char_range(text, line, &first_char, &char_count);
+        if (needle_count > char_count)
+            continue;
+
+        for (offset = 0; offset <= char_count - needle_count; ++offset) {
+            if (!extractpdf_chars_match(
+                    text, first_char + offset, needle, needle_count))
+                continue;
+
+            extractpdf_make_search_quad(
+                text,
+                line,
+                first_char + offset,
+                needle_count,
+                &results[result_index].quad);
+            ++result_index;
+        }
+    }
+}
+
+extractpdf_status extractpdf_text_search(
+    const extractpdf_text_page *text,
+    const char *needle_utf8,
+    extractpdf_search_result *results,
+    size_t capacity,
+    size_t *out_count)
+{
+    uint32_t *needle = NULL;
+    size_t needle_count = 0;
+    size_t required = 0;
+    size_t minimum_size;
+    size_t i;
+    extractpdf_status status;
+
+    if (out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_count = 0;
+
+    if (text == NULL || needle_utf8 == NULL || needle_utf8[0] == '\0')
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (results == NULL && capacity != 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_decode_search_needle(
+        needle_utf8, &needle, &needle_count);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    status = extractpdf_count_search_results(
+        text, needle, needle_count, &required);
+    if (status != EXTRACTPDF_OK) {
+        free(needle);
+        return status;
+    }
+
+    *out_count = required;
+    if (results == NULL) {
+        free(needle);
+        return EXTRACTPDF_OK;
+    }
+
+    if (capacity < required) {
+        free(needle);
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    }
+
+    minimum_size = offsetof(extractpdf_search_result, quad) +
+        sizeof(results[0].quad);
+    for (i = 0; i < required; ++i) {
+        if (results[i].struct_size < minimum_size) {
+            free(needle);
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        }
+    }
+
+    extractpdf_fill_search_results(text, needle, needle_count, results);
+    free(needle);
+    return EXTRACTPDF_OK;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,13 +49,21 @@ target_compile_definitions(extractpdf_test_structured_text PRIVATE
 add_test(NAME extractpdf.structured_text COMMAND extractpdf_test_structured_text)
 set_tests_properties(extractpdf.structured_text PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_text_search test_text_search.c)
+target_link_libraries(extractpdf_test_text_search PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_text_search PRIVATE
+  STRUCTURED_TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/structured-text.pdf")
+add_test(NAME extractpdf.text_search COMMAND extractpdf_test_text_search)
+set_tests_properties(extractpdf.text_search PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
       extractpdf_test_document
       extractpdf_test_render
       extractpdf_test_text
-      extractpdf_test_structured_text)
+      extractpdf_test_structured_text
+      extractpdf_test_text_search)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/test_text_search.c
+++ b/tests/test_text_search.c
@@ -1,0 +1,123 @@
+#include <extractpdf/extractpdf.h>
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static void check_point(extractpdf_point point)
+{
+    CHECK(isfinite(point.x));
+    CHECK(isfinite(point.y));
+}
+
+static void check_quad(const extractpdf_quad *quad)
+{
+    check_point(quad->ul);
+    check_point(quad->ur);
+    check_point(quad->ll);
+    check_point(quad->lr);
+    CHECK(quad->ur.x > quad->ul.x);
+    CHECK(quad->lr.x > quad->ll.x);
+    CHECK(quad->ll.y > quad->ul.y);
+    CHECK(quad->lr.y > quad->ur.y);
+}
+
+int main(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_text_page *text = NULL;
+    extractpdf_search_result result = { sizeof(result), { { 0 } } };
+    extractpdf_search_result repeated[2] = {
+        { sizeof(repeated[0]), { { 0 } } },
+        { sizeof(repeated[1]), { { 0 } } }
+    };
+    size_t count = 0;
+
+    CHECK(extractpdf_open(STRUCTURED_TEXT_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_structured_text(page, &text) == EXTRACTPDF_OK);
+
+    /* Search must use only the immutable snapshot. */
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    page = NULL;
+    document = NULL;
+
+    /* UTF-8 search may cross style spans on the same line. */
+    count = 123;
+    CHECK(extractpdf_text_search(text, "lo Caf\xc3\xa9", NULL, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "lo Caf\xc3\xa9", &result, 1, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(result.struct_size == sizeof(result));
+    check_quad(&result.quad);
+
+    /* Repeated matches exercise sizing, insufficient capacity, and fill. */
+    count = 123;
+    CHECK(extractpdf_text_search(text, "l", NULL, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 2);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "l", repeated, 1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 2);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "l", repeated, 2, &count) == EXTRACTPDF_OK);
+    CHECK(count == 2);
+    check_quad(&repeated[0].quad);
+    check_quad(&repeated[1].quad);
+    CHECK(repeated[1].quad.ul.x > repeated[0].quad.ul.x);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "missing", NULL, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 0);
+
+    /* Invalid arguments reset count before a required count is known. */
+    count = 123;
+    CHECK(extractpdf_text_search(NULL, "l", NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, NULL, NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "", NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "\xc3\x28", NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    count = 123;
+    CHECK(extractpdf_text_search(text, "l", NULL, 1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    CHECK(extractpdf_text_search(text, "l", repeated, 2, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    /* V1 result structs require the quad field to be present. */
+    result.struct_size = offsetof(extractpdf_search_result, quad);
+    count = 123;
+    CHECK(extractpdf_text_search(text, "Caf\xc3\xa9", &result, 1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 1);
+
+    extractpdf_drop_text_page(text);
+    (void)sentinel;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 3 Content search slice from #11 / #2, stacked on structured-text PR #10.

Implemented bounded design:
- search only the immutable `extractpdf_text_page`; no MuPDF page/document re-extraction
- strict UTF-8 decode + exact Unicode codepoint matching for V1
- line-scoped matching; matches may cross style spans on one line but never bridge lines
- two-call count/fill API returning versioned `extractpdf_search_result` quads in Fitz page space
- insufficient capacity reports the total required count and returns `EXTRACTPDF_ERROR_ARGUMENT` rather than truncating
- repeated/overlapping matches are supported
- result geometry combines the matched copied character quads in the line's baseline/normal basis, preserving line orientation
- implementation lives in `src/search.c`; structured snapshot private layout is unchanged

TDD evidence:
- RED commit `44abba273b60613bc2e7f6e597a491bf76aed65a`: only search contract test + CTest wiring
- RED independently verified against the exact pre-feature header: expected missing `extractpdf_search_result` / `extractpdf_text_search`
- workflow #118 was superseded/cancelled by concurrency after the GREEN head was pushed and is not treated as pass evidence
- exact GREEN head `f4b9a8931094f5a43f5f20a715a86c290302439a`
- workflow #119: Linux static build ✅, all 6 normal CTests ✅, ASan/UBSan build ✅, all 6 sanitizer CTests ✅

Scope review relative to structured-text base `76b629ef`: only public search ABI, `src/search.c`, root CMake, and search test/CMake wiring changed; no Page/Render/plain-text/structured-text implementation was modified.

Deferred cross-platform verification is now complete on the cumulative Phase 3 exact head `204aa90349256e323685ef34ad564032dd4aac52`: `full-ci` workflow #130 passed Linux static + ASan/UBSan, macOS native build/test, and Windows DLL build/test.

PR remains draft for stacked integration. Tracks #11 and #2.