### PR TITLE
feat: enumerate page links with copied destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ add_library(extractpdf
   src/structured_text.c
   src/search.c
   src/images.c
-  src/image_bitmap.c)
+  src/image_bitmap.c
+  src/links.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -23,6 +23,7 @@ typedef struct extractpdf_page extractpdf_page;
 typedef struct extractpdf_bitmap extractpdf_bitmap;
 typedef struct extractpdf_text_page extractpdf_text_page;
 typedef struct extractpdf_image_page extractpdf_image_page;
+typedef struct extractpdf_link_page extractpdf_link_page;
 
 typedef struct extractpdf_point {
     float x;
@@ -92,6 +93,19 @@ typedef struct extractpdf_image_info {
     int bits_per_component;
     int has_alpha;
 } extractpdf_image_info;
+
+typedef enum extractpdf_link_kind {
+    EXTRACTPDF_LINK_URI = 1,
+    EXTRACTPDF_LINK_INTERNAL = 2
+} extractpdf_link_kind;
+
+typedef struct extractpdf_link_info {
+    size_t struct_size;
+    extractpdf_rect hotspot;
+    extractpdf_link_kind kind;
+    int target_page;
+    extractpdf_point target;
+} extractpdf_link_info;
 
 typedef enum extractpdf_status {
     EXTRACTPDF_OK = 0,
@@ -229,6 +243,25 @@ EXTRACTPDF_API extractpdf_status extractpdf_image_render(
     size_t index,
     extractpdf_bitmap **out_bitmap);
 
+EXTRACTPDF_API extractpdf_status extractpdf_extract_links(
+    extractpdf_page *page,
+    extractpdf_link_page **out_links);
+
+EXTRACTPDF_API extractpdf_status extractpdf_link_count(
+    const extractpdf_link_page *links,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_link_get_info(
+    const extractpdf_link_page *links,
+    size_t index,
+    extractpdf_link_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_link_uri(
+    const extractpdf_link_page *links,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
 
@@ -240,6 +273,9 @@ EXTRACTPDF_API void extractpdf_drop_text_page(
 
 EXTRACTPDF_API void extractpdf_drop_image_page(
     extractpdf_image_page *images);
+
+EXTRACTPDF_API void extractpdf_drop_link_page(
+    extractpdf_link_page *links);
 
 EXTRACTPDF_API void extractpdf_drop_bitmap(
     extractpdf_bitmap *bitmap);

--- a/src/internal.h
+++ b/src/internal.h
@@ -85,6 +85,20 @@ struct extractpdf_image_page {
     int oom;
 };
 
+typedef struct extractpdf_link_internal {
+    extractpdf_rect hotspot;
+    extractpdf_link_kind kind;
+    int target_page;
+    extractpdf_point target;
+    char *uri;
+    size_t uri_size;
+} extractpdf_link_internal;
+
+struct extractpdf_link_page {
+    extractpdf_link_internal *items;
+    size_t count;
+};
+
 extractpdf_status extractpdf_status_from_mupdf(int code);
 
 #endif

--- a/src/links.c
+++ b/src/links.c
@@ -1,0 +1,250 @@
+#include "internal.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void extractpdf_zero_rect(extractpdf_rect *rect)
+{
+    rect->x0 = 0.0f;
+    rect->y0 = 0.0f;
+    rect->x1 = 0.0f;
+    rect->y1 = 0.0f;
+}
+
+static void extractpdf_dispose_link_page(extractpdf_link_page *links)
+{
+    size_t i;
+
+    if (links == NULL)
+        return;
+
+    for (i = 0; i < links->count; ++i)
+        free(links->items[i].uri);
+    free(links->items);
+    free(links);
+}
+
+static char *extractpdf_copy_uri(const char *uri, size_t *out_size)
+{
+    char *copy;
+    size_t size;
+
+    *out_size = 0;
+    if (uri == NULL)
+        return NULL;
+
+    size = strlen(uri);
+    if (size == SIZE_MAX)
+        return NULL;
+
+    copy = (char *)malloc(size + 1);
+    if (copy == NULL)
+        return NULL;
+
+    memcpy(copy, uri, size + 1);
+    *out_size = size;
+    return copy;
+}
+
+extractpdf_status extractpdf_extract_links(
+    extractpdf_page *page,
+    extractpdf_link_page **out_links)
+{
+    extractpdf_link_page *snapshot;
+    fz_context *ctx;
+    fz_link *head = NULL;
+    fz_link *link;
+    size_t count = 0;
+    size_t index = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_links == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_links = NULL;
+
+    if (page == NULL || page->page == NULL || page->document == NULL ||
+        page->document->ctx == NULL || page->document->doc == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    snapshot = (extractpdf_link_page *)calloc(1, sizeof(*snapshot));
+    if (snapshot == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    ctx = page->document->ctx;
+    fz_var(head);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        head = fz_load_links(ctx, page->page);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        extractpdf_status status = extractpdf_status_from_mupdf(caught_code);
+        extractpdf_dispose_link_page(snapshot);
+        return status;
+    }
+
+    for (link = head; link != NULL; link = link->next) {
+        if (count == SIZE_MAX) {
+            fz_drop_link(ctx, head);
+            extractpdf_dispose_link_page(snapshot);
+            return EXTRACTPDF_ERROR_NOMEM;
+        }
+        ++count;
+    }
+
+    if (count != 0) {
+        if (count > SIZE_MAX / sizeof(*snapshot->items)) {
+            fz_drop_link(ctx, head);
+            extractpdf_dispose_link_page(snapshot);
+            return EXTRACTPDF_ERROR_NOMEM;
+        }
+        snapshot->items = (extractpdf_link_internal *)calloc(
+            count,
+            sizeof(*snapshot->items));
+        if (snapshot->items == NULL) {
+            fz_drop_link(ctx, head);
+            extractpdf_dispose_link_page(snapshot);
+            return EXTRACTPDF_ERROR_NOMEM;
+        }
+    }
+    snapshot->count = count;
+
+    for (link = head; link != NULL; link = link->next, ++index) {
+        extractpdf_link_internal *item = &snapshot->items[index];
+
+        item->hotspot.x0 = link->rect.x0;
+        item->hotspot.y0 = link->rect.y0;
+        item->hotspot.x1 = link->rect.x1;
+        item->hotspot.y1 = link->rect.y1;
+        item->target_page = -1;
+
+        if (fz_is_external_link(ctx, link->uri)) {
+            item->kind = EXTRACTPDF_LINK_URI;
+            item->uri = extractpdf_copy_uri(link->uri, &item->uri_size);
+            if (item->uri == NULL) {
+                fz_drop_link(ctx, head);
+                extractpdf_dispose_link_page(snapshot);
+                return EXTRACTPDF_ERROR_NOMEM;
+            }
+        }
+        else {
+            caught_code = FZ_ERROR_NONE;
+            item->kind = EXTRACTPDF_LINK_INTERNAL;
+            fz_try(ctx)
+            {
+                fz_link_dest dest = fz_resolve_link_dest(
+                    ctx,
+                    page->document->doc,
+                    link->uri);
+                item->target_page = fz_page_number_from_location(
+                    ctx,
+                    page->document->doc,
+                    dest.loc);
+                item->target.x = dest.x;
+                item->target.y = dest.y;
+            }
+            fz_catch(ctx)
+            {
+                caught_code = fz_caught(ctx);
+                fz_report_error(ctx);
+            }
+
+            if (caught_code != FZ_ERROR_NONE) {
+                extractpdf_status status = extractpdf_status_from_mupdf(caught_code);
+                fz_drop_link(ctx, head);
+                extractpdf_dispose_link_page(snapshot);
+                return status;
+            }
+        }
+    }
+
+    fz_drop_link(ctx, head);
+    *out_links = snapshot;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_link_count(
+    const extractpdf_link_page *links,
+    size_t *out_count)
+{
+    if (out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_count = 0;
+
+    if (links == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_count = links->count;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_link_get_info(
+    const extractpdf_link_page *links,
+    size_t index,
+    extractpdf_link_info *out_info)
+{
+    const extractpdf_link_internal *item;
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_link_info, target) +
+        sizeof(out_info->target);
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    extractpdf_zero_rect(&out_info->hotspot);
+    out_info->kind = (extractpdf_link_kind)0;
+    out_info->target_page = -1;
+    out_info->target.x = 0.0f;
+    out_info->target.y = 0.0f;
+
+    if (links == NULL || index >= links->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    item = &links->items[index];
+    out_info->hotspot = item->hotspot;
+    out_info->kind = item->kind;
+    out_info->target_page = item->target_page;
+    out_info->target = item->target;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_link_uri(
+    const extractpdf_link_page *links,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size)
+{
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
+
+    if (out_utf8 == NULL || out_size == NULL || links == NULL ||
+        index >= links->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    if (links->items[index].kind != EXTRACTPDF_LINK_URI ||
+        links->items[index].uri == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_utf8 = links->items[index].uri;
+    *out_size = links->items[index].uri_size;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_link_page(extractpdf_link_page *links)
+{
+    extractpdf_dispose_link_page(links);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,13 @@ target_compile_definitions(extractpdf_test_image_bitmap PRIVATE
 add_test(NAME extractpdf.image_bitmap COMMAND extractpdf_test_image_bitmap)
 set_tests_properties(extractpdf.image_bitmap PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_links test_links.c)
+target_link_libraries(extractpdf_test_links PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_links PRIVATE
+  PAGE_LINKS_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/page-links.pdf")
+add_test(NAME extractpdf.links COMMAND extractpdf_test_links)
+set_tests_properties(extractpdf.links PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -81,7 +88,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_structured_text
       extractpdf_test_text_search
       extractpdf_test_images
-      extractpdf_test_image_bitmap)
+      extractpdf_test_image_bitmap
+      extractpdf_test_links)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/page-links.pdf
+++ b/tests/fixtures/page-links.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Annots [4 0 R 6 0 R] >>
+endobj
+4 0 obj
+<< /Type /Annot /Subtype /Link /Rect [20 140 100 160] /Border [0 0 0] /A << /S /URI /URI (https://example.com/extractpdf-phase3) >> >>
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Link /Rect [20 100 100 120] /Border [0 0 0] /Dest [5 0 R /XYZ 30 150 1] >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000121 00000 n 
+0000000214 00000 n 
+0000000364 00000 n 
+0000000435 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+551
+%%EOF

--- a/tests/test_links.c
+++ b/tests/test_links.c
@@ -1,0 +1,132 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    if (d < 0.0f)
+        d = -d;
+    return d < 0.01f;
+}
+
+static void check_rect(
+    const extractpdf_rect *rect,
+    float x0,
+    float y0,
+    float x1,
+    float y1)
+{
+    CHECK(close_float(rect->x0, x0));
+    CHECK(close_float(rect->y0, y0));
+    CHECK(close_float(rect->x1, x1));
+    CHECK(close_float(rect->y1, y1));
+}
+
+static void test_links_and_document_independent_lifetime(void)
+{
+    static const char expected_uri[] =
+        "https://example.com/extractpdf-phase3";
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_link_page *links = NULL;
+    extractpdf_link_info external = { 0 };
+    extractpdf_link_info internal = { 0 };
+    const char *uri = NULL;
+    size_t uri_size = 0;
+    size_t count = 0;
+
+    external.struct_size = sizeof(external);
+    internal.struct_size = sizeof(internal);
+
+    CHECK(extractpdf_open(PAGE_LINKS_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_links(page, &links) == EXTRACTPDF_OK);
+    CHECK(links != NULL);
+
+    /*
+     * Link snapshots contain only ExtractPDF-owned copies. They must not
+     * retain or require the source page, document, or MuPDF link objects.
+     */
+    extractpdf_drop_page(page);
+    page = NULL;
+    extractpdf_close(document);
+    document = NULL;
+
+    CHECK(extractpdf_link_count(links, &count) == EXTRACTPDF_OK);
+    CHECK(count == 2);
+
+    CHECK(extractpdf_link_get_info(links, 0, &external) == EXTRACTPDF_OK);
+    CHECK(external.struct_size == sizeof(external));
+    CHECK(external.kind == EXTRACTPDF_LINK_URI);
+    check_rect(&external.hotspot, 20.0f, 40.0f, 100.0f, 60.0f);
+    CHECK(external.target_page == -1);
+    CHECK(close_float(external.target.x, 0.0f));
+    CHECK(close_float(external.target.y, 0.0f));
+
+    CHECK(extractpdf_link_uri(links, 0, &uri, &uri_size) == EXTRACTPDF_OK);
+    CHECK(uri != NULL);
+    CHECK(uri_size == strlen(expected_uri));
+    CHECK(memcmp(uri, expected_uri, uri_size) == 0);
+    CHECK(uri[uri_size] == '\0');
+
+    CHECK(extractpdf_link_get_info(links, 1, &internal) == EXTRACTPDF_OK);
+    CHECK(internal.struct_size == sizeof(internal));
+    CHECK(internal.kind == EXTRACTPDF_LINK_INTERNAL);
+    check_rect(&internal.hotspot, 20.0f, 80.0f, 100.0f, 100.0f);
+    CHECK(internal.target_page == 1);
+    CHECK(close_float(internal.target.x, 30.0f));
+    CHECK(close_float(internal.target.y, 50.0f));
+
+    extractpdf_drop_link_page(links);
+}
+
+static void test_argument_contract(void)
+{
+    int sentinel = 0;
+    extractpdf_link_page *links = (extractpdf_link_page *)&sentinel;
+    extractpdf_link_info info = { 0 };
+    const char *uri = (const char *)&sentinel;
+    size_t count = 99;
+    size_t uri_size = 99;
+
+    info.struct_size = sizeof(info);
+
+    CHECK(extractpdf_extract_links(NULL, &links) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(links == NULL);
+    CHECK(extractpdf_extract_links(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_link_count(NULL, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_link_count(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_link_get_info(NULL, 0, &info) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_link_get_info(NULL, 0, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_link_uri(NULL, 0, &uri, &uri_size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(uri == NULL);
+    CHECK(uri_size == 0);
+    CHECK(extractpdf_link_uri(NULL, 0, NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    extractpdf_drop_link_page(NULL);
+}
+
+int main(void)
+{
+    test_links_and_document_independent_lifetime();
+    test_argument_contract();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 3 Content links slice for #17 / #2, stacked on decoded-image PR #16.

## Contract

- immutable `extractpdf_link_page` snapshot
- hotspot rectangles in existing Fitz page-space
- external URI vs internal destination kind
- internal destination flattened to 0-based target page + page-space point
- URI returned from snapshot-owned UTF-8 copy
- snapshot remains readable after both source page and document are dropped
- versioned `extractpdf_link_info` via `struct_size`

Deterministic two-page fixture contains, in page-0 annotation order:

1. `https://example.com/extractpdf-phase3`, hotspot `(20,40)-(100,60)`
2. internal `[page2 /XYZ 30 150 1]`, expected flat target page `1`, target `(30,50)`, hotspot `(20,80)-(100,100)`

## TDD evidence

RED exact head `ca9ca038d347a93bd916240c071a121779b3da6e`:

- workflow #128 / Linux job `98599918080`
- MuPDF install + static configure + library + all pre-existing test targets passed to build/link
- only `extractpdf_test_links` failed at final link
- missing symbols were exactly the five new links API functions

GREEN exact head `204aa90349256e323685ef34ad564032dd4aac52`:

- production delta is only `src/links.c`, private snapshot storage in `src/internal.h`, and root CMake wiring
- no document/MuPDF pointer is retained in `extractpdf_link_page`
- external URI bytes are copied into snapshot-owned storage
- internal destination uses Fitz `fz_resolve_link_dest` + `fz_page_number_from_location`; no PDF-private API and no target-page reload
- workflow #129: Linux static build/tests ✅, ASan/UBSan build/tests ✅

## Phase 3 Content checkpoint

`full-ci` workflow #130 completed successfully on the same exact GREEN head `204aa90349256e323685ef34ad564032dd4aac52`:

- Linux static build/tests ✅
- Linux ASan/UBSan build/tests ✅
- macOS native configure/build/test ✅
- Windows DLL configure/build/test ✅

The deferred Phase 3 cross-platform checkpoint is now complete. No additional production change was required after the Linux GREEN.

Keep this PR draft until the stacked Phase 3 PR integration/merge order is reviewed; no merge is performed here.