### PR TITLE
test: lock immutable delete-by-complement semantics

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,14 @@ target_compile_definitions(extractpdf_test_pdf_order PRIVATE
 add_test(NAME extractpdf.pdf_order COMMAND extractpdf_test_pdf_order)
 set_tests_properties(extractpdf.pdf_order PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_pdf_delete test_pdf_delete.c)
+target_link_libraries(extractpdf_test_pdf_delete PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_delete PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  DELETE_OUTPUT_PDF="${CMAKE_CURRENT_BINARY_DIR}/composition-delete-output.pdf")
+add_test(NAME extractpdf.pdf_delete COMMAND extractpdf_test_pdf_delete)
+set_tests_properties(extractpdf.pdf_delete PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -118,7 +126,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_links
       extractpdf_test_pdf_export
       extractpdf_test_pdf_range
-      extractpdf_test_pdf_order)
+      extractpdf_test_pdf_order
+      extractpdf_test_pdf_delete)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/test_pdf_delete.c
+++ b/tests/test_pdf_delete.c
@@ -1,0 +1,207 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static extractpdf_output *output_sentinel(void)
+{
+    return (extractpdf_output *)(uintptr_t)1;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static int expect_page(
+    extractpdf_document *document,
+    int index,
+    const char *needle,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+    int ok = 0;
+
+    if (extractpdf_load_page(document, index, &page) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_page_bounds(page, &bounds) != EXTRACTPDF_OK)
+        goto done;
+    if (bounds.x0 != 0.0f || bounds.y0 != 0.0f ||
+        bounds.x1 != width || bounds.y1 != height)
+        goto done;
+    if (extractpdf_extract_text(page, &text, &text_size) != EXTRACTPDF_OK)
+        goto done;
+    if (text == NULL || strstr(text, needle) == NULL)
+        goto done;
+
+    ok = 1;
+
+done:
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+    return ok;
+}
+
+static int verify_delete_complement(
+    extractpdf_document *source,
+    const int *retained_indices,
+    size_t retained_count,
+    const char *const *expected_text,
+    const float *expected_width,
+    const float *expected_height)
+{
+    extractpdf_output *first = NULL;
+    extractpdf_output *second = NULL;
+    extractpdf_document *reopened = NULL;
+    const unsigned char *first_data = NULL;
+    const unsigned char *second_data = NULL;
+    size_t first_size = 0;
+    size_t second_size = 0;
+    int reopened_count = 0;
+    size_t i;
+    int ok = 0;
+
+    (void)remove(DELETE_OUTPUT_PDF);
+
+    if (extractpdf_export_pages(source, retained_indices, retained_count, &first) !=
+            EXTRACTPDF_OK ||
+        first == NULL)
+        goto done;
+    if (extractpdf_export_pages(source, retained_indices, retained_count, &second) !=
+            EXTRACTPDF_OK ||
+        second == NULL)
+        goto done;
+
+    if (extractpdf_output_data(first, &first_data, &first_size) != EXTRACTPDF_OK ||
+        first_data == NULL || first_size < 5 ||
+        memcmp(first_data, "%PDF-", 5) != 0)
+        goto done;
+    if (extractpdf_output_data(second, &second_data, &second_size) != EXTRACTPDF_OK ||
+        second_data == NULL || second_size != first_size ||
+        memcmp(first_data, second_data, first_size) != 0)
+        goto done;
+
+    if (!write_bytes(DELETE_OUTPUT_PDF, first_data, first_size))
+        goto done;
+    if (extractpdf_open(DELETE_OUTPUT_PDF, NULL, &reopened) != EXTRACTPDF_OK)
+        goto done;
+    if (extractpdf_page_count(reopened, &reopened_count) != EXTRACTPDF_OK ||
+        reopened_count != (int)retained_count)
+        goto done;
+
+    for (i = 0; i < retained_count; ++i) {
+        if (!expect_page(
+                reopened,
+                (int)i,
+                expected_text[i],
+                expected_width[i],
+                expected_height[i]))
+            goto done;
+    }
+
+    ok = 1;
+
+done:
+    extractpdf_close(reopened);
+    extractpdf_drop_output(first);
+    extractpdf_drop_output(second);
+    (void)remove(DELETE_OUTPUT_PDF);
+    return ok;
+}
+
+int main(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_output *probe = NULL;
+    int page_count = 0;
+    int delete_middle_keep[] = {0, 2};
+    const char *delete_middle_text[] = {"PAGE-A", "PAGE-C"};
+    float delete_middle_width[] = {200.0f, 300.0f};
+    float delete_middle_height[] = {200.0f, 150.0f};
+    int delete_edges_keep[] = {1};
+    const char *delete_edges_text[] = {"PAGE-B"};
+    float delete_edges_width[] = {240.0f};
+    float delete_edges_height[] = {180.0f};
+    int dummy_index = 0;
+    int result = 1;
+
+    if (extractpdf_open(COMPOSITION_PDF, NULL, &source) != EXTRACTPDF_OK) {
+        fprintf(stderr, "could not open composition source PDF\n");
+        goto cleanup;
+    }
+
+    if (extractpdf_page_count(source, &page_count) != EXTRACTPDF_OK || page_count != 3 ||
+        !expect_page(source, 0, "PAGE-A", 200.0f, 200.0f) ||
+        !expect_page(source, 1, "PAGE-B", 240.0f, 180.0f) ||
+        !expect_page(source, 2, "PAGE-C", 300.0f, 150.0f)) {
+        fprintf(stderr, "source fixture contract failed\n");
+        goto cleanup;
+    }
+
+    /* delete {1} => retain complement {0,2} in original source order */
+    if (!verify_delete_complement(
+            source,
+            delete_middle_keep,
+            sizeof(delete_middle_keep) / sizeof(delete_middle_keep[0]),
+            delete_middle_text,
+            delete_middle_width,
+            delete_middle_height)) {
+        fprintf(stderr, "delete-middle complement contract failed\n");
+        goto cleanup;
+    }
+
+    /* delete {0,2} => retain complement {1} */
+    if (!verify_delete_complement(
+            source,
+            delete_edges_keep,
+            sizeof(delete_edges_keep) / sizeof(delete_edges_keep[0]),
+            delete_edges_text,
+            delete_edges_width,
+            delete_edges_height)) {
+        fprintf(stderr, "delete-edges complement contract failed\n");
+        goto cleanup;
+    }
+
+    /* delete-all would require an empty retained set; V1 intentionally rejects it. */
+    probe = output_sentinel();
+    if (extractpdf_export_pages(source, &dummy_index, 0, &probe) !=
+            EXTRACTPDF_ERROR_ARGUMENT ||
+        probe != NULL) {
+        fprintf(stderr, "delete-all unsupported contract failed\n");
+        if (probe != NULL && probe != output_sentinel())
+            extractpdf_drop_output(probe);
+        probe = NULL;
+        goto cleanup;
+    }
+
+    if (extractpdf_page_count(source, &page_count) != EXTRACTPDF_OK || page_count != 3 ||
+        !expect_page(source, 0, "PAGE-A", 200.0f, 200.0f) ||
+        !expect_page(source, 1, "PAGE-B", 240.0f, 180.0f) ||
+        !expect_page(source, 2, "PAGE-C", 300.0f, 150.0f)) {
+        fprintf(stderr, "source document changed after delete-by-complement exports\n");
+        goto cleanup;
+    }
+
+    result = 0;
+
+cleanup:
+    extractpdf_close(source);
+    if (probe != NULL && probe != output_sentinel())
+        extractpdf_drop_output(probe);
+    (void)remove(DELETE_OUTPUT_PDF);
+    return result;
+}


### PR DESCRIPTION
Phase 4 PDF Composition contract-closure slice for #25 / #2. Stacked on #23 / PR #24 and ultimately depends on #19 / PR #20.

This PR intentionally adds **no production code and no new API**. It defines delete as immutable export of the complement page selection through the existing `extractpdf_export_pages(...)` engine.

## Locked contract

```text
delete {1}   -> keep {0,2} -> [PAGE-A, PAGE-C]
delete {0,2} -> keep {1}   -> [PAGE-B]
delete all   -> unsupported in V1 because empty retained selection is EXTRACTPDF_ERROR_ARGUMENT
```

For both supported delete cases, `extractpdf.pdf_delete`:

- exports the retained complement twice and requires byte-for-byte identical PDF output under the same pinned build
- reopens the result through existing public APIs
- verifies exact page count, searchable text, and geometry
- verifies retained pages remain in original source order
- verifies the source remains the original `[PAGE-A, PAGE-B, PAGE-C]`

The delete-all case locks the existing zero-page export boundary: `extractpdf_export_pages(..., page_count=0, ...)` returns `EXTRACTPDF_ERROR_ARGUMENT` and resets the output slot rather than defining an empty-PDF special case.

## Verification evidence

Exact head: `18a6c0596b68c1ca7b116624a09e27dcf0ac4a7f`.

Workflow #152 (`33125835355`) completed successfully:

- Linux strict static configure/build ✅
- all normal CTests, including `extractpdf.pdf_export`, `extractpdf.pdf_range`, `extractpdf.pdf_order`, and new `extractpdf.pdf_delete` ✅
- ASan/UBSan configure/build ✅
- all sanitizer CTests ✅

This is intentionally a direct-GREEN contract-closure slice: the selected-page engine already provided the behavior, so no artificial RED was created and no production change was required.

## Scope

Relative to `test/pdf-order-contract @ 09927b63013061ab6ec67849744aab6a10910143`, the entire diff is tests-only:

- `tests/test_pdf_delete.c`
- `tests/CMakeLists.txt`

No public header, `src/`, MuPDF call, output ownership rule, mutation API, or composition path changed.

macOS/Windows are intentionally deferred because this slice adds no production or platform-specific code; the cumulative composition engine already has #20 full-ci #146 across Linux/macOS/Windows.

Keep draft and unmerged pending explicit integration decision.