### PR TITLE
feat: export contiguous PDF page ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@ add_library(extractpdf
   src/images.c
   src/image_bitmap.c
   src/links.c
-  src/pdf_export.c)
+  src/pdf_export.c
+  src/pdf_range.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/docs/superpowers/plans/2026-08-28-extractpdf-pdf-export-range.md
+++ b/docs/superpowers/plans/2026-08-28-extractpdf-pdf-export-range.md
@@ -1,0 +1,327 @@
+# PDF Contiguous Range Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `extractpdf_export_page_range(...)` as a thin contiguous-index mapping layer over the already-verified `extractpdf_export_pages(...)` composition engine.
+
+**Architecture:** The new helper validates only mapping-safe arguments, expands `(first_page, page_count)` into a temporary `int[]`, and delegates to `extractpdf_export_pages(...)`. It owns no PDF-specific behavior and must not include `<mupdf/pdf.h>` or call any MuPDF PDF graft/write API.
+
+**Tech Stack:** C11, CMake/CTest, existing ExtractPDF immutable output ABI, MuPDF 1.28.2 only through the already-existing export-pages engine.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-pdf-export-range-design.md`
+
+## Global Constraints
+
+- Stacked base is PR #20 exact head `d7d3e2a3c0ead330d0f8c97dd2bab7cd695f0012`; implementation branch is `feat/pdf-export-range`.
+- Public ABI remains stable C and exposes no MuPDF type.
+- `extractpdf_export_pages(...)` remains the only PDF composition/serialization engine.
+- `src/pdf_range.c` must not include `<mupdf/pdf.h>` and must not call `pdf_specifics`, `pdf_create_document`, `pdf_new_graft_map`, `pdf_graft_page`, `pdf_graft_mapped_page`, `pdf_write_document`, `pdf_save_document`, or `fz_new_output_with_buffer`.
+- Range syntax is zero-based `first_page + page_count`, forward and contiguous only.
+- `page_count > 0`; no descending, stepped, disjoint, duplicate-in-range, string-range, or multi-output API.
+- Mapping-safety checks happen before allocation: `first_page >= 0`, `page_count <= INT_MAX`, `page_count <= SIZE_MAX / sizeof(int)`, and `first_page + page_count - 1 <= INT_MAX` without overflow.
+- Document-dependent page bounds and non-PDF handling remain delegated to `extractpdf_export_pages(...)`.
+- Returned output ownership/lifetime is exactly the existing immutable `extractpdf_output` contract.
+- TDD is strict: do not add the declaration or production helper until the new range test has failed at the intended missing-API boundary.
+
+---
+
+### Task 1: Range-only deterministic RED
+
+**Files:**
+- Create: `tests/test_pdf_range.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes existing APIs: `extractpdf_open`, `extractpdf_close`, `extractpdf_export_pages`, `extractpdf_output_data`, `extractpdf_drop_output`, `extractpdf_page_count`, `extractpdf_load_page`, `extractpdf_page_bounds`, `extractpdf_extract_text`, `extractpdf_free`, `extractpdf_drop_page`.
+- Produces the wished-for compile contract only:
+
+```c
+extractpdf_status extractpdf_export_page_range(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_output **out_output);
+```
+
+- [ ] **Step 1: Write `tests/test_pdf_range.c` against the absent API**
+
+Use only `<extractpdf/extractpdf.h>` plus standard C headers. Do not locally declare the new function.
+
+Required helpers:
+
+```c
+#include <extractpdf/extractpdf.h>
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static extractpdf_output *output_sentinel(void)
+{
+    return (extractpdf_output *)(uintptr_t)1;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static int expect_page(
+    extractpdf_document *document,
+    int index,
+    const char *needle,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+    int ok = 0;
+
+    if (extractpdf_load_page(document, index, &page) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_page_bounds(page, &bounds) != EXTRACTPDF_OK)
+        goto done;
+    if (bounds.x0 != 0.0f || bounds.y0 != 0.0f ||
+        bounds.x1 != width || bounds.y1 != height)
+        goto done;
+    if (extractpdf_extract_text(page, &text, &text_size) != EXTRACTPDF_OK)
+        goto done;
+    if (text == NULL || strstr(text, needle) == NULL)
+        goto done;
+    ok = 1;
+
+done:
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+    return ok;
+}
+```
+
+Primary success proof:
+
+```c
+extractpdf_output *range_output = NULL;
+extractpdf_output *index_output = NULL;
+const unsigned char *range_data = NULL;
+const unsigned char *index_data = NULL;
+size_t range_size = 0;
+size_t index_size = 0;
+int indices[] = {1, 2};
+
+/* open COMPOSITION_PDF */
+/* export_page_range(document, 1, 2, &range_output) -> OK */
+/* export_pages(document, indices, 2, &index_output) -> OK */
+/* output_data for both -> non-NULL PDF bytes */
+/* require equal sizes and memcmp(range_data,index_data,size)==0 */
+/* write range bytes to RANGE_OUTPUT_PDF and reopen */
+/* page_count == 2 */
+/* page 0 PAGE-B, 240x180 */
+/* page 1 PAGE-C, 300x150 */
+```
+
+Additional success checks:
+
+```c
+extractpdf_export_page_range(document, 2, 1, &out) == EXTRACTPDF_OK;
+/* bytes equal export_pages({2}) */
+
+extractpdf_export_page_range(document, 0, 3, &out) == EXTRACTPDF_OK;
+/* bytes equal export_pages({0,1,2}) */
+```
+
+Required failure checks, each using a non-NULL sentinel output when an output slot is supplied and requiring reset to NULL:
+
+```c
+extractpdf_export_page_range(NULL, 0, 1, &out) == EXTRACTPDF_ERROR_ARGUMENT;
+extractpdf_export_page_range(document, 0, 1, NULL) == EXTRACTPDF_ERROR_ARGUMENT;
+extractpdf_export_page_range(document, -1, 1, &out) == EXTRACTPDF_ERROR_ARGUMENT;
+extractpdf_export_page_range(document, 0, 0, &out) == EXTRACTPDF_ERROR_ARGUMENT;
+extractpdf_export_page_range(document, 2, 2, &out) == EXTRACTPDF_ERROR_ARGUMENT;
+extractpdf_export_page_range(document, INT_MAX, 2, &out) == EXTRACTPDF_ERROR_ARGUMENT;
+```
+
+When `SIZE_MAX > INT_MAX`, also require:
+
+```c
+extractpdf_export_page_range(
+    document, 0, (size_t)INT_MAX + 1u, &out) == EXTRACTPDF_ERROR_ARGUMENT;
+```
+
+Non-PDF proof:
+
+```c
+extractpdf_open(COMPOSITION_NON_PDF, NULL, &text_document) == EXTRACTPDF_OK;
+extractpdf_export_page_range(text_document, 0, 1, &out) == EXTRACTPDF_ERROR_UNSUPPORTED;
+out == NULL;
+```
+
+- [ ] **Step 2: Wire only the new range test into CTest**
+
+Append before the Windows copy loop:
+
+```cmake
+add_executable(extractpdf_test_pdf_range test_pdf_range.c)
+target_link_libraries(extractpdf_test_pdf_range PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_range PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  COMPOSITION_NON_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-non-pdf.txt"
+  RANGE_OUTPUT_PDF="${CMAKE_CURRENT_BINARY_DIR}/composition-range-output.pdf")
+add_test(NAME extractpdf.pdf_range COMMAND extractpdf_test_pdf_range)
+set_tests_properties(extractpdf.pdf_range PROPERTIES TIMEOUT 30)
+```
+
+Add `extractpdf_test_pdf_range` to the existing Windows shared-library copy loop. Do not modify the public header, root CMake, `src/internal.h`, `src/pdf_export.c`, or any other production file in RED.
+
+- [ ] **Step 3: Verify the stacked feature diff before opening the PR**
+
+Compare the branch against `d7d3e2a3c0ead330d0f8c97dd2bab7cd695f0012`. At the RED boundary the only non-doc feature files must be `tests/test_pdf_range.c` and `tests/CMakeLists.txt`.
+
+- [ ] **Step 4: Open a draft stacked PR**
+
+Base: `feat/pdf-export-pages`  
+Head: `feat/pdf-export-range`
+
+The PR body must state that the current head is intentionally RED-only and that production code is forbidden until the missing range API is observed in CI.
+
+- [ ] **Step 5: Verify the RED workflow**
+
+Expected Linux result:
+
+```text
+pinned dependencies/configure                 PASS
+libextractpdf + all existing test executables PASS
+extractpdf_test_pdf_range                     FAIL compile
+```
+
+The failure must be caused by the absent `extractpdf_export_page_range` declaration/function. Any failure in #20 code/tests, fixture parsing, CMake syntax, or unrelated targets is not an acceptable RED.
+
+---
+
+### Task 2: Thin mapping GREEN
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Create: `src/pdf_range.c`
+- Modify: `CMakeLists.txt`
+- Test: `tests/test_pdf_range.c`
+
+**Interfaces:**
+- Consumes:
+
+```c
+extractpdf_status extractpdf_export_pages(
+    extractpdf_document *document,
+    const int *page_indices,
+    size_t page_count,
+    extractpdf_output **out_output);
+```
+
+- Produces:
+
+```c
+extractpdf_status extractpdf_export_page_range(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_output **out_output);
+```
+
+- [ ] **Step 1: Add only the approved public declaration**
+
+Place the new declaration next to `extractpdf_export_pages(...)` in `include/extractpdf/extractpdf.h`.
+
+- [ ] **Step 2: Implement `src/pdf_range.c` without MuPDF PDF APIs**
+
+Exact implementation shape:
+
+```c
+#include "internal.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extractpdf_status extractpdf_export_page_range(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_output **out_output)
+{
+    int *indices;
+    extractpdf_status status;
+    size_t i;
+    size_t offset;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (document == NULL || first_page < 0 || page_count == 0 ||
+        page_count > (size_t)INT_MAX ||
+        page_count > SIZE_MAX / sizeof(*indices))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    offset = page_count - 1;
+    if ((size_t)first_page > (size_t)INT_MAX - offset)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    indices = (int *)malloc(page_count * sizeof(*indices));
+    if (indices == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    for (i = 0; i < page_count; ++i)
+        indices[i] = first_page + (int)i;
+
+    status = extractpdf_export_pages(document, indices, page_count, out_output);
+    free(indices);
+    return status;
+}
+```
+
+Do not add `<mupdf/pdf.h>` or any PDF/MuPDF composition call.
+
+- [ ] **Step 3: Register only `src/pdf_range.c` in root CMake**
+
+Add it alongside `src/pdf_export.c` in the existing `add_library(extractpdf ...)` source list. No other build-system change is needed.
+
+- [ ] **Step 4: Verify exact-head Linux GREEN**
+
+Require on the new branch head:
+
+```text
+strict static build                  PASS
+all normal CTests                    PASS
+extractpdf.pdf_export                PASS
+extractpdf.pdf_range                 PASS
+ASan/UBSan build                     PASS
+all sanitizer CTests                 PASS
+```
+
+The range test must prove `(1,2) -> PAGE-B/PAGE-C`, `(2,1)`, `(0,3)`, byte equality against equivalent explicit-index exports, overflow validation, out-of-range delegation, output reset, and non-PDF unsupported behavior.
+
+- [ ] **Step 5: Scope review**
+
+Compare against stacked base `d7d3e2a3c0ead330d0f8c97dd2bab7cd695f0012`. Production feature delta must be limited to:
+
+```text
+include/extractpdf/extractpdf.h
+src/pdf_range.c
+CMakeLists.txt
+```
+
+`src/pdf_export.c`, `src/internal.h`, and all previous feature implementations must be byte-identical to the stacked base.
+
+- [ ] **Step 6: Keep the PR draft and update #21 / #2**
+
+Record RED and GREEN exact-head workflow evidence. Do not merge #20 or the range PR without a separate explicit integration decision.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-pdf-export-range-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-pdf-export-range-design.md
@@ -1,0 +1,393 @@
+# ExtractPDF Contiguous PDF Page Range Export Design
+
+Date: 2026-08-28  
+Status: approved design  
+Tracks: #21, umbrella #2  
+Stacked base: #19 / PR #20 head `d7d3e2a3c0ead330d0f8c97dd2bab7cd695f0012`  
+Branch: `feat/pdf-export-range`
+
+## Goal
+
+Add a thin public helper for exporting one forward contiguous page range to one immutable PDF output while keeping `extractpdf_export_pages(...)` as the only composition engine.
+
+This slice supplies the public range primitive needed for page-range split workflows without introducing output arrays, filenames, a second graft path, or new output ownership rules.
+
+## Architectural decision
+
+V1 exposes one **single-output** range helper:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_export_page_range(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_output **out_output);
+```
+
+The helper converts a contiguous range into the same explicit zero-based index sequence already consumed by:
+
+```c
+extractpdf_export_pages(document, indices, page_count, out_output);
+```
+
+It must not call MuPDF PDF composition APIs directly.
+
+Conceptually:
+
+```text
+extractpdf_export_page_range(document, 1, 2, &out)
+        |
+        v
+validate mapping-safe arguments
+        |
+        v
+indices = [1, 2]
+        |
+        v
+extractpdf_export_pages(document, indices, 2, &out)
+        |
+        v
+existing PDF graft / serialization / immutable output engine
+```
+
+## Why `first_page + page_count`
+
+Three public shapes were considered:
+
+1. `first_page + page_count`;
+2. `[start_page, end_page_exclusive)`;
+3. a versioned `extractpdf_page_range` struct.
+
+V1 chooses `first_page + page_count` because it maps directly to split semantics:
+
+```text
+single page      (3, 1)
+three pages      (3, 3) -> [3, 4, 5]
+whole document   (0, document_page_count)
+```
+
+There is no inclusive/exclusive endpoint convention for callers to remember. A struct would add ABI surface without any range options that need future extension.
+
+## Public semantics
+
+`first_page` is zero-based, matching `extractpdf_load_page` and `extractpdf_export_pages`.
+
+`page_count` is the number of consecutive pages to export.
+
+The range is always **forward and contiguous**:
+
+```text
+(first_page = 2, page_count = 3)
+=> [2, 3, 4]
+```
+
+V1 does not express:
+
+- descending ranges;
+- stepped ranges;
+- disjoint ranges;
+- duplicated pages inside a range.
+
+Those cases already belong to the more general `extractpdf_export_pages(...)` index-list primitive.
+
+## Split model
+
+V1 deliberately does not return an array/list of `extractpdf_output` objects.
+
+Per-page split is expressed by repeated single-page calls:
+
+```c
+for (int page = 0; page < count; ++page)
+    extractpdf_export_page_range(document, page, 1, &output);
+```
+
+Page-range split is the same primitive with a larger `page_count`.
+
+This keeps:
+
+- output ownership identical to #19 / PR #20;
+- partial-success policy outside the core ABI;
+- filename/output naming policy with the caller;
+- one output per call;
+- error reporting one operation at a time.
+
+No `extractpdf_output_list`, output array, batch callback, or partial-result collection is introduced.
+
+## Validation responsibilities
+
+The range layer validates only what is required to map its public arguments safely into an `int[]` index sequence.
+
+When `out_output != NULL`, the helper sets `*out_output = NULL` before further validation.
+
+It returns `EXTRACTPDF_ERROR_ARGUMENT` for syntactically or arithmetically invalid requests:
+
+- `out_output == NULL`;
+- `document == NULL`;
+- `first_page < 0`;
+- `page_count == 0`;
+- `page_count > INT_MAX`;
+- `page_count > SIZE_MAX / sizeof(int)`;
+- `first_page + page_count - 1` cannot be represented as an `int`.
+
+The implementation must not compute `first_page + page_count - 1` before proving it cannot overflow. With `page_count <= INT_MAX`, the safe check is equivalent to:
+
+```c
+size_t offset = page_count - 1;
+if ((size_t)first_page > (size_t)INT_MAX - offset)
+    return EXTRACTPDF_ERROR_ARGUMENT;
+```
+
+Only after those checks may it allocate/fill the index array.
+
+## Document-dependent page bounds
+
+The helper does **not** create a second source-page-count validation path.
+
+After safe expansion, it delegates the index list to `extractpdf_export_pages(...)`, which already validates every requested index against the source PDF page count before grafting any page.
+
+Therefore a PDF request such as:
+
+```text
+source has 3 pages
+first_page = 2
+page_count = 2
+indices = [2, 3]
+```
+
+is rejected by the existing engine with `EXTRACTPDF_ERROR_ARGUMENT` and no partial output.
+
+This preserves one authoritative PDF page-boundary contract.
+
+## Non-PDF precedence
+
+The helper performs its format-independent argument/arithmetic checks first.
+
+For an otherwise mapping-valid request on a successfully opened non-PDF document, delegation reaches `extractpdf_export_pages(...)`, which returns `EXTRACTPDF_ERROR_UNSUPPORTED`.
+
+Document-dependent page-range validity is intentionally not defined for non-PDF composition because the composition operation itself is unsupported. This matches the existing engine's PDF-specific boundary rather than adding a competing generic range-count check.
+
+## Allocation and ownership
+
+The helper allocates only one temporary `int` array:
+
+```text
+int indices[page_count]   // dynamic allocation
+```
+
+The array contains:
+
+```c
+indices[i] = first_page + (int)i;
+```
+
+After calling `extractpdf_export_pages(...)`, the helper frees the temporary array on both success and failure.
+
+The range helper never owns or retains:
+
+- `extractpdf_document`;
+- `extractpdf_output` after returning it;
+- MuPDF context/document/output/buffer objects.
+
+The returned `extractpdf_output` has exactly the ownership/lifetime contract already defined by #19 / PR #20: immutable ExtractPDF-owned PDF bytes, independent of the source document after the export call succeeds.
+
+`EXTRACTPDF_ERROR_NOMEM` is returned if the temporary index-array allocation fails.
+
+## One composition engine rule
+
+The implementation for this slice must not include `<mupdf/pdf.h>` and must not call any MuPDF composition primitive.
+
+In particular, the range helper must not call:
+
+```text
+pdf_specifics
+pdf_create_document
+pdf_new_graft_map
+pdf_graft_page
+pdf_graft_mapped_page
+pdf_write_document
+pdf_save_document
+fz_new_output_with_buffer
+```
+
+All PDF-specific behavior remains in the existing `extractpdf_export_pages(...)` implementation.
+
+The recommended responsibility split is:
+
+```text
+src/pdf_range.c
+    range argument validation
+    overflow-safe contiguous index expansion
+    delegate to extractpdf_export_pages
+    free temporary indices
+
+src/pdf_export.c
+    unchanged composition engine from #19 / PR #20
+```
+
+No existing Page/Render/Text/Search/Image/Links implementation changes are allowed.
+
+## Deterministic TDD fixture
+
+Reuse `tests/fixtures/composition-three-page.pdf` from #19 / PR #20:
+
+```text
+page 0: PAGE-A, 200 x 200 pt
+page 1: PAGE-B, 240 x 180 pt
+page 2: PAGE-C, 300 x 150 pt
+```
+
+No new PDF fixture is needed.
+
+## Primary range proof
+
+The main case is:
+
+```text
+extractpdf_export_page_range(document, 1, 2, &range_output)
+```
+
+Expected reopened result:
+
+```text
+page_count = 2
+page 0: PAGE-B, 240 x 180 pt
+page 1: PAGE-C, 300 x 150 pt
+```
+
+This proves start/count mapping and order.
+
+## Engine-equivalence proof
+
+The same test also calls:
+
+```c
+int indices[] = {1, 2};
+extractpdf_export_pages(document, indices, 2, &index_output);
+```
+
+Under the same pinned build, bytes returned by `range_output` and `index_output` must be byte-for-byte identical.
+
+This equality is valuable architecture evidence: the public range helper is only an index-mapping layer and reaches the exact existing deterministic serialization engine rather than a second implementation.
+
+The equality contract is test-local to the same pinned build, matching the existing #19 deterministic-output scope; it does not create a cross-version or cross-platform byte-identity promise.
+
+## Additional success cases
+
+The deterministic test covers:
+
+```text
+(2, 1) -> [PAGE-C]
+(0, 3) -> [PAGE-A, PAGE-B, PAGE-C]
+```
+
+The single-page case proves per-page split semantics. The whole-range case proves that a contiguous range can represent the complete document without special casing.
+
+At least the primary `(1, 2)` result is reopened through the existing filename-based `extractpdf_open` test path to verify page count, searchable text, and geometry. Additional cases may use byte equality against equivalent `extractpdf_export_pages` calls to avoid redundant temporary-file machinery.
+
+## Failure cases
+
+Required contract tests include:
+
+1. `document == NULL` -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset;
+2. `out_output == NULL` -> `EXTRACTPDF_ERROR_ARGUMENT`;
+3. `first_page < 0` -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset;
+4. `page_count == 0` -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset;
+5. `(2, 2)` against the 3-page PDF -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset;
+6. `first_page = INT_MAX, page_count = 2` -> arithmetic-overflow `EXTRACTPDF_ERROR_ARGUMENT` before allocation/delegation;
+7. mapping-valid range on `composition-non-pdf.txt` -> `EXTRACTPDF_ERROR_UNSUPPORTED`, output reset;
+8. successful returned output remains governed by the existing `extractpdf_output_data` / `extractpdf_drop_output` lifecycle.
+
+A platform-specific test for `page_count > INT_MAX` is only added where `SIZE_MAX > INT_MAX`; the implementation guard is required on all platforms.
+
+## TDD boundary
+
+The first RED change is range-test-only:
+
+- create `tests/test_pdf_range.c`;
+- wire one new CTest target;
+- reuse the two existing composition fixtures;
+- do not add the public declaration or production helper yet.
+
+The expected RED is compile failure in only the new test because `extractpdf_export_page_range` is absent from the stacked #20 public header. Existing #20 production code and tests must continue to build.
+
+The minimal GREEN then adds only:
+
+- one public function declaration;
+- focused `src/pdf_range.c`;
+- root CMake source registration.
+
+`src/internal.h` and `src/pdf_export.c` should remain unchanged unless a concrete compiler/test failure proves a minimal shared change is required. No speculative refactor is permitted.
+
+## Stacked PR strategy
+
+This slice is stacked because #20 is still draft/unmerged.
+
+```text
+master
+  |
+  +-- feat/pdf-export-pages   PR #20
+          |
+          +-- feat/pdf-export-range   #21 / new stacked PR
+```
+
+The range PR base is `feat/pdf-export-pages`, not `master`, until #20 is integrated.
+
+Its true feature diff must therefore remain narrow: range spec/test/API/helper/CMake only.
+
+If #20 is later merged first, the range PR may be retargeted to `master` only after verifying that the stacked branch is a descendant or reconciling history without changing the range feature tree.
+
+## CI policy
+
+Development remains Linux-first:
+
+1. RED exact-head workflow must fail only at the missing range API boundary;
+2. GREEN exact-head Linux strict build + all normal CTests must pass;
+3. Linux ASan/UBSan build + CTests must pass;
+4. macOS/Windows may remain deferred to a later Phase 4 checkpoint because #20 already established the architecture-critical output/PDF-private-linkage checkpoint;
+5. an earlier range full-ci run is allowed if stack retargeting or Windows shared-library export behavior changes.
+
+No success claim may reuse a workflow from an earlier head.
+
+## Files and responsibilities
+
+Expected range-slice files:
+
+```text
+include/extractpdf/extractpdf.h
+    add one public range declaration
+
+src/pdf_range.c
+    validate mapping-safe range arguments
+    expand contiguous indices
+    delegate to extractpdf_export_pages
+    free temporary array
+
+CMakeLists.txt
+    register src/pdf_range.c
+
+tests/test_pdf_range.c
+    range semantics, engine equivalence, errors
+
+tests/CMakeLists.txt
+    register CTest / Windows DLL copy target
+```
+
+Existing composition fixtures are reused unchanged.
+
+## Non-goals
+
+This slice does not add:
+
+- multiple outputs in one call;
+- output arrays/lists;
+- automatic filename generation;
+- direct file saving;
+- descending or stepped range syntax;
+- string page-range parsing;
+- multi-document merge;
+- page deletion or source mutation;
+- a second MuPDF composition engine;
+- new output ownership semantics;
+- memory-open API;
+- Phase 5 link/annotation/form preservation;
+- new concurrency guarantees.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -134,6 +134,12 @@ EXTRACTPDF_API extractpdf_status extractpdf_export_pages(
     size_t page_count,
     extractpdf_output **out_output);
 
+EXTRACTPDF_API extractpdf_status extractpdf_export_page_range(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_output **out_output);
+
 EXTRACTPDF_API extractpdf_status extractpdf_output_data(
     const extractpdf_output *output,
     const unsigned char **out_data,

--- a/src/pdf_range.c
+++ b/src/pdf_range.c
@@ -1,0 +1,41 @@
+#include "internal.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extractpdf_status extractpdf_export_page_range(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_output **out_output)
+{
+    int *indices;
+    extractpdf_status status;
+    size_t i;
+    size_t offset;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (document == NULL || first_page < 0 || page_count == 0 ||
+        page_count > (size_t)INT_MAX ||
+        page_count > SIZE_MAX / sizeof(*indices))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    offset = page_count - 1;
+    if ((size_t)first_page > (size_t)INT_MAX - offset)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    indices = (int *)malloc(page_count * sizeof(*indices));
+    if (indices == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    for (i = 0; i < page_count; ++i)
+        indices[i] = first_page + (int)i;
+
+    status = extractpdf_export_pages(document, indices, page_count, out_output);
+    free(indices);
+    return status;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,15 @@ target_compile_definitions(extractpdf_test_pdf_export PRIVATE
 add_test(NAME extractpdf.pdf_export COMMAND extractpdf_test_pdf_export)
 set_tests_properties(extractpdf.pdf_export PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_pdf_range test_pdf_range.c)
+target_link_libraries(extractpdf_test_pdf_range PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_range PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  COMPOSITION_NON_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-non-pdf.txt"
+  RANGE_OUTPUT_PDF="${CMAKE_CURRENT_BINARY_DIR}/composition-range-output.pdf")
+add_test(NAME extractpdf.pdf_range COMMAND extractpdf_test_pdf_range)
+set_tests_properties(extractpdf.pdf_range PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -99,7 +108,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_images
       extractpdf_test_image_bitmap
       extractpdf_test_links
-      extractpdf_test_pdf_export)
+      extractpdf_test_pdf_export
+      extractpdf_test_pdf_range)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/test_pdf_range.c
+++ b/tests/test_pdf_range.c
@@ -1,0 +1,260 @@
+#include <extractpdf/extractpdf.h>
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static extractpdf_output *output_sentinel(void)
+{
+    return (extractpdf_output *)(uintptr_t)1;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static int expect_page(
+    extractpdf_document *document,
+    int index,
+    const char *needle,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+    int ok = 0;
+
+    if (extractpdf_load_page(document, index, &page) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_page_bounds(page, &bounds) != EXTRACTPDF_OK)
+        goto done;
+    if (bounds.x0 != 0.0f || bounds.y0 != 0.0f ||
+        bounds.x1 != width || bounds.y1 != height)
+        goto done;
+    if (extractpdf_extract_text(page, &text, &text_size) != EXTRACTPDF_OK)
+        goto done;
+    if (text == NULL || strstr(text, needle) == NULL)
+        goto done;
+
+    ok = 1;
+
+done:
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+    return ok;
+}
+
+static int expect_range_error(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    extractpdf_status expected)
+{
+    extractpdf_output *output = output_sentinel();
+    extractpdf_status status = extractpdf_export_page_range(
+        document, first_page, page_count, &output);
+
+    if (status != expected || output != NULL) {
+        if (output != NULL && output != output_sentinel())
+            extractpdf_drop_output(output);
+        return 0;
+    }
+    return 1;
+}
+
+static int range_equals_indices(
+    extractpdf_document *document,
+    int first_page,
+    size_t page_count,
+    const int *indices,
+    size_t index_count)
+{
+    extractpdf_output *range_output = NULL;
+    extractpdf_output *index_output = NULL;
+    const unsigned char *range_data = NULL;
+    const unsigned char *index_data = NULL;
+    size_t range_size = 0;
+    size_t index_size = 0;
+    int ok = 0;
+
+    if (extractpdf_export_page_range(
+            document, first_page, page_count, &range_output) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_export_pages(
+            document, indices, index_count, &index_output) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_output_data(range_output, &range_data, &range_size) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_output_data(index_output, &index_data, &index_size) != EXTRACTPDF_OK)
+        goto done;
+    if (range_data == NULL || index_data == NULL || range_size == 0 ||
+        range_size != index_size || memcmp(range_data, index_data, range_size) != 0)
+        goto done;
+
+    ok = 1;
+
+done:
+    extractpdf_drop_output(range_output);
+    extractpdf_drop_output(index_output);
+    return ok;
+}
+
+int main(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_document *reopened = NULL;
+    extractpdf_document *text_document = NULL;
+    extractpdf_output *range_output = NULL;
+    extractpdf_output *index_output = NULL;
+    extractpdf_output *probe = NULL;
+    const unsigned char *range_data = NULL;
+    const unsigned char *index_data = NULL;
+    size_t range_size = 0;
+    size_t index_size = 0;
+    int page_count = 0;
+    int primary_indices[] = {1, 2};
+    int single_index[] = {2};
+    int full_indices[] = {0, 1, 2};
+    int result = 1;
+
+    (void)remove(RANGE_OUTPUT_PDF);
+
+    if (extractpdf_open(COMPOSITION_PDF, NULL, &document) != EXTRACTPDF_OK) {
+        fprintf(stderr, "could not open composition source PDF\n");
+        goto cleanup;
+    }
+
+    if (!expect_range_error(NULL, 0, 1, EXTRACTPDF_ERROR_ARGUMENT)) {
+        fprintf(stderr, "NULL document range contract failed\n");
+        goto cleanup;
+    }
+
+    if (extractpdf_export_page_range(document, 0, 1, NULL) !=
+        EXTRACTPDF_ERROR_ARGUMENT) {
+        fprintf(stderr, "NULL out_output range contract failed\n");
+        goto cleanup;
+    }
+
+    if (!expect_range_error(document, -1, 1, EXTRACTPDF_ERROR_ARGUMENT) ||
+        !expect_range_error(document, 0, 0, EXTRACTPDF_ERROR_ARGUMENT) ||
+        !expect_range_error(document, 2, 2, EXTRACTPDF_ERROR_ARGUMENT) ||
+        !expect_range_error(document, INT_MAX, 2, EXTRACTPDF_ERROR_ARGUMENT)) {
+        fprintf(stderr, "range validation/reset contract failed\n");
+        goto cleanup;
+    }
+
+#if SIZE_MAX > INT_MAX
+    if (!expect_range_error(
+            document, 0, (size_t)INT_MAX + 1u, EXTRACTPDF_ERROR_ARGUMENT)) {
+        fprintf(stderr, "large page_count contract failed\n");
+        goto cleanup;
+    }
+#endif
+
+    if (extractpdf_export_page_range(document, 1, 2, &range_output) !=
+            EXTRACTPDF_OK ||
+        range_output == NULL) {
+        fprintf(stderr, "primary range export failed\n");
+        goto cleanup;
+    }
+
+    if (extractpdf_export_pages(document, primary_indices, 2, &index_output) !=
+            EXTRACTPDF_OK ||
+        index_output == NULL) {
+        fprintf(stderr, "primary explicit-index export failed\n");
+        goto cleanup;
+    }
+
+    if (extractpdf_output_data(range_output, &range_data, &range_size) !=
+            EXTRACTPDF_OK ||
+        extractpdf_output_data(index_output, &index_data, &index_size) !=
+            EXTRACTPDF_OK ||
+        range_data == NULL || index_data == NULL || range_size < 5 ||
+        range_size != index_size || memcmp(range_data, "%PDF-", 5) != 0 ||
+        memcmp(range_data, index_data, range_size) != 0) {
+        fprintf(stderr, "range/explicit engine-equivalence contract failed\n");
+        goto cleanup;
+    }
+
+    if (!range_equals_indices(document, 2, 1, single_index, 1)) {
+        fprintf(stderr, "single-page range equivalence failed\n");
+        goto cleanup;
+    }
+
+    if (!range_equals_indices(document, 0, 3, full_indices, 3)) {
+        fprintf(stderr, "whole-document range equivalence failed\n");
+        goto cleanup;
+    }
+
+    extractpdf_close(document);
+    document = NULL;
+
+    if (range_data[0] != '%' || range_data[1] != 'P' ||
+        !write_bytes(RANGE_OUTPUT_PDF, range_data, range_size)) {
+        fprintf(stderr, "range output did not survive source close\n");
+        goto cleanup;
+    }
+
+    if (extractpdf_open(RANGE_OUTPUT_PDF, NULL, &reopened) != EXTRACTPDF_OK) {
+        fprintf(stderr, "could not reopen range output\n");
+        goto cleanup;
+    }
+
+    if (extractpdf_page_count(reopened, &page_count) != EXTRACTPDF_OK ||
+        page_count != 2) {
+        fprintf(stderr, "range output page count mismatch\n");
+        goto cleanup;
+    }
+
+    if (!expect_page(reopened, 0, "PAGE-B", 240.0f, 180.0f) ||
+        !expect_page(reopened, 1, "PAGE-C", 300.0f, 150.0f)) {
+        fprintf(stderr, "range output order/text/geometry mismatch\n");
+        goto cleanup;
+    }
+
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    if (extractpdf_open(COMPOSITION_NON_PDF, NULL, &text_document) !=
+            EXTRACTPDF_OK) {
+        fprintf(stderr, "non-PDF fixture did not open through generic API\n");
+        goto cleanup;
+    }
+
+    probe = output_sentinel();
+    if (extractpdf_export_page_range(text_document, 0, 1, &probe) !=
+            EXTRACTPDF_ERROR_UNSUPPORTED ||
+        probe != NULL) {
+        fprintf(stderr, "non-PDF range unsupported contract failed\n");
+        if (probe != NULL && probe != output_sentinel())
+            extractpdf_drop_output(probe);
+        probe = NULL;
+        goto cleanup;
+    }
+
+    result = 0;
+
+cleanup:
+    extractpdf_close(document);
+    extractpdf_close(reopened);
+    extractpdf_close(text_document);
+    extractpdf_drop_output(range_output);
+    extractpdf_drop_output(index_output);
+    if (probe != NULL && probe != output_sentinel())
+        extractpdf_drop_output(probe);
+    (void)remove(RANGE_OUTPUT_PDF);
+    return result;
+}


### PR DESCRIPTION
Phase 4 PDF Composition stacked slice for #21 / #2. Depends on #19 / PR #20.

Design: `docs/superpowers/specs/2026-08-28-extractpdf-pdf-export-range-design.md`
Plan: `docs/superpowers/plans/2026-08-28-extractpdf-pdf-export-range.md`

## V1 contract

```c
extractpdf_status extractpdf_export_page_range(
    extractpdf_document *document,
    int first_page,
    size_t page_count,
    extractpdf_output **out_output);
```

- zero-based `first_page + page_count`
- forward contiguous ranges only
- `(page, 1)` is the per-page split primitive
- mapping/arithmetic validation happens before allocation
- document-dependent page bounds and non-PDF handling are delegated to `extractpdf_export_pages(...)`
- output ownership/lifetime is exactly the existing immutable `extractpdf_output` contract
- `src/pdf_range.c` contains no `<mupdf/pdf.h>` and no MuPDF PDF graft/write calls

## TDD evidence

### RED

Exact RED head: `7f3f6839b1257b1d9683ebca75dedf8c833e2f4d`.

Workflow #147 (`33124068795`) reached the intended boundary:

- pinned MuPDF install ✅
- static configure ✅
- #20 library including `src/pdf_export.c` ✅
- all existing test executables including `extractpdf_test_pdf_export` ✅ build/link
- only new `extractpdf_test_pdf_range` failed
- failure was the absent `extractpdf_export_page_range` declaration/symbol (implicit declaration + undefined reference)

No range production declaration/implementation existed at the RED head.

### GREEN

Exact GREEN head: `6bd7b01c01c3f2439a86932e476074b758639220`.

Workflow #150 (`33124170261`) completed successfully on this exact head:

- Linux strict static configure/build ✅
- all normal CTests including `extractpdf.pdf_export` and `extractpdf.pdf_range` ✅
- ASan/UBSan configure/build ✅
- all sanitizer CTests ✅

The range test proves:

- `(1,2) -> PAGE-B 240x180, PAGE-C 300x150`
- `(2,1)` single-page split semantics
- `(0,3)` whole-document contiguous range
- byte-for-byte equality with equivalent explicit-index `extractpdf_export_pages(...)` calls under the same pinned build
- negative/zero/out-of-range/overflow validation and output reset
- mapping-valid non-PDF input delegates to `EXTRACTPDF_ERROR_UNSUPPORTED`
- returned output remains valid after closing the source document

## Scope review

Relative to stacked base `d7d3e2a3c0ead330d0f8c97dd2bab7cd695f0012`, production changes are limited to:

- `include/extractpdf/extractpdf.h` — one range declaration
- `src/pdf_range.c` — 41-line mapping/delegation helper
- root `CMakeLists.txt` — source registration

`src/pdf_export.c`, `src/internal.h`, and all existing Page/Render/Text/Search/Image/Links implementation files are unchanged.

Cross-platform rerun is intentionally deferred: PR #20 already established the architecture-critical output/PDF-private-linkage checkpoint on Linux/macOS/Windows, while this slice adds no PDF-private linkage and no Windows-specific implementation path.

PR remains draft and unmerged. No merge of #20 or #22 without an explicit integration decision.