### PR TITLE
feat: merge immutable PDF outputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(extractpdf
   src/links.c
   src/pdf_export.c
   src/pdf_output.c
-  src/pdf_range.c)
+  src/pdf_range.c
+  src/pdf_merge.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(extractpdf
   src/image_bitmap.c
   src/links.c
   src/pdf_export.c
+  src/pdf_output.c
   src/pdf_range.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)

--- a/docs/superpowers/plans/2026-08-28-extractpdf-pdf-merge-outputs.md
+++ b/docs/superpowers/plans/2026-08-28-extractpdf-pdf-merge-outputs.md
@@ -1,0 +1,1002 @@
+# ExtractPDF Immutable PDF Output Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `extractpdf_merge_outputs(...)` so immutable Phase 4 PDF outputs can be merged in exact caller order without crossing live document MuPDF-context ownership boundaries.
+
+**Architecture:** Merge reparses every immutable `extractpdf_output` inside one fresh temporary `fz_context`, uses one destination `pdf_document` and one source-local `pdf_graft_map` per input, then serializes the destination exactly once. The deterministic PDF writer currently embedded in `extractpdf_export_pages(...)` becomes one private serializer shared by export and merge; the existing export graft/validation semantics remain unchanged.
+
+**Tech Stack:** C11, MuPDF 1.28.2 PDF/Fitz APIs, CMake 3.20+, CTest, GitHub Actions, Linux ASan/UBSan, Windows DLL build, macOS static build.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-pdf-merge-outputs-design.md`
+
+## Global Constraints
+
+- Stack on #25 / PR #26 exact head `18a6c0596b68c1ca7b116624a09e27dcf0ac4a7f`; do not retarget during implementation unless the stack is explicitly integrated first.
+- MuPDF remains pinned to 1.28.2 through the existing all-OS vcpkg model; do not change `vcpkg.json`, overlay ports, or CI dependency versions.
+- Preserve the stable C ABI and expose no MuPDF types in `include/extractpdf/extractpdf.h`.
+- Keep every existing `extractpdf_document` owning its own `fz_context`; merge must not consume live document handles or pass MuPDF objects across contexts.
+- Public API is exactly:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_merge_outputs(
+    const extractpdf_output *const *inputs,
+    size_t input_count,
+    extractpdf_output **out_output);
+```
+
+- `input_count == 0`, `inputs == NULL`, or any `inputs[i] == NULL` returns `EXTRACTPDF_ERROR_ARGUMENT`; a non-NULL output slot is reset to `NULL` before further work.
+- One input is valid; duplicate input pointers are valid; exact input order defines whole-document append order.
+- Total merged page count must not exceed `INT_MAX`; use overflow-safe arithmetic before grafting the source that would exceed the limit.
+- Merge is strictly all-or-nothing: no partial output may be published on any failure.
+- Inputs remain immutable and alive only for the duration of the call; the successful result is independent of all inputs.
+- Do not expand the Phase 4 preservation boundary beyond `Contents`, `Resources`, page boxes, `Rotate`, and `UserUnit`; do not add links/annotations/widgets, metadata, outlines, forms, signatures, encryption, JavaScript, page labels, named destinations, or other document-root state.
+- The deterministic writer policy is shared by selected-page export and merge and remains `pdf_default_write_options` with `reproducible = 1` and `dont_regenerate_id = 1`.
+- No merge session, live-document merge array, cross-document page-selection descriptor, output list, filename policy, save-to-path API, or unrelated Page/Render/Text/Search/Image/Links refactor belongs in this slice.
+- Development remains Linux-first. Because this slice adds public ABI, memory-stream parsing, a new temporary context, and a shared writer refactor, the final exact head must pass Linux normal tests + ASan/UBSan and then a `full-ci` run on Linux/macOS/Windows.
+- Do not merge PRs without explicit user authorization.
+
+---
+
+## File Structure
+
+The implementation is intentionally split by responsibility:
+
+```text
+include/extractpdf/extractpdf.h
+    public merge declaration only
+
+src/pdf_internal.h
+    PDF-private shared helper declaration; includes MuPDF PDF types privately
+
+src/pdf_output.c
+    deterministic pdf_document -> immutable extractpdf_output serializer only
+
+src/pdf_export.c
+    existing single-source selected-page validation/grafting;
+    serialization block replaced by the shared private serializer call
+
+src/pdf_merge.c
+    merge argument validation, temporary context, memory-source parsing,
+    one graft map per source, page-total guard, atomic cleanup
+
+CMakeLists.txt
+    register pdf_output.c and pdf_merge.c
+
+tests/test_pdf_merge.c
+    deterministic public merge contract
+
+tests/CMakeLists.txt
+    register extractpdf.pdf_merge and Windows DLL copy target
+```
+
+Do not move `extractpdf_output_data(...)` or `extractpdf_drop_output(...)`; they remain where they are unless a concrete compile failure proves a minimal move is necessary.
+
+---
+
+### Task 1: Add the strict merge-contract RED
+
+**Files:**
+- Create: `tests/test_pdf_merge.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: existing `extractpdf_open`, `extractpdf_export_pages`, `extractpdf_output_data`, `extractpdf_drop_output`, `extractpdf_page_count`, `extractpdf_load_page`, `extractpdf_page_bounds`, `extractpdf_extract_text`.
+- Produces: one deterministic CTest named `extractpdf.pdf_merge` that fully specifies the new public merge ABI before production code exists.
+
+- [ ] **Step 1: Create `tests/test_pdf_merge.c` with the public contract**
+
+Use the existing fixtures only. The test must create immutable inputs through the public export API, close the original documents before merge, and validate repeated determinism, single-input semantics, duplicate whole-document semantics, lifetime independence, and argument/reset behavior.
+
+Use this structure:
+
+```c
+#include <extractpdf/extractpdf.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static extractpdf_document *open_output(
+    const extractpdf_output *output,
+    const char *path)
+{
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_output_data(output, &data, &size) == EXTRACTPDF_OK);
+    CHECK(data != NULL);
+    CHECK(size >= 5);
+    CHECK(memcmp(data, "%PDF-", 5) == 0);
+    CHECK(write_bytes(path, data, size));
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    return document;
+}
+
+static void expect_page(
+    extractpdf_document *document,
+    int page_index,
+    const char *needle,
+    int check_geometry,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    if (check_geometry) {
+        CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+        CHECK(bounds.x0 == 0.0f);
+        CHECK(bounds.y0 == 0.0f);
+        CHECK(bounds.x1 == width);
+        CHECK(bounds.y1 == height);
+    }
+    CHECK(extractpdf_extract_text(page, &text, &text_size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(strstr(text, needle) != NULL);
+
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+}
+
+static void expect_same_bytes(
+    const extractpdf_output *left,
+    const extractpdf_output *right)
+{
+    const unsigned char *left_data = NULL;
+    const unsigned char *right_data = NULL;
+    size_t left_size = 0;
+    size_t right_size = 0;
+
+    CHECK(extractpdf_output_data(left, &left_data, &left_size) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(right, &right_data, &right_size) == EXTRACTPDF_OK);
+    CHECK(left_size == right_size);
+    CHECK(memcmp(left_data, right_data, left_size) == 0);
+}
+
+int main(void)
+{
+    int sentinel = 0;
+    extractpdf_document *composition = NULL;
+    extractpdf_document *text = NULL;
+    extractpdf_document *reopened = NULL;
+    extractpdf_output *output_a = NULL;
+    extractpdf_output *output_b = NULL;
+    extractpdf_output *merged_ab_1 = NULL;
+    extractpdf_output *merged_ab_2 = NULL;
+    extractpdf_output *merged_single = NULL;
+    extractpdf_output *merged_duplicate = NULL;
+    extractpdf_output *reset_output = (extractpdf_output *)&sentinel;
+    int composition_indices[] = {2, 0};
+    int text_indices[] = {0};
+    const extractpdf_output *empty_inputs[] = {NULL};
+    int page_count = 0;
+
+    (void)remove(MERGE_OUTPUT_PDF);
+
+    CHECK(extractpdf_merge_outputs(NULL, 1, &reset_output) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(reset_output == NULL);
+
+    reset_output = (extractpdf_output *)&sentinel;
+    CHECK(extractpdf_merge_outputs(empty_inputs, 0, &reset_output) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(reset_output == NULL);
+
+    CHECK(extractpdf_merge_outputs(empty_inputs, 1, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_open(COMPOSITION_PDF, NULL, &composition) == EXTRACTPDF_OK);
+    CHECK(extractpdf_open(TEXT_PDF, NULL, &text) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_export_pages(
+        composition,
+        composition_indices,
+        sizeof(composition_indices) / sizeof(composition_indices[0]),
+        &output_a) == EXTRACTPDF_OK);
+    CHECK(output_a != NULL);
+
+    CHECK(extractpdf_export_pages(
+        text,
+        text_indices,
+        sizeof(text_indices) / sizeof(text_indices[0]),
+        &output_b) == EXTRACTPDF_OK);
+    CHECK(output_b != NULL);
+
+    extractpdf_close(composition);
+    extractpdf_close(text);
+    composition = NULL;
+    text = NULL;
+
+    {
+        const extractpdf_output *invalid_inputs[] = {output_a, NULL};
+        reset_output = (extractpdf_output *)&sentinel;
+        CHECK(extractpdf_merge_outputs(
+            invalid_inputs,
+            sizeof(invalid_inputs) / sizeof(invalid_inputs[0]),
+            &reset_output) == EXTRACTPDF_ERROR_ARGUMENT);
+        CHECK(reset_output == NULL);
+    }
+
+    {
+        const extractpdf_output *inputs[] = {output_a, output_b};
+        CHECK(extractpdf_merge_outputs(inputs, 2, &merged_ab_1) == EXTRACTPDF_OK);
+        CHECK(extractpdf_merge_outputs(inputs, 2, &merged_ab_2) == EXTRACTPDF_OK);
+        CHECK(merged_ab_1 != NULL);
+        CHECK(merged_ab_2 != NULL);
+        expect_same_bytes(merged_ab_1, merged_ab_2);
+    }
+
+    {
+        const extractpdf_output *inputs[] = {output_a};
+        CHECK(extractpdf_merge_outputs(inputs, 1, &merged_single) == EXTRACTPDF_OK);
+        CHECK(merged_single != NULL);
+    }
+
+    {
+        const extractpdf_output *inputs[] = {output_b, output_a, output_b};
+        CHECK(extractpdf_merge_outputs(inputs, 3, &merged_duplicate) == EXTRACTPDF_OK);
+        CHECK(merged_duplicate != NULL);
+    }
+
+    /* Successful merge outputs must be independent of every input. */
+    extractpdf_drop_output(output_a);
+    extractpdf_drop_output(output_b);
+    output_a = NULL;
+    output_b = NULL;
+
+    reopened = open_output(merged_ab_1, MERGE_OUTPUT_PDF);
+    CHECK(extractpdf_page_count(reopened, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 3);
+    expect_page(reopened, 0, "PAGE-C", 1, 300.0f, 150.0f);
+    expect_page(reopened, 1, "PAGE-A", 1, 200.0f, 200.0f);
+    expect_page(reopened, 2, "Hello Caf", 0, 0.0f, 0.0f);
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    reopened = open_output(merged_single, MERGE_OUTPUT_PDF);
+    CHECK(extractpdf_page_count(reopened, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 2);
+    expect_page(reopened, 0, "PAGE-C", 1, 300.0f, 150.0f);
+    expect_page(reopened, 1, "PAGE-A", 1, 200.0f, 200.0f);
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    reopened = open_output(merged_duplicate, MERGE_OUTPUT_PDF);
+    CHECK(extractpdf_page_count(reopened, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 4);
+    expect_page(reopened, 0, "Hello Caf", 0, 0.0f, 0.0f);
+    expect_page(reopened, 1, "PAGE-C", 1, 300.0f, 150.0f);
+    expect_page(reopened, 2, "PAGE-A", 1, 200.0f, 200.0f);
+    expect_page(reopened, 3, "Hello Caf", 0, 0.0f, 0.0f);
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    extractpdf_drop_output(merged_ab_1);
+    extractpdf_drop_output(merged_ab_2);
+    extractpdf_drop_output(merged_single);
+    extractpdf_drop_output(merged_duplicate);
+    (void)remove(MERGE_OUTPUT_PDF);
+    return EXIT_SUCCESS;
+}
+```
+
+Use `"Hello Caf"` rather than embedding a source-code accent in this new test; the existing UTF-8 text test already proves the complete `Hello Café` byte sequence, while this merge test only needs a stable distinguishing substring from the second source.
+
+- [ ] **Step 2: Register the RED target in `tests/CMakeLists.txt`**
+
+Add immediately after `extractpdf.pdf_delete`:
+
+```cmake
+add_executable(extractpdf_test_pdf_merge test_pdf_merge.c)
+target_link_libraries(extractpdf_test_pdf_merge PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_merge PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/text-one-page.pdf"
+  MERGE_OUTPUT_PDF="${CMAKE_CURRENT_BINARY_DIR}/composition-merge-output.pdf")
+add_test(NAME extractpdf.pdf_merge COMMAND extractpdf_test_pdf_merge)
+set_tests_properties(extractpdf.pdf_merge PROPERTIES TIMEOUT 30)
+```
+
+Also append `extractpdf_test_pdf_merge` to the existing `if(WIN32 AND BUILD_SHARED_LIBS)` test-target list so the DLL is copied beside the new executable.
+
+- [ ] **Step 3: Commit the test-only RED**
+
+```bash
+git add tests/test_pdf_merge.c tests/CMakeLists.txt
+git commit -m "test: define immutable PDF merge contract"
+```
+
+Do not add the public declaration or production implementation in this commit.
+
+- [ ] **Step 4: Open a draft stacked PR to trigger exact-head CI**
+
+Create the PR with:
+
+```text
+base: test/pdf-delete-contract
+head: feat/pdf-merge-outputs
+draft: true
+tracks: #27 / #2
+```
+
+The PR body must state that this exact head is the intentional RED and that no production merge API exists yet. Record the PR number returned by GitHub; all later plan steps refer to that same draft Merge PR.
+
+- [ ] **Step 5: Verify the RED is the intended missing-API boundary**
+
+Use the PR-triggered workflow on the exact RED SHA. The expected Linux failure is only the new `extractpdf_test_pdf_merge` target because `extractpdf_merge_outputs` is not declared/defined. Existing library sources and pre-existing test targets must continue to build.
+
+Expected diagnostic shape is the same class as the earlier range RED:
+
+```text
+implicit declaration of function 'extractpdf_merge_outputs'
+undefined reference to 'extractpdf_merge_outputs'
+```
+
+If any pre-existing target fails, or the new target fails for fixture/test-code mistakes, fix the RED test before touching production code and re-run until the failure boundary is exact.
+
+---
+
+### Task 2: Extract the shared deterministic serializer without changing export behavior
+
+**Files:**
+- Create: `src/pdf_internal.h`
+- Create: `src/pdf_output.c`
+- Modify: `src/pdf_export.c`
+- Modify: `CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: private `extractpdf_output` layout from `src/internal.h`; MuPDF `fz_context` and `pdf_document` types.
+- Produces: private helper
+
+```c
+extractpdf_status extractpdf_serialize_pdf(
+    fz_context *ctx,
+    pdf_document *document,
+    extractpdf_output **out_output);
+```
+
+used by both export and the later merge task.
+
+This is a behavior-preserving refactor. The existing `extractpdf.pdf_export` repeated-byte test is the characterization gate. The new merge target remains intentionally RED after this task because the public merge symbol still does not exist.
+
+- [ ] **Step 1: Add a focused PDF-private header**
+
+Create `src/pdf_internal.h`:
+
+```c
+#ifndef EXTRACTPDF_PDF_INTERNAL_H
+#define EXTRACTPDF_PDF_INTERNAL_H
+
+#include "internal.h"
+
+#include <mupdf/pdf.h>
+
+extractpdf_status extractpdf_serialize_pdf(
+    fz_context *ctx,
+    pdf_document *document,
+    extractpdf_output **out_output);
+
+#endif
+```
+
+Do not put MuPDF PDF types in `include/extractpdf/extractpdf.h` or broaden `src/internal.h` with `<mupdf/pdf.h>` for unrelated source files.
+
+- [ ] **Step 2: Move only deterministic serialization into `src/pdf_output.c`**
+
+Create `src/pdf_output.c`:
+
+```c
+#include "pdf_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void extractpdf_drop_pdf_serialization_state(
+    fz_context *ctx,
+    fz_buffer *buffer,
+    fz_output *memory_output)
+{
+    if (memory_output != NULL)
+        fz_drop_output(ctx, memory_output);
+    if (buffer != NULL)
+        fz_drop_buffer(ctx, buffer);
+}
+
+extractpdf_status extractpdf_serialize_pdf(
+    fz_context *ctx,
+    pdf_document *document,
+    extractpdf_output **out_output)
+{
+    pdf_write_options options = pdf_default_write_options;
+    fz_buffer *buffer = NULL;
+    fz_output *memory_output = NULL;
+    extractpdf_output *result = NULL;
+    unsigned char *buffer_data = NULL;
+    size_t buffer_size = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (ctx == NULL || document == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    options.reproducible = 1;
+    options.dont_regenerate_id = 1;
+
+    fz_var(buffer);
+    fz_var(memory_output);
+    fz_var(buffer_data);
+    fz_var(buffer_size);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        buffer = fz_new_buffer(ctx, 0);
+        memory_output = fz_new_output_with_buffer(ctx, buffer);
+        pdf_write_document(ctx, document, memory_output, &options);
+        fz_close_output(ctx, memory_output);
+        buffer_size = fz_buffer_storage(ctx, buffer, &buffer_data);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        extractpdf_status status = extractpdf_status_from_mupdf(caught_code);
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        return status;
+    }
+
+    if (buffer_data == NULL || buffer_size == 0) {
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+
+    result = (extractpdf_output *)calloc(1, sizeof(*result));
+    if (result == NULL) {
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    result->data = (unsigned char *)malloc(buffer_size);
+    if (result->data == NULL) {
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        free(result);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    memcpy(result->data, buffer_data, buffer_size);
+    result->size = buffer_size;
+    extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+
+    *out_output = result;
+    return EXTRACTPDF_OK;
+}
+```
+
+The helper owns only buffer/output serialization state plus the newly allocated output snapshot. It must never drop the supplied `pdf_document` or context.
+
+- [ ] **Step 3: Refactor `src/pdf_export.c` to call the helper**
+
+Change its include to:
+
+```c
+#include "pdf_internal.h"
+
+#include <limits.h>
+```
+
+Remove only the old serialization locals and allocation/copy block:
+
+```text
+fz_buffer *buffer
+fz_output *memory_output
+extractpdf_output *result
+buffer_data
+buffer_size
+pdf_write_options options
+calloc/malloc/memcpy serialization code
+```
+
+Reduce the export cleanup helper to destination/graft ownership only:
+
+```c
+static void extractpdf_drop_pdf_export_state(
+    fz_context *ctx,
+    pdf_document *destination,
+    pdf_graft_map *graft)
+{
+    if (graft != NULL)
+        pdf_drop_graft_map(ctx, graft);
+    if (destination != NULL)
+        pdf_drop_document(ctx, destination);
+}
+```
+
+Keep the existing argument/PDF/page-count/all-indices-prevalidated logic exactly as-is. Keep the existing destination/graft loop exactly as-is. After grafting succeeds, replace the old writer block with:
+
+```c
+{
+    extractpdf_status status = extractpdf_serialize_pdf(
+        ctx, destination, out_output);
+    extractpdf_drop_pdf_export_state(ctx, destination, graft);
+    return status;
+}
+```
+
+On graft failure, continue mapping the caught MuPDF error and clean up destination/graft before returning. Do not alter caller-order, duplicate-index, unsupported-format, or bounds semantics.
+
+- [ ] **Step 4: Register `src/pdf_output.c` in the library**
+
+In root `CMakeLists.txt`, add `src/pdf_output.c` beside the other PDF composition files. Do not add `src/pdf_merge.c` yet.
+
+The tail should conceptually be:
+
+```cmake
+  src/links.c
+  src/pdf_export.c
+  src/pdf_output.c
+  src/pdf_range.c)
+```
+
+- [ ] **Step 5: Build and run the export characterization gate**
+
+With the same dependency configuration as CI, build only the existing export target so the intentionally missing merge symbol does not block this refactor check:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build --target extractpdf_test_pdf_export --parallel 2
+ctest --test-dir build -R '^extractpdf\.pdf_export$' --output-on-failure
+```
+
+Expected: `extractpdf.pdf_export` passes, including its repeated-export byte identity and source-independent output lifetime checks.
+
+Also build the merge target once and confirm it is still the same intentional RED because the merge API remains absent:
+
+```bash
+cmake --build build --target extractpdf_test_pdf_merge --parallel 2
+```
+
+Expected: failure only at the missing `extractpdf_merge_outputs` declaration/symbol boundary.
+
+- [ ] **Step 6: Commit the serializer refactor**
+
+```bash
+git add src/pdf_internal.h src/pdf_output.c src/pdf_export.c CMakeLists.txt
+git commit -m "refactor: share deterministic PDF serializer"
+```
+
+Do not claim merge GREEN after this commit.
+
+---
+
+### Task 3: Implement immutable-output merge and turn the RED GREEN
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Create: `src/pdf_merge.c`
+- Modify: `CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: `extractpdf_serialize_pdf(...)` from Task 2 and the private immutable bytes in `struct extractpdf_output`.
+- Produces: public `extractpdf_merge_outputs(...)` with exact-order whole-document append, strict atomicity, duplicate-input support, single-input support, `INT_MAX` page-total guard, and input-independent result lifetime.
+
+- [ ] **Step 1: Add the public declaration only at the established composition surface**
+
+In `include/extractpdf/extractpdf.h`, place the declaration after `extractpdf_export_page_range(...)` and before `extractpdf_output_data(...)`:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_merge_outputs(
+    const extractpdf_output *const *inputs,
+    size_t input_count,
+    extractpdf_output **out_output);
+```
+
+No new public structs, enums, MuPDF types, or filename parameters are added.
+
+- [ ] **Step 2: Implement one source-local merge helper in `src/pdf_merge.c`**
+
+Create the file with private PDF includes and a local silent-log callback matching the library's existing no-stderr behavior:
+
+```c
+#include "pdf_internal.h"
+
+#include <limits.h>
+#include <stddef.h>
+
+static void extractpdf_merge_discard_log(void *user, const char *message)
+{
+    (void)user;
+    (void)message;
+}
+
+static extractpdf_status extractpdf_merge_one_output(
+    fz_context *ctx,
+    pdf_document *destination,
+    const extractpdf_output *input,
+    int *total_page_count)
+{
+    fz_stream *stream = NULL;
+    pdf_document *source = NULL;
+    pdf_graft_map *graft = NULL;
+    extractpdf_status status = EXTRACTPDF_OK;
+    int source_page_count = 0;
+    int new_total = *total_page_count;
+    int caught_code = FZ_ERROR_NONE;
+    int page;
+
+    fz_var(stream);
+    fz_var(source);
+    fz_var(graft);
+    fz_var(status);
+    fz_var(source_page_count);
+    fz_var(new_total);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        stream = fz_open_memory(ctx, input->data, input->size);
+        source = pdf_open_document_with_stream(ctx, stream);
+        source_page_count = pdf_count_pages(ctx, source);
+
+        if (source_page_count < 0) {
+            status = EXTRACTPDF_ERROR_MUPDF;
+        } else if (source_page_count > INT_MAX - *total_page_count) {
+            status = EXTRACTPDF_ERROR_ARGUMENT;
+        } else {
+            new_total = *total_page_count + source_page_count;
+            graft = pdf_new_graft_map(ctx, destination);
+            for (page = 0; page < source_page_count; ++page)
+                pdf_graft_mapped_page(ctx, graft, -1, source, page);
+        }
+    }
+    fz_always(ctx)
+    {
+        if (graft != NULL)
+            pdf_drop_graft_map(ctx, graft);
+        if (source != NULL)
+            pdf_drop_document(ctx, source);
+        if (stream != NULL)
+            fz_drop_stream(ctx, stream);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    *total_page_count = new_total;
+    return EXTRACTPDF_OK;
+}
+```
+
+The total is updated only after the complete source graft succeeds. If page 2 of a source throws, the helper returns an error without advancing the running total; the caller then discards the entire private destination, preserving operation atomicity.
+
+- [ ] **Step 3: Implement the public all-or-nothing merge function**
+
+Continue `src/pdf_merge.c` with:
+
+```c
+extractpdf_status extractpdf_merge_outputs(
+    const extractpdf_output *const *inputs,
+    size_t input_count,
+    extractpdf_output **out_output)
+{
+    fz_context *ctx = NULL;
+    pdf_document *destination = NULL;
+    extractpdf_status status = EXTRACTPDF_OK;
+    int total_page_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+    size_t i;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (inputs == NULL || input_count == 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    for (i = 0; i < input_count; ++i) {
+        if (inputs[i] == NULL)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+    }
+
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    fz_set_error_callback(ctx, extractpdf_merge_discard_log, NULL);
+    fz_set_warning_callback(ctx, extractpdf_merge_discard_log, NULL);
+
+    fz_var(destination);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        destination = pdf_create_document(ctx);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        status = extractpdf_status_from_mupdf(caught_code);
+        fz_drop_context(ctx);
+        return status;
+    }
+
+    for (i = 0; i < input_count; ++i) {
+        status = extractpdf_merge_one_output(
+            ctx, destination, inputs[i], &total_page_count);
+        if (status != EXTRACTPDF_OK) {
+            pdf_drop_document(ctx, destination);
+            fz_drop_context(ctx);
+            return status;
+        }
+    }
+
+    status = extractpdf_serialize_pdf(ctx, destination, out_output);
+    pdf_drop_document(ctx, destination);
+    fz_drop_context(ctx);
+    return status;
+}
+```
+
+Do not add a one-input fast path or special duplicate handling. The generic loop must naturally satisfy both contracts.
+
+- [ ] **Step 4: Register `src/pdf_merge.c`**
+
+Update root `CMakeLists.txt` so the PDF section is:
+
+```cmake
+  src/pdf_export.c
+  src/pdf_output.c
+  src/pdf_range.c
+  src/pdf_merge.c)
+```
+
+The exact order is not ABI-significant; keep the grouping readable and do not touch unrelated sources.
+
+- [ ] **Step 5: Build the merge target and verify the original RED turns GREEN**
+
+Run:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build --target extractpdf_test_pdf_merge --parallel 2
+ctest --test-dir build -R '^extractpdf\.pdf_merge$' --output-on-failure
+```
+
+Expected: `extractpdf.pdf_merge` passes all contract cases from Task 1.
+
+- [ ] **Step 6: Run all normal Linux tests**
+
+```bash
+cmake --build build --parallel 2
+ctest --test-dir build --output-on-failure
+```
+
+Expected: every existing test remains green, including:
+
+```text
+extractpdf.pdf_export
+extractpdf.pdf_range
+extractpdf.pdf_order
+extractpdf.pdf_delete
+extractpdf.pdf_merge
+```
+
+The export test's byte-determinism assertion is the regression proof that serializer extraction did not drift the old writer path.
+
+- [ ] **Step 7: Run Linux ASan/UBSan from a fresh sanitizer build directory**
+
+```bash
+cmake -S . -B build-asan \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+cmake --build build-asan --parallel 2
+ctest --test-dir build-asan --output-on-failure
+```
+
+Expected: all sanitizer CTests pass with no sanitizer diagnostics.
+
+- [ ] **Step 8: Commit the GREEN implementation**
+
+```bash
+git add \
+  include/extractpdf/extractpdf.h \
+  src/pdf_merge.c \
+  CMakeLists.txt
+git commit -m "feat: merge immutable PDF outputs"
+```
+
+Do not fold the RED or serializer-refactor commits into this commit during normal execution; the three-step history is useful evidence:
+
+```text
+test RED
+refactor shared serializer
+feature GREEN
+```
+
+---
+
+### Task 4: Exact-head CI, cross-platform checkpoint, and roadmap evidence
+
+**Files:**
+- No production/test source changes expected.
+- Update the draft Merge PR created in Task 1, issue #27, and umbrella #2 only after exact-head verification succeeds.
+
+**Interfaces:**
+- Consumes: the exact GREEN head from Task 3.
+- Produces: auditable Linux GREEN + Linux/macOS/Windows architecture-checkpoint evidence, with #27 and #2 updated but all stacked PRs still unmerged.
+
+- [ ] **Step 1: Verify the PR stack and exact feature diff before trusting CI**
+
+Capture the implementation head once Task 3 is committed:
+
+```bash
+GREEN_SHA=$(git rev-parse HEAD)
+printf '%s\n' "$GREEN_SHA"
+```
+
+Then confirm the draft Merge PR created in Task 1 remains:
+
+```text
+base ref: test/pdf-delete-contract
+base sha: 18a6c0596b68c1ca7b116624a09e27dcf0ac4a7f
+head ref: feat/pdf-merge-outputs
+head sha: exactly the GREEN_SHA printed above
+draft: true
+```
+
+The feature diff should contain only:
+
+```text
+docs/superpowers/specs/2026-08-28-extractpdf-pdf-merge-outputs-design.md
+docs/superpowers/plans/2026-08-28-extractpdf-pdf-merge-outputs.md
+include/extractpdf/extractpdf.h
+src/pdf_internal.h
+src/pdf_output.c
+src/pdf_export.c
+src/pdf_merge.c
+CMakeLists.txt
+tests/test_pdf_merge.c
+tests/CMakeLists.txt
+```
+
+Any unrelated file is a scope blocker and must be removed before the final verification run.
+
+- [ ] **Step 2: Verify the exact GREEN SHA's normal PR workflow**
+
+Read the workflow run attached to `GREEN_SHA`. Require Linux success for every step already defined in `.github/workflows/ci.yml`:
+
+```text
+Configure static build
+Build static library and tests
+Test static build
+Configure sanitizer build
+Build sanitizer configuration
+Test sanitizer configuration
+```
+
+macOS/Windows may be skipped on this normal pull-request synchronization run; do not call the architecture checkpoint complete yet.
+
+- [ ] **Step 3: Update the draft PR body with RED/GREEN evidence before triggering full-ci**
+
+Record:
+
+```text
+RED exact SHA + workflow number/run id + intended missing-symbol failure
+GREEN exact SHA + workflow number/run id + Linux normal/sanitizer success
+public ABI
+one-temp-context / one-graft-map-per-source architecture
+shared serializer requirement
+preservation boundary
+no live-document/context crossing
+```
+
+Keep the PR draft and unmerged.
+
+- [ ] **Step 4: Apply the existing `full-ci` label to the draft PR**
+
+The existing workflow is already configured so a pull-request `labeled` event with label `full-ci` runs macOS and Windows in addition to Linux. Do not edit `.github/workflows/ci.yml` for this feature.
+
+Require the triggered run to use the same exact `GREEN_SHA` verified in Step 2.
+
+- [ ] **Step 5: Verify every full-ci platform on the same exact head**
+
+Require:
+
+```text
+Linux:
+  static configure/build/tests ✅
+  ASan/UBSan configure/build/tests ✅
+
+macOS:
+  configure/build/tests ✅
+
+Windows:
+  DLL configure/build/tests ✅
+  extractpdf_test_pdf_merge links and runs against the shared library ✅
+```
+
+If Windows fails because the new public function is not exported, verify the declaration carries `EXTRACTPDF_API` before considering any broader fix. If a platform reveals a real implementation defect, use systematic debugging and add the smallest regression test/fix; then repeat exact-head Linux and full-ci verification on the new SHA.
+
+- [ ] **Step 6: Update issue #27 with completion evidence**
+
+Keep #27 open only for stacked integration bookkeeping. Record:
+
+```text
+implementation PR number returned when Task 1 opened the draft Merge PR
+exact GREEN SHA
+RED workflow evidence
+Linux GREEN workflow evidence
+same-head full-ci evidence
+final production/file scope
+preservation boundary
+atomicity and lifetime guarantees
+```
+
+- [ ] **Step 7: Update umbrella #2 only after full-ci is green**
+
+Read the concrete numeric PR number returned when Task 1 opened the draft Merge PR. Replace the open `Merge pages/documents` checklist line with a checked line containing that exact number together with `#27`. Do not use a symbolic marker in the persisted issue body.
+
+Add one concise Phase 4 merge-proof paragraph with `GREEN_SHA` and the same-head full-ci workflow evidence. Leave `Save/write with explicit ownership and error handling` open.
+
+- [ ] **Step 8: Final completion gate**
+
+Freshly re-read:
+
+1. PR state/head/base: still draft, open, unmerged, and head SHA exactly equals `GREEN_SHA`;
+2. exact-head full-ci jobs: Linux/macOS/Windows all successful;
+3. compare against PR #26 base: only the scoped spec/plan/API/PDF implementation/test/CMake files above;
+4. issue #27 and umbrella #2: evidence matches `GREEN_SHA` and no unverified claim is present.
+
+Only then report the Merge slice implementation complete. Do not merge #20/#22/#24/#26 or the Merge PR without explicit authorization.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-pdf-merge-outputs-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-pdf-merge-outputs-design.md
@@ -1,0 +1,774 @@
+# ExtractPDF Immutable PDF Output Merge Design
+
+Date: 2026-08-28  
+Status: approved design  
+Tracks: #27, umbrella #2  
+Stacked base: #25 / PR #26 head `18a6c0596b68c1ca7b116624a09e27dcf0ac4a7f`  
+Branch: `feat/pdf-merge-outputs`
+
+## Goal
+
+Add the first true cross-document PDF composition primitive while preserving ExtractPDF's existing ownership model: every live `extractpdf_document` keeps its own MuPDF context, and no MuPDF object crosses from one document context into another.
+
+Merge therefore consumes immutable `extractpdf_output` values rather than live document handles. It reparses those PDF bytes inside one temporary MuPDF context, appends every input document in caller order, serializes one destination exactly once, and returns a new immutable `extractpdf_output`.
+
+The public API is:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_merge_outputs(
+    const extractpdf_output *const *inputs,
+    size_t input_count,
+    extractpdf_output **out_output);
+```
+
+This slice closes the Phase 4 `Merge pages/documents` roadmap item without introducing a merge session, a live-document array API, a multi-document page-selection DSL, filenames, or a new output ownership model.
+
+## Architectural problem
+
+The existing single-document composition engine is bound to one live ExtractPDF document:
+
+```text
+extractpdf_document
+    ├── fz_context *ctx
+    └── fz_document *doc
+```
+
+`extractpdf_export_pages(...)` obtains the source `pdf_document` from `document->ctx`, creates the destination in the same context, uses one graft map, and serializes the result.
+
+This is correct for one source document but cannot be generalized by simply passing several `extractpdf_document *` handles into one graft loop. Existing document handles may own different `fz_context` instances, and MuPDF objects must not be mixed across those contexts.
+
+Pinned MuPDF 1.28.2's own `pdfmerge` tool confirms the safe model:
+
+- create one `fz_context`;
+- create one destination `pdf_document` in that context;
+- open every source document in that same context;
+- create a fresh `pdf_graft_map` for each source;
+- append that source's selected pages;
+- drop the source-local graft state before moving to the next source.
+
+ExtractPDF V1 adopts that model, but its sources are immutable output bytes rather than filenames or live document handles.
+
+## Why immutable outputs are the merge boundary
+
+Three API families were considered.
+
+### 1. Immutable output array — selected
+
+```c
+extractpdf_merge_outputs(inputs, input_count, out_output);
+```
+
+Benefits:
+
+- no live MuPDF object crosses document-context boundaries;
+- every input already has clear ExtractPDF ownership/lifetime semantics;
+- subset/range/reorder/delete/duplicate compose naturally before merge;
+- one destination and one final serialization are sufficient for N inputs;
+- no new session lifecycle is required;
+- no repeated pairwise serialization is required.
+
+### 2. Live document array — rejected for V1
+
+A shape such as:
+
+```c
+extractpdf_merge_documents(documents, count, out_output);
+```
+
+looks convenient but would either misuse MuPDF objects from different contexts or secretly serialize/reparse every live document before merge. The latter hides an expensive bridge inside an API whose apparent semantics suggest direct composition.
+
+### 3. Merge session — rejected for V1
+
+A dedicated merge/session object could own one context and reopen all sources itself. That could optimize future workflows, but it adds a new lifecycle, source-open policy, error model, and stateful subsystem before V1 has evidence that such complexity is necessary.
+
+The immutable-output array is therefore the smallest safe boundary that composes with the rest of Phase 4.
+
+## Public semantics
+
+### Input order
+
+Each input contributes its **entire PDF** in exact caller order.
+
+Conceptually:
+
+```text
+inputs = [A, B, C]
+
+A pages: A0 A1
+B pages: B0
+C pages: C0 C1 C2
+
+result:
+A0 A1 B0 C0 C1 C2
+```
+
+Merge does not sort, deduplicate, normalize, or inspect semantic identity between inputs.
+
+### Single input
+
+`input_count == 1` is valid.
+
+The result is a new, independently owned PDF output created by the same merge engine. V1 promises semantic page equivalence under the Phase 4 preservation contract, but it does **not** promise byte-for-byte identity with the source input.
+
+There is deliberately no one-input memcpy fast path. All valid merge calls follow one parse/graft/serialize engine.
+
+### Duplicate input handles
+
+Repeated input pointers are valid:
+
+```text
+inputs = [A, B, A]
+```
+
+The result contains all pages from A, then B, then A again.
+
+This is whole-document duplication. It does not require copying or cloning the input `extractpdf_output` object before the call.
+
+### Empty merge
+
+`input_count == 0` is invalid and returns `EXTRACTPDF_ERROR_ARGUMENT`.
+
+V1 does not introduce an empty-PDF output special case. This remains consistent with the existing selected-page composition boundary where zero selected pages are invalid.
+
+## Argument validation
+
+When `out_output == NULL`, return `EXTRACTPDF_ERROR_ARGUMENT`.
+
+When `out_output != NULL`, set:
+
+```c
+*out_output = NULL;
+```
+
+before any further validation or fallible work.
+
+Then reject with `EXTRACTPDF_ERROR_ARGUMENT`:
+
+- `inputs == NULL`;
+- `input_count == 0`;
+- any `inputs[i] == NULL`.
+
+The implementation does not expose or validate private byte fields as part of the public ABI. `extractpdf_output` remains opaque; a non-NULL handle produced by ExtractPDF is treated as satisfying the output object's internal invariant.
+
+## Total page-count boundary
+
+The merged PDF page count must fit the same `int` page-index domain used throughout the current public API.
+
+For each source:
+
+1. open the source PDF;
+2. obtain its page count;
+3. before grafting that source, check the running total without overflow;
+4. reject if the new total would exceed `INT_MAX`.
+
+Conceptually:
+
+```c
+if (source_page_count > INT_MAX - total_page_count)
+    return EXTRACTPDF_ERROR_ARGUMENT;
+```
+
+The check occurs before grafting pages from the source that would exceed the limit.
+
+It is acceptable that previous sources may already have been grafted into the private destination at that point because the operation is atomic: no destination or partial output is externally visible before final success.
+
+No huge runtime fixture is required to force an `INT_MAX` overflow. The guard is an arithmetic safety requirement verified by code review and ordinary boundary reasoning.
+
+## Temporary-context ownership model
+
+Every merge call creates a fresh temporary MuPDF context that belongs only to that call.
+
+Conceptually:
+
+```text
+extractpdf_merge_outputs(...)
+        |
+        v
+fz_new_context(...)
+        |
+        +--> destination pdf_document
+        |
+        +--> source A stream/document/graft
+        |
+        +--> source B stream/document/graft
+        |
+        +--> ...
+        |
+        v
+serialize destination
+        |
+        v
+drop all MuPDF state + context
+```
+
+The merge context is not stored in any public or persistent ExtractPDF object.
+
+The existing `extractpdf_document` structure is unchanged.
+
+No input `extractpdf_output` gains a MuPDF reference, context pointer, or hidden mutable state.
+
+## Opening immutable outputs as PDF sources
+
+Each input is opened from its owned PDF bytes inside the temporary merge context.
+
+The intended MuPDF flow is:
+
+```text
+fz_open_memory(ctx, input->data, input->size)
+        |
+        v
+pdf_open_document_with_stream(ctx, stream)
+        |
+        v
+pdf_count_pages(ctx, source)
+        |
+        v
+pdf_new_graft_map(ctx, destination)
+        |
+        v
+pdf_graft_mapped_page(... each source page ...)
+```
+
+`fz_open_memory` does not take ownership of the raw memory block. Therefore the input `extractpdf_output` objects must remain alive for the duration of `extractpdf_merge_outputs(...)`.
+
+After the source PDF and its stream have been dropped, the merge engine retains only grafted destination objects. After the merge call returns, the returned `extractpdf_output` is independent of all inputs.
+
+Inputs may be dropped immediately after successful return.
+
+## One graft map per source
+
+The destination document is created once.
+
+A **new `pdf_graft_map` is created for each source input** and reused for all pages copied from that one source.
+
+Conceptually:
+
+```text
+destination
+  |
+  +-- graft map A -> all pages from source A
+  |
+  +-- graft map B -> all pages from source B
+  |
+  +-- graft map C -> all pages from source C
+```
+
+A graft map is not shared across different source documents.
+
+This matches the source-local resource deduplication model used by MuPDF's own merge tool and prevents source-object-number mappings from one input from leaking into another.
+
+## Strict failure atomicity
+
+Merge is all-or-nothing.
+
+No partial destination is ever returned.
+
+The lifecycle is:
+
+```text
+reset out_output
+validate arguments
+create temporary context
+create destination
+for every source:
+    open stream
+    open PDF
+    count/preflight pages
+    create graft map
+    graft all pages
+    drop source-local state
+serialize destination once
+copy serialized bytes into new extractpdf_output
+publish *out_output
+```
+
+If any step fails:
+
+```text
+drop current source-local state
+        +
+drop partial destination
+        +
+drop serialization state
+        +
+drop temporary context
+        +
+free ExtractPDF-owned temporary/result allocations
+        |
+        v
+return error with *out_output == NULL
+```
+
+Earlier successfully grafted inputs do not create a partial-success result.
+
+No input is mutated or consumed on success or failure.
+
+## Error mapping
+
+Merge reuses the existing `extractpdf_status` vocabulary.
+
+No merge-specific status enum is added.
+
+Required mapping:
+
+- public shape/NULL/zero-count/page-total errors -> `EXTRACTPDF_ERROR_ARGUMENT`;
+- temporary context or ExtractPDF-owned allocation failure -> `EXTRACTPDF_ERROR_NOMEM`;
+- MuPDF format/syntax parse errors -> existing `EXTRACTPDF_ERROR_FORMAT` mapping;
+- MuPDF unsupported errors -> `EXTRACTPDF_ERROR_UNSUPPORTED`;
+- MuPDF system errors -> existing `EXTRACTPDF_ERROR_IO` mapping;
+- other MuPDF exceptions -> `EXTRACTPDF_ERROR_MUPDF`.
+
+The existing `extractpdf_status_from_mupdf(...)` remains authoritative for MuPDF exception mapping.
+
+V1 does not expose which input index failed. A single operation status remains consistent with the rest of the stable C ABI.
+
+## Shared deterministic PDF serializer
+
+The deterministic writer currently embedded in `extractpdf_export_pages(...)` must be extracted into one private helper and reused by merge.
+
+Recommended private interface:
+
+```c
+extractpdf_status extractpdf_serialize_pdf(
+    fz_context *ctx,
+    pdf_document *document,
+    extractpdf_output **out_output);
+```
+
+This helper is private implementation surface only. It is not declared in the public header.
+
+Its sole responsibility is:
+
+```text
+pdf_default_write_options
+    reproducible = 1
+    dont_regenerate_id = 1
+        |
+        v
+fz_new_buffer
+fz_new_output_with_buffer
+pdf_write_document
+fz_close_output
+fz_buffer_storage
+        |
+        v
+allocate extractpdf_output
+copy serialized bytes
+        |
+        v
+return immutable output
+```
+
+The helper must reset a supplied output slot before its own fallible work and publish the result only after the byte copy is complete.
+
+It owns and cleans up its serialization buffer/output state on both success and failure.
+
+## Required export-path refactor boundary
+
+`extractpdf_export_pages(...)` currently contains both page grafting and deterministic serialization.
+
+This slice may refactor **only the serialization portion** into the shared private helper.
+
+The following existing export behavior must not change:
+
+- PDF-only source check;
+- page-count retrieval;
+- validation of all selected indices before first graft;
+- exact caller order;
+- duplicate indices;
+- one shared graft map for the single source;
+- output reset/error precedence;
+- selected-page preservation boundary.
+
+After the refactor the intended split is:
+
+```text
+src/pdf_export.c
+    validate source/indices
+    create destination + single-source graft map
+    graft selected pages
+    call extractpdf_serialize_pdf(...)
+
+private serializer implementation
+    deterministic writer options
+    serialize destination to memory
+    copy bytes into extractpdf_output
+
+src/pdf_merge.c
+    create temporary context + destination
+    parse each immutable input in same context
+    one graft map per source
+    graft all pages
+    call extractpdf_serialize_pdf(...)
+```
+
+No other Page/Render/Text/Search/Image/Links implementation refactor belongs in this slice.
+
+## Output data/drop lifecycle
+
+`extractpdf_output_data(...)` and `extractpdf_drop_output(...)` remain public lifecycle operations exactly as defined by #19 / PR #20.
+
+They do not need to move files merely because serialization becomes shared.
+
+Avoiding an unnecessary file/lifecycle refactor keeps the merge diff focused on actual shared behavior rather than cosmetic organization.
+
+## Preservation boundary
+
+Merge V1 does **not** expand the Phase 4 selected-page preservation policy.
+
+The page-level state currently copied by pinned MuPDF 1.28.2 `pdf_graft_mapped_page` is the merge contract:
+
+- `Contents`;
+- `Resources`;
+- `MediaBox`;
+- `CropBox`;
+- `BleedBox`;
+- `TrimBox`;
+- `ArtBox`;
+- `Rotate`;
+- `UserUnit`.
+
+Merge V1 does not promise preservation of:
+
+- annotations or `Annots`;
+- external/internal links;
+- widgets;
+- document metadata / Info;
+- outlines / bookmarks;
+- page labels;
+- named destinations;
+- AcroForm state;
+- signatures;
+- encryption/permissions;
+- JavaScript;
+- document-level optional-content configuration.
+
+This remains true even though MuPDF's standalone `pdfmerge` utility contains extra logic for some external links/outlines. ExtractPDF merge is composition of Phase 4 immutable outputs, not an implicit upgrade to Phase 5 interactive/document-root preservation.
+
+## Determinism scope
+
+Merge uses the same deterministic writer options as selected-page export:
+
+```text
+reproducible = 1
+dont_regenerate_id = 1
+```
+
+For identical input byte sequences in identical order under the same pinned build, repeated merge calls must return byte-for-byte identical output.
+
+This is a deterministic-build test contract. It does not promise byte identity across different MuPDF versions, compiler/toolchain versions, or platforms unless separately proven and intentionally documented.
+
+A one-input merge does not promise byte identity with that input because the source is reparsed, grafted into a new destination, and serialized again.
+
+## Deterministic fixture strategy
+
+No new binary PDF fixture is required.
+
+Reuse two existing, semantically different fixtures to prove a real cross-source merge.
+
+### Source A
+
+Open:
+
+```text
+tests/fixtures/composition-three-page.pdf
+```
+
+Export indices:
+
+```text
+{2, 0}
+```
+
+Expected immutable output A:
+
+```text
+page 0: PAGE-C, 300 x 150 pt
+page 1: PAGE-A, 200 x 200 pt
+```
+
+### Source B
+
+Open:
+
+```text
+tests/fixtures/text-one-page.pdf
+```
+
+Export index:
+
+```text
+{0}
+```
+
+Expected immutable output B contains the existing stable text prefix:
+
+```text
+Hello Café
+```
+
+Close both original source documents **before** calling merge.
+
+This proves that merge consumes only immutable outputs and does not depend on the original document handles or their MuPDF contexts.
+
+## Primary cross-source proof
+
+Call:
+
+```c
+const extractpdf_output *inputs[] = {output_a, output_b};
+extractpdf_merge_outputs(inputs, 2, &merged);
+```
+
+Reopen merged bytes through the existing public test path.
+
+Expected result:
+
+```text
+page_count = 3
+page 0: PAGE-C, 300 x 150 pt
+page 1: PAGE-A, 200 x 200 pt
+page 2: text contains "Hello Café"
+```
+
+The test must verify exact page order and sufficient content/geometry to distinguish the sources.
+
+## Repeated-merge determinism proof
+
+Call the same merge twice with the same `A,B` inputs.
+
+The two returned outputs must have:
+
+- the same size;
+- byte-for-byte identical contents.
+
+This proves the new merge path uses deterministic serialization.
+
+## Single-input proof
+
+Call:
+
+```text
+merge({A})
+```
+
+Expected result:
+
+```text
+PAGE-C
+PAGE-A
+```
+
+with the same page geometry/content semantics as A.
+
+The test must **not** require:
+
+```text
+bytes(merge({A})) == bytes(A)
+```
+
+because V1 intentionally defines one-input merge as semantic reserialization, not a copy fast path.
+
+## Duplicate-input proof
+
+Call:
+
+```text
+merge({B, A, B})
+```
+
+Expected pages:
+
+```text
+B page
+PAGE-C
+PAGE-A
+B page
+```
+
+This proves duplicate pointers are valid and whole-document multiplicity/order is preserved.
+
+The B pages may be identified by stable text; the A pages retain their known geometry and labels.
+
+## Result lifetime proof
+
+After one successful merge:
+
+1. drop all input outputs A/B;
+2. keep merged output alive;
+3. obtain/reuse merged bytes and reopen the merged PDF;
+4. verify the merged pages again.
+
+This proves the result owns copied bytes independently of all input outputs.
+
+The inverse lifetime is also implicit: successful merge does not consume or alter inputs; callers may continue using A/B until they choose to drop them.
+
+## Failure/argument tests
+
+Required deterministic argument cases:
+
+1. `out_output == NULL` -> `EXTRACTPDF_ERROR_ARGUMENT`;
+2. `inputs == NULL` with valid output slot -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset;
+3. `input_count == 0` with a non-NULL input pointer -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset;
+4. input array containing a NULL element -> `EXTRACTPDF_ERROR_ARGUMENT`, output reset.
+
+The output-reset sentinel pattern used by existing tests should be reused.
+
+No artificial malformed `extractpdf_output` object is constructed in tests because the type is opaque and the public API provides no constructor for invalid output handles.
+
+## RED boundary
+
+The first implementation-stage commit is **merge-test-only**.
+
+It adds:
+
+- `tests/test_pdf_merge.c`;
+- CTest registration / Windows DLL copy-list wiring;
+- no public merge declaration;
+- no production merge implementation;
+- no shared serializer refactor yet.
+
+The intended RED is that all existing production targets and tests continue to build, while only the new merge test fails because `extractpdf_merge_outputs(...)` is absent.
+
+The RED must not be manufactured through fixture corruption, disabled symbols, or production stubs.
+
+## Minimal GREEN boundary
+
+After the RED is observed, GREEN may add only the production pieces required by this design:
+
+- one public `extractpdf_merge_outputs(...)` declaration;
+- focused `src/pdf_merge.c`;
+- one private shared deterministic serializer implementation/declaration;
+- the minimum `src/pdf_export.c` change needed to call that serializer;
+- root CMake source registration;
+- internal declarations required to share the serializer.
+
+No new public types are required.
+
+No `extractpdf_document` layout change is required.
+
+No direct-save/filename API is required.
+
+## Expected file responsibilities
+
+Likely production/test surface:
+
+```text
+include/extractpdf/extractpdf.h
+    add extractpdf_merge_outputs declaration
+
+src/pdf_merge.c
+    validate input array
+    create temporary context/destination
+    open immutable input bytes as source PDFs
+    running page-count guard
+    one graft map per source
+    append all pages in exact input order
+    atomic cleanup
+    call shared serializer
+
+src/pdf_output.c   (or another focused private name chosen in the plan)
+    deterministic pdf_write_document -> immutable extractpdf_output
+
+src/internal.h
+    private serializer declaration only if required
+
+src/pdf_export.c
+    retain existing selected-page graft behavior
+    replace inline writer/copy code with shared serializer call
+
+CMakeLists.txt
+    register new focused production source(s)
+
+tests/test_pdf_merge.c
+    cross-source order, duplicate/single input, lifetime, determinism, errors
+
+tests/CMakeLists.txt
+    register CTest / Windows DLL copy target
+```
+
+The implementation plan may choose the exact private serializer filename, but it must preserve these responsibility boundaries.
+
+## Stacked branch / PR strategy
+
+PR #20, #22, #24, and #26 are still stacked/unmerged.
+
+Merge therefore starts from the exact current #26 head:
+
+```text
+master
+  |
+  +-- feat/pdf-export-pages           PR #20
+        |
+        +-- feat/pdf-export-range     PR #22
+              |
+              +-- test/pdf-order-contract    PR #24
+                    |
+                    +-- test/pdf-delete-contract   PR #26
+                          |
+                          +-- feat/pdf-merge-outputs   #27 / merge PR
+```
+
+The future Merge PR base is `test/pdf-delete-contract`, not `master`, until earlier Phase 4 slices are integrated.
+
+At the spec gate, the merge branch must contain only this design document beyond the #26 base.
+
+Retargeting after upstream integration is a later integration task and must preserve the merge feature tree/evidence.
+
+## CI policy
+
+This slice creates a new public ABI, a new temporary MuPDF context, memory-stream PDF parsing, multi-source grafting, and a shared writer refactor. It is therefore an architecture checkpoint.
+
+Required sequence:
+
+1. exact-head RED proves only the merge API is missing;
+2. exact-head Linux strict static build + all normal CTests pass;
+3. exact-head Linux ASan/UBSan configure/build + all CTests pass;
+4. apply/run `full-ci` on the same final feature head;
+5. Linux, macOS, and Windows all pass before the Merge slice is considered architecture-complete.
+
+Unlike the recent tests-only reorder/delete closures, macOS/Windows are not deferred here.
+
+No passing workflow from an earlier SHA can be used as completion evidence for a later head.
+
+## Acceptance criteria
+
+The Merge roadmap item can be marked complete only when all of the following are true:
+
+- public ABI is exactly the approved output-array form;
+- no live document/MuPDF object is used across contexts;
+- one temporary context/destination is used per merge call;
+- each source input gets its own graft map;
+- inputs are appended in exact whole-document caller order;
+- duplicate and single inputs follow the approved semantics;
+- total page-count overflow is guarded;
+- failure is atomic and output reset semantics are proven;
+- result lifetime is independent of inputs;
+- preservation does not exceed the existing Phase 4 page-graft boundary;
+- export and merge use one private deterministic serializer;
+- all preexisting composition tests remain green after the serializer refactor;
+- merge deterministic tests pass;
+- Linux normal + ASan/UBSan pass;
+- final same-head Linux/macOS/Windows full-ci passes;
+- scope review finds no merge session, live-document merge API, selection descriptor, interactive preservation, or filename-save expansion.
+
+## Non-goals
+
+This slice does not add:
+
+- `extractpdf_merge_documents(...)` for live documents;
+- a merge/session/builder handle;
+- incremental append mutation of an existing output;
+- pairwise-only merge API;
+- per-input range/index descriptors;
+- automatic page selection during merge;
+- automatic filename generation;
+- direct file saving;
+- empty-PDF creation;
+- mutation of source documents or outputs;
+- link/annotation/widget copying;
+- metadata/outline/page-label/named-destination merging;
+- form/signature/encryption preservation;
+- JavaScript or optional-content merging;
+- new concurrency guarantees;
+- a new error enum or per-input diagnostic object.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -140,6 +140,11 @@ EXTRACTPDF_API extractpdf_status extractpdf_export_page_range(
     size_t page_count,
     extractpdf_output **out_output);
 
+EXTRACTPDF_API extractpdf_status extractpdf_merge_outputs(
+    const extractpdf_output *const *inputs,
+    size_t input_count,
+    extractpdf_output **out_output);
+
 EXTRACTPDF_API extractpdf_status extractpdf_output_data(
     const extractpdf_output *output,
     const unsigned char **out_data,

--- a/src/pdf_export.c
+++ b/src/pdf_export.c
@@ -1,22 +1,13 @@
-#include "internal.h"
-
-#include <mupdf/pdf.h>
+#include "pdf_internal.h"
 
 #include <limits.h>
 #include <stdlib.h>
-#include <string.h>
 
 static void extractpdf_drop_pdf_export_state(
     fz_context *ctx,
     pdf_document *destination,
-    pdf_graft_map *graft,
-    fz_buffer *buffer,
-    fz_output *memory_output)
+    pdf_graft_map *graft)
 {
-    if (memory_output != NULL)
-        fz_drop_output(ctx, memory_output);
-    if (buffer != NULL)
-        fz_drop_buffer(ctx, buffer);
     if (graft != NULL)
         pdf_drop_graft_map(ctx, graft);
     if (destination != NULL)
@@ -33,12 +24,6 @@ extractpdf_status extractpdf_export_pages(
     pdf_document *source_pdf;
     pdf_document *destination = NULL;
     pdf_graft_map *graft = NULL;
-    fz_buffer *buffer = NULL;
-    fz_output *memory_output = NULL;
-    extractpdf_output *result = NULL;
-    unsigned char *buffer_data = NULL;
-    size_t buffer_size = 0;
-    pdf_write_options options = pdf_default_write_options;
     int source_page_count = 0;
     int caught_code = FZ_ERROR_NONE;
     size_t i;
@@ -77,20 +62,10 @@ extractpdf_status extractpdf_export_pages(
             return EXTRACTPDF_ERROR_ARGUMENT;
     }
 
-    result = (extractpdf_output *)calloc(1, sizeof(*result));
-    if (result == NULL)
-        return EXTRACTPDF_ERROR_NOMEM;
-
-    options.reproducible = 1;
-    options.dont_regenerate_id = 1;
     caught_code = FZ_ERROR_NONE;
 
     fz_var(destination);
     fz_var(graft);
-    fz_var(buffer);
-    fz_var(memory_output);
-    fz_var(buffer_data);
-    fz_var(buffer_size);
     fz_var(caught_code);
 
     fz_try(ctx)
@@ -100,12 +75,6 @@ extractpdf_status extractpdf_export_pages(
 
         for (i = 0; i < page_count; ++i)
             pdf_graft_mapped_page(ctx, graft, -1, source_pdf, page_indices[i]);
-
-        buffer = fz_new_buffer(ctx, 0);
-        memory_output = fz_new_output_with_buffer(ctx, buffer);
-        pdf_write_document(ctx, destination, memory_output, &options);
-        fz_close_output(ctx, memory_output);
-        buffer_size = fz_buffer_storage(ctx, buffer, &buffer_data);
     }
     fz_catch(ctx)
     {
@@ -115,35 +84,16 @@ extractpdf_status extractpdf_export_pages(
 
     if (caught_code != FZ_ERROR_NONE) {
         extractpdf_status status = extractpdf_status_from_mupdf(caught_code);
-        extractpdf_drop_pdf_export_state(
-            ctx, destination, graft, buffer, memory_output);
-        free(result);
+        extractpdf_drop_pdf_export_state(ctx, destination, graft);
         return status;
     }
 
-    if (buffer_data == NULL || buffer_size == 0) {
-        extractpdf_drop_pdf_export_state(
-            ctx, destination, graft, buffer, memory_output);
-        free(result);
-        return EXTRACTPDF_ERROR_MUPDF;
+    {
+        extractpdf_status status = extractpdf_serialize_pdf(
+            ctx, destination, out_output);
+        extractpdf_drop_pdf_export_state(ctx, destination, graft);
+        return status;
     }
-
-    result->data = (unsigned char *)malloc(buffer_size);
-    if (result->data == NULL) {
-        extractpdf_drop_pdf_export_state(
-            ctx, destination, graft, buffer, memory_output);
-        free(result);
-        return EXTRACTPDF_ERROR_NOMEM;
-    }
-
-    memcpy(result->data, buffer_data, buffer_size);
-    result->size = buffer_size;
-
-    extractpdf_drop_pdf_export_state(
-        ctx, destination, graft, buffer, memory_output);
-
-    *out_output = result;
-    return EXTRACTPDF_OK;
 }
 
 extractpdf_status extractpdf_output_data(

--- a/src/pdf_internal.h
+++ b/src/pdf_internal.h
@@ -1,0 +1,13 @@
+#ifndef EXTRACTPDF_PDF_INTERNAL_H
+#define EXTRACTPDF_PDF_INTERNAL_H
+
+#include "internal.h"
+
+#include <mupdf/pdf.h>
+
+extractpdf_status extractpdf_serialize_pdf(
+    fz_context *ctx,
+    pdf_document *document,
+    extractpdf_output **out_output);
+
+#endif

--- a/src/pdf_merge.c
+++ b/src/pdf_merge.c
@@ -1,0 +1,139 @@
+#include "pdf_internal.h"
+
+#include <limits.h>
+#include <stddef.h>
+
+static void extractpdf_merge_discard_log(void *user, const char *message)
+{
+    (void)user;
+    (void)message;
+}
+
+static extractpdf_status extractpdf_merge_one_output(
+    fz_context *ctx,
+    pdf_document *destination,
+    const extractpdf_output *input,
+    int *total_page_count)
+{
+    fz_stream *stream = NULL;
+    pdf_document *source = NULL;
+    pdf_graft_map *graft = NULL;
+    extractpdf_status status = EXTRACTPDF_OK;
+    int source_page_count = 0;
+    int new_total = *total_page_count;
+    int caught_code = FZ_ERROR_NONE;
+    int page;
+
+    fz_var(stream);
+    fz_var(source);
+    fz_var(graft);
+    fz_var(status);
+    fz_var(source_page_count);
+    fz_var(new_total);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        stream = fz_open_memory(ctx, input->data, input->size);
+        source = pdf_open_document_with_stream(ctx, stream);
+        source_page_count = pdf_count_pages(ctx, source);
+
+        if (source_page_count < 0) {
+            status = EXTRACTPDF_ERROR_MUPDF;
+        } else if (source_page_count > INT_MAX - *total_page_count) {
+            status = EXTRACTPDF_ERROR_ARGUMENT;
+        } else {
+            new_total = *total_page_count + source_page_count;
+            graft = pdf_new_graft_map(ctx, destination);
+            for (page = 0; page < source_page_count; ++page)
+                pdf_graft_mapped_page(ctx, graft, -1, source, page);
+        }
+    }
+    fz_always(ctx)
+    {
+        if (graft != NULL)
+            pdf_drop_graft_map(ctx, graft);
+        if (source != NULL)
+            pdf_drop_document(ctx, source);
+        if (stream != NULL)
+            fz_drop_stream(ctx, stream);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    *total_page_count = new_total;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_merge_outputs(
+    const extractpdf_output *const *inputs,
+    size_t input_count,
+    extractpdf_output **out_output)
+{
+    fz_context *ctx = NULL;
+    pdf_document *destination = NULL;
+    extractpdf_status status = EXTRACTPDF_OK;
+    int total_page_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+    size_t i;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (inputs == NULL || input_count == 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    for (i = 0; i < input_count; ++i) {
+        if (inputs[i] == NULL)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+    }
+
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    fz_set_error_callback(ctx, extractpdf_merge_discard_log, NULL);
+    fz_set_warning_callback(ctx, extractpdf_merge_discard_log, NULL);
+
+    fz_var(destination);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        destination = pdf_create_document(ctx);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        status = extractpdf_status_from_mupdf(caught_code);
+        fz_drop_context(ctx);
+        return status;
+    }
+
+    for (i = 0; i < input_count; ++i) {
+        status = extractpdf_merge_one_output(
+            ctx, destination, inputs[i], &total_page_count);
+        if (status != EXTRACTPDF_OK) {
+            pdf_drop_document(ctx, destination);
+            fz_drop_context(ctx);
+            return status;
+        }
+    }
+
+    status = extractpdf_serialize_pdf(ctx, destination, out_output);
+    pdf_drop_document(ctx, destination);
+    fz_drop_context(ctx);
+    return status;
+}

--- a/src/pdf_output.c
+++ b/src/pdf_output.c
@@ -1,0 +1,90 @@
+#include "pdf_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void extractpdf_drop_pdf_serialization_state(
+    fz_context *ctx,
+    fz_buffer *buffer,
+    fz_output *memory_output)
+{
+    if (memory_output != NULL)
+        fz_drop_output(ctx, memory_output);
+    if (buffer != NULL)
+        fz_drop_buffer(ctx, buffer);
+}
+
+extractpdf_status extractpdf_serialize_pdf(
+    fz_context *ctx,
+    pdf_document *document,
+    extractpdf_output **out_output)
+{
+    pdf_write_options options = pdf_default_write_options;
+    fz_buffer *buffer = NULL;
+    fz_output *memory_output = NULL;
+    extractpdf_output *result = NULL;
+    unsigned char *buffer_data = NULL;
+    size_t buffer_size = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (ctx == NULL || document == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    options.reproducible = 1;
+    options.dont_regenerate_id = 1;
+
+    fz_var(buffer);
+    fz_var(memory_output);
+    fz_var(buffer_data);
+    fz_var(buffer_size);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        buffer = fz_new_buffer(ctx, 0);
+        memory_output = fz_new_output_with_buffer(ctx, buffer);
+        pdf_write_document(ctx, document, memory_output, &options);
+        fz_close_output(ctx, memory_output);
+        buffer_size = fz_buffer_storage(ctx, buffer, &buffer_data);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        extractpdf_status status = extractpdf_status_from_mupdf(caught_code);
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        return status;
+    }
+
+    if (buffer_data == NULL || buffer_size == 0) {
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+
+    result = (extractpdf_output *)calloc(1, sizeof(*result));
+    if (result == NULL) {
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    result->data = (unsigned char *)malloc(buffer_size);
+    if (result->data == NULL) {
+        extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+        free(result);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    memcpy(result->data, buffer_data, buffer_size);
+    result->size = buffer_size;
+    extractpdf_drop_pdf_serialization_state(ctx, buffer, memory_output);
+
+    *out_output = result;
+    return EXTRACTPDF_OK;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,15 @@ target_compile_definitions(extractpdf_test_pdf_delete PRIVATE
 add_test(NAME extractpdf.pdf_delete COMMAND extractpdf_test_pdf_delete)
 set_tests_properties(extractpdf.pdf_delete PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_pdf_merge test_pdf_merge.c)
+target_link_libraries(extractpdf_test_pdf_merge PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_merge PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/text-one-page.pdf"
+  MERGE_OUTPUT_PDF="${CMAKE_CURRENT_BINARY_DIR}/composition-merge-output.pdf")
+add_test(NAME extractpdf.pdf_merge COMMAND extractpdf_test_pdf_merge)
+set_tests_properties(extractpdf.pdf_merge PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -127,7 +136,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_pdf_export
       extractpdf_test_pdf_range
       extractpdf_test_pdf_order
-      extractpdf_test_pdf_delete)
+      extractpdf_test_pdf_delete
+      extractpdf_test_pdf_merge)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/test_pdf_merge.c
+++ b/tests/test_pdf_merge.c
@@ -1,0 +1,211 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static extractpdf_document *open_output(
+    const extractpdf_output *output,
+    const char *path)
+{
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_output_data(output, &data, &size) == EXTRACTPDF_OK);
+    CHECK(data != NULL);
+    CHECK(size >= 5);
+    CHECK(memcmp(data, "%PDF-", 5) == 0);
+    CHECK(write_bytes(path, data, size));
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    return document;
+}
+
+static void expect_page(
+    extractpdf_document *document,
+    int page_index,
+    const char *needle,
+    int check_geometry,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    if (check_geometry) {
+        CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+        CHECK(bounds.x0 == 0.0f);
+        CHECK(bounds.y0 == 0.0f);
+        CHECK(bounds.x1 == width);
+        CHECK(bounds.y1 == height);
+    }
+    CHECK(extractpdf_extract_text(page, &text, &text_size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(strstr(text, needle) != NULL);
+
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+}
+
+static void expect_same_bytes(
+    const extractpdf_output *left,
+    const extractpdf_output *right)
+{
+    const unsigned char *left_data = NULL;
+    const unsigned char *right_data = NULL;
+    size_t left_size = 0;
+    size_t right_size = 0;
+
+    CHECK(extractpdf_output_data(left, &left_data, &left_size) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(right, &right_data, &right_size) == EXTRACTPDF_OK);
+    CHECK(left_size == right_size);
+    CHECK(memcmp(left_data, right_data, left_size) == 0);
+}
+
+int main(void)
+{
+    int sentinel = 0;
+    extractpdf_document *composition = NULL;
+    extractpdf_document *text = NULL;
+    extractpdf_document *reopened = NULL;
+    extractpdf_output *output_a = NULL;
+    extractpdf_output *output_b = NULL;
+    extractpdf_output *merged_ab_1 = NULL;
+    extractpdf_output *merged_ab_2 = NULL;
+    extractpdf_output *merged_single = NULL;
+    extractpdf_output *merged_duplicate = NULL;
+    extractpdf_output *reset_output = (extractpdf_output *)&sentinel;
+    int composition_indices[] = {2, 0};
+    int text_indices[] = {0};
+    const extractpdf_output *empty_inputs[] = {NULL};
+    int page_count = 0;
+
+    (void)remove(MERGE_OUTPUT_PDF);
+
+    CHECK(extractpdf_merge_outputs(NULL, 1, &reset_output) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(reset_output == NULL);
+
+    reset_output = (extractpdf_output *)&sentinel;
+    CHECK(extractpdf_merge_outputs(empty_inputs, 0, &reset_output) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(reset_output == NULL);
+
+    CHECK(extractpdf_merge_outputs(empty_inputs, 1, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_open(COMPOSITION_PDF, NULL, &composition) == EXTRACTPDF_OK);
+    CHECK(extractpdf_open(TEXT_PDF, NULL, &text) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_export_pages(
+        composition,
+        composition_indices,
+        sizeof(composition_indices) / sizeof(composition_indices[0]),
+        &output_a) == EXTRACTPDF_OK);
+    CHECK(output_a != NULL);
+
+    CHECK(extractpdf_export_pages(
+        text,
+        text_indices,
+        sizeof(text_indices) / sizeof(text_indices[0]),
+        &output_b) == EXTRACTPDF_OK);
+    CHECK(output_b != NULL);
+
+    extractpdf_close(composition);
+    extractpdf_close(text);
+    composition = NULL;
+    text = NULL;
+
+    {
+        const extractpdf_output *invalid_inputs[] = {output_a, NULL};
+        reset_output = (extractpdf_output *)&sentinel;
+        CHECK(extractpdf_merge_outputs(
+            invalid_inputs,
+            sizeof(invalid_inputs) / sizeof(invalid_inputs[0]),
+            &reset_output) == EXTRACTPDF_ERROR_ARGUMENT);
+        CHECK(reset_output == NULL);
+    }
+
+    {
+        const extractpdf_output *inputs[] = {output_a, output_b};
+        CHECK(extractpdf_merge_outputs(inputs, 2, &merged_ab_1) == EXTRACTPDF_OK);
+        CHECK(extractpdf_merge_outputs(inputs, 2, &merged_ab_2) == EXTRACTPDF_OK);
+        CHECK(merged_ab_1 != NULL);
+        CHECK(merged_ab_2 != NULL);
+        expect_same_bytes(merged_ab_1, merged_ab_2);
+    }
+
+    {
+        const extractpdf_output *inputs[] = {output_a};
+        CHECK(extractpdf_merge_outputs(inputs, 1, &merged_single) == EXTRACTPDF_OK);
+        CHECK(merged_single != NULL);
+    }
+
+    {
+        const extractpdf_output *inputs[] = {output_b, output_a, output_b};
+        CHECK(extractpdf_merge_outputs(inputs, 3, &merged_duplicate) == EXTRACTPDF_OK);
+        CHECK(merged_duplicate != NULL);
+    }
+
+    extractpdf_drop_output(output_a);
+    extractpdf_drop_output(output_b);
+    output_a = NULL;
+    output_b = NULL;
+
+    reopened = open_output(merged_ab_1, MERGE_OUTPUT_PDF);
+    CHECK(extractpdf_page_count(reopened, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 3);
+    expect_page(reopened, 0, "PAGE-C", 1, 300.0f, 150.0f);
+    expect_page(reopened, 1, "PAGE-A", 1, 200.0f, 200.0f);
+    expect_page(reopened, 2, "Hello Caf", 0, 0.0f, 0.0f);
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    reopened = open_output(merged_single, MERGE_OUTPUT_PDF);
+    CHECK(extractpdf_page_count(reopened, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 2);
+    expect_page(reopened, 0, "PAGE-C", 1, 300.0f, 150.0f);
+    expect_page(reopened, 1, "PAGE-A", 1, 200.0f, 200.0f);
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    reopened = open_output(merged_duplicate, MERGE_OUTPUT_PDF);
+    CHECK(extractpdf_page_count(reopened, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 4);
+    expect_page(reopened, 0, "Hello Caf", 0, 0.0f, 0.0f);
+    expect_page(reopened, 1, "PAGE-C", 1, 300.0f, 150.0f);
+    expect_page(reopened, 2, "PAGE-A", 1, 200.0f, 200.0f);
+    expect_page(reopened, 3, "Hello Caf", 0, 0.0f, 0.0f);
+    extractpdf_close(reopened);
+    reopened = NULL;
+
+    extractpdf_drop_output(merged_ab_1);
+    extractpdf_drop_output(merged_ab_2);
+    extractpdf_drop_output(merged_single);
+    extractpdf_drop_output(merged_duplicate);
+    (void)remove(MERGE_OUTPUT_PDF);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 4 PDF Composition architectural slice for #27 / #2, stacked on #25 / PR #26.

## Public ABI

```c
extractpdf_status extractpdf_merge_outputs(
    const extractpdf_output *const *inputs,
    size_t input_count,
    extractpdf_output **out_output);
```

Merge consumes immutable outputs rather than live documents. Each call creates one fresh temporary MuPDF context and one destination PDF; every input is reparsed from memory inside that context and uses its own graft map. The destination is serialized once through the same private deterministic serializer now shared with `extractpdf_export_pages(...)`.

## RED evidence

Exact RED head: `b1bce1d6afd480ef1fbcefecaa915a3b39e0e294`.

Workflow #153 (`33131410945`) built the library and every pre-existing test executable successfully, then failed only on the new merge contract target because `extractpdf_merge_outputs` was absent:
- implicit declaration of `extractpdf_merge_outputs`
- undefined references to `extractpdf_merge_outputs`

## GREEN evidence

Exact GREEN head: `a6d35b6f5d68207cf9c628b2b38c35addb868d82`.

Normal workflow #155 (`33131655616`) completed Linux successfully:
- strict static configure/build ✅
- all normal CTests, including existing export/range/order/delete and new merge ✅
- ASan/UBSan configure/build ✅
- all sanitizer CTests ✅

Architecture-checkpoint `full-ci` workflow #156 (`33131798909`) ran on the same exact GREEN head:
- Linux static configure/build/tests ✅
- Linux ASan/UBSan configure/build/tests ✅
- macOS configure/build/tests ✅
- Windows DLL configure/build/tests ✅

The Windows result proves the new `EXTRACTPDF_API extractpdf_merge_outputs` surface exports, links, and executes through the shared-library build.

## Contract / architecture

- exact input order appends whole input PDFs
- single input valid
- duplicate input pointers valid
- strict all-or-nothing output; no partial success
- output slot reset before failure
- total merged page count guarded against `INT_MAX`
- inputs unchanged and result independent after return
- no live `extractpdf_document` or MuPDF object crosses contexts
- one source-local graft map per input
- one shared deterministic serializer for export + merge

## Preservation boundary

No Phase 5 preservation expansion. Merge keeps the established Phase 4 page-graft boundary (`Contents`, `Resources`, page boxes, `Rotate`, `UserUnit`) and does not promise annotations/links/widgets, metadata, outlines/bookmarks, page labels, named destinations, AcroForm, signatures, encryption, JavaScript, or other document-root state.

## Scope

Relative to PR #26 exact head `18a6c0596b68c1ca7b116624a09e27dcf0ac4a7f`, the diff is exactly 10 files:
- `CMakeLists.txt`
- design spec
- implementation plan
- `include/extractpdf/extractpdf.h`
- `src/pdf_export.c`
- `src/pdf_internal.h`
- `src/pdf_merge.c`
- `src/pdf_output.c`
- `tests/CMakeLists.txt`
- `tests/test_pdf_merge.c`

No unrelated Page/Render/Text/Search/Image/Links implementation changed.

Keep draft and unmerged pending explicit integration.