### PR TITLE
feat: save immutable outputs to UTF-8 paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(extractpdf
   src/pdf_export.c
   src/pdf_output.c
   src/pdf_range.c
-  src/pdf_merge.c)
+  src/pdf_merge.c
+  src/output_file.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/docs/superpowers/plans/2026-08-28-extractpdf-output-save-file.md
+++ b/docs/superpowers/plans/2026-08-28-extractpdf-output-save-file.md
@@ -1,0 +1,744 @@
+# ExtractPDF Immutable Output File Save Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `extractpdf_output_save_file(...)` so an immutable `extractpdf_output` can be written to a UTF-8 filesystem path without moving filename policy into PDF composition.
+
+**Architecture:** The new API is a terminal adapter over the existing immutable `data + size` snapshot. It performs no MuPDF work: Windows strictly converts UTF-8 to UTF-16 before wide-character binary open, while Linux/macOS use the UTF-8 byte path directly; all platforms exact-write, flush, close, and return the existing ExtractPDF status vocabulary.
+
+**Tech Stack:** C11, stdio, Win32 `MultiByteToWideChar` on Windows, CMake 3.20+, CTest, GitHub Actions, Linux ASan/UBSan, Windows DLL build, macOS static build.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-output-save-file-design.md`
+
+## Global Constraints
+
+- Stack on #27 / PR #28 exact GREEN head `a6d35b6f5d68207cf9c628b2b38c35addb868d82`; do not retarget during implementation unless the existing stack is explicitly integrated first.
+- Public ABI is exactly:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename);
+```
+
+- The function is a terminal file adapter only. It must not invoke MuPDF, create an `fz_context`, reparse/reserialize PDF bytes, or alter export/merge composition behavior.
+- `output` is non-consuming and immutable on success and failure. The caller continues to own it until `extractpdf_drop_output(...)`.
+- `output == NULL`, `filename == NULL`, or `filename[0] == '\0'` returns `EXTRACTPDF_ERROR_ARGUMENT`.
+- Windows public paths are strict UTF-8: invalid UTF-8 returns `EXTRACTPDF_ERROR_ARGUMENT`; temporary UTF-16 buffer allocation failure returns `EXTRACTPDF_ERROR_NOMEM`.
+- Windows opens with a wide-character binary write path; do not use narrow `fopen()` for public UTF-8 paths.
+- Linux/macOS use `fopen(filename, "wb")` and do not add a cross-platform UTF-8 validator.
+- Missing targets are created; existing targets are truncated and overwritten; parent directories are not created.
+- A successful save requires every `output->size` byte to be written, `fflush(...) == 0`, and `fclose(...) == 0`.
+- Open/write/flush/close failures return `EXTRACTPDF_ERROR_IO`.
+- V1 is deliberately non-atomic and non-durable: no temp-file/rename transaction, rollback, `fsync`, `fdatasync`, `FlushFileBuffers`, `F_FULLFSYNC`, ACL policy, symlink policy, or power-loss guarantee.
+- On I/O failure the target may be absent, empty, truncated, or partially written; the input `extractpdf_output` remains valid and reusable.
+- Do not change `struct extractpdf_output`, `src/pdf_export.c`, `src/pdf_output.c`, `src/pdf_merge.c`, or any PDF preservation/composition semantics.
+- No callback sink, file-handle API, output options struct, save session, or directory-creation helper belongs in this slice.
+- MuPDF remains pinned to 1.28.2 through the existing vcpkg model; no dependency or workflow-version changes are required.
+- Development is Linux-first. Because this adds a public DLL export and a Windows-specific UTF-8→UTF-16 production path, final acceptance requires Linux normal + ASan/UBSan and then same-head Linux/macOS/Windows `full-ci`.
+- Do not merge PRs without explicit user authorization.
+
+---
+
+## File Structure
+
+```text
+include/extractpdf/extractpdf.h
+    public output-save declaration only
+
+src/output_file.c
+    argument validation
+    platform-specific UTF-8 file open
+    exact byte-write loop
+    flush + close error handling
+    no MuPDF calls
+
+CMakeLists.txt
+    register src/output_file.c
+
+tests/test_output_file.c
+    public save-file contract
+    ASCII exact-byte/truncate proof
+    UTF-8 filename proof
+    deterministic missing-parent I/O failure
+    Windows invalid-UTF-8 proof
+    output ownership preservation
+
+tests/CMakeLists.txt
+    register extractpdf.output_file
+    define build-directory test paths
+    add MSVC /utf-8
+    add Windows DLL copy target
+```
+
+No new PDF fixture is created.
+
+---
+
+### Task 1: Add the strict save-file RED
+
+**Files:**
+- Create: `tests/test_output_file.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: existing `extractpdf_open`, `extractpdf_export_pages`, `extractpdf_output_data`, `extractpdf_drop_output`, `extractpdf_page_count`, `extractpdf_load_page`, `extractpdf_page_bounds`, `extractpdf_extract_text`.
+- Produces: one deterministic CTest `extractpdf.output_file` that specifies the public file-save contract before production code exists.
+
+- [ ] **Step 1: Create `tests/test_output_file.c`**
+
+Use this complete test structure:
+
+```c
+#include <extractpdf/extractpdf.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int write_stale_file(
+    const char *path,
+    const unsigned char *data,
+    size_t size)
+{
+    static const unsigned char stale_tail[] =
+        "THIS-STALE-TRAILING-DATA-MUST-BE-TRUNCATED";
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    if (fwrite(stale_tail, 1, sizeof(stale_tail), file) != sizeof(stale_tail)) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static void expect_exact_file_bytes(
+    const char *path,
+    const unsigned char *expected,
+    size_t expected_size)
+{
+    FILE *file = fopen(path, "rb");
+    unsigned char *actual = NULL;
+    int next;
+
+    CHECK(file != NULL);
+    CHECK(expected_size > 0);
+
+    actual = (unsigned char *)malloc(expected_size);
+    CHECK(actual != NULL);
+    CHECK(fread(actual, 1, expected_size, file) == expected_size);
+    CHECK(memcmp(actual, expected, expected_size) == 0);
+
+    next = fgetc(file);
+    CHECK(next == EOF);
+    CHECK(feof(file) != 0);
+    CHECK(ferror(file) == 0);
+    CHECK(fclose(file) == 0);
+    free(actual);
+}
+
+static void expect_page(
+    extractpdf_document *document,
+    int page_index,
+    const char *needle,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+    CHECK(bounds.x0 == 0.0f);
+    CHECK(bounds.y0 == 0.0f);
+    CHECK(bounds.x1 == width);
+    CHECK(bounds.y1 == height);
+    CHECK(extractpdf_extract_text(page, &text, &text_size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(strstr(text, needle) != NULL);
+
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+}
+
+static void expect_saved_pdf(
+    const char *path,
+    const char *first_text,
+    float first_width,
+    float first_height,
+    const char *second_text,
+    float second_width,
+    float second_height)
+{
+    extractpdf_document *document = NULL;
+    int page_count = 0;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_count(document, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 2);
+    expect_page(document, 0, first_text, first_width, first_height);
+    expect_page(document, 1, second_text, second_width, second_height);
+    extractpdf_close(document);
+}
+
+static void remove_missing_parent_if_empty(void)
+{
+    (void)remove(MISSING_PARENT_PDF);
+#ifdef _WIN32
+    (void)_rmdir(MISSING_PARENT_DIR);
+#else
+    (void)rmdir(MISSING_PARENT_DIR);
+#endif
+}
+
+int main(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_output *output = NULL;
+    const unsigned char *before_data = NULL;
+    const unsigned char *after_data = NULL;
+    size_t before_size = 0;
+    size_t after_size = 0;
+    int indices[] = {2, 0};
+
+    (void)remove(ASCII_OUTPUT_PDF);
+    remove_missing_parent_if_empty();
+
+    CHECK(extractpdf_output_save_file(NULL, ASCII_OUTPUT_PDF) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_open(COMPOSITION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_export_pages(source, indices, 2, &output) == EXTRACTPDF_OK);
+    CHECK(output != NULL);
+    extractpdf_close(source);
+    source = NULL;
+
+    CHECK(extractpdf_output_data(output, &before_data, &before_size) ==
+          EXTRACTPDF_OK);
+    CHECK(before_data != NULL);
+    CHECK(before_size > 0);
+
+    CHECK(extractpdf_output_save_file(output, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_output_save_file(output, "") ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(write_stale_file(ASCII_OUTPUT_PDF, before_data, before_size));
+    CHECK(extractpdf_output_save_file(output, ASCII_OUTPUT_PDF) ==
+          EXTRACTPDF_OK);
+    expect_exact_file_bytes(ASCII_OUTPUT_PDF, before_data, before_size);
+    expect_saved_pdf(
+        ASCII_OUTPUT_PDF,
+        "PAGE-C", 300.0f, 150.0f,
+        "PAGE-A", 200.0f, 200.0f);
+
+    CHECK(extractpdf_output_save_file(output, UTF8_OUTPUT_PDF) ==
+          EXTRACTPDF_OK);
+    expect_saved_pdf(
+        UTF8_OUTPUT_PDF,
+        "PAGE-C", 300.0f, 150.0f,
+        "PAGE-A", 200.0f, 200.0f);
+
+    remove_missing_parent_if_empty();
+    CHECK(extractpdf_output_save_file(output, MISSING_PARENT_PDF) ==
+          EXTRACTPDF_ERROR_IO);
+
+#ifdef _WIN32
+    {
+        const char invalid_utf8[] = { (char)0xC3, (char)0x28, '\0' };
+        CHECK(extractpdf_output_save_file(output, invalid_utf8) ==
+              EXTRACTPDF_ERROR_ARGUMENT);
+    }
+#endif
+
+    CHECK(extractpdf_output_data(output, &after_data, &after_size) ==
+          EXTRACTPDF_OK);
+    CHECK(after_data != NULL);
+    CHECK(after_size == before_size);
+    CHECK(memcmp(after_data, before_data, before_size) == 0);
+
+    extractpdf_drop_output(output);
+    (void)remove(ASCII_OUTPUT_PDF);
+    return EXIT_SUCCESS;
+}
+```
+
+The test deliberately does not use narrow Windows `fopen()` on `UTF8_OUTPUT_PDF`; it verifies that path only through the public UTF-8 `extractpdf_open(...)` API.
+
+The `MISSING_PARENT_DIR` cleanup makes reruns deterministic: if an empty directory from an interrupted local run exists, remove it before requiring the missing-parent save to fail.
+
+- [ ] **Step 2: Register the RED target in `tests/CMakeLists.txt`**
+
+Add immediately after `extractpdf.pdf_merge`:
+
+```cmake
+set(OUTPUT_FILE_ASCII "${CMAKE_CURRENT_BINARY_DIR}/composition-save-output.pdf")
+set(OUTPUT_FILE_UTF8 "${CMAKE_CURRENT_BINARY_DIR}/composition-save-测试.pdf")
+set(OUTPUT_FILE_MISSING_PARENT_DIR
+  "${CMAKE_CURRENT_BINARY_DIR}/extractpdf-save-missing-parent")
+set(OUTPUT_FILE_MISSING_PARENT
+  "${OUTPUT_FILE_MISSING_PARENT_DIR}/output.pdf")
+
+add_executable(extractpdf_test_output_file test_output_file.c)
+target_link_libraries(extractpdf_test_output_file PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_output_file PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  ASCII_OUTPUT_PDF="${OUTPUT_FILE_ASCII}"
+  UTF8_OUTPUT_PDF="${OUTPUT_FILE_UTF8}"
+  MISSING_PARENT_DIR="${OUTPUT_FILE_MISSING_PARENT_DIR}"
+  MISSING_PARENT_PDF="${OUTPUT_FILE_MISSING_PARENT}")
+if(MSVC)
+  target_compile_options(extractpdf_test_output_file PRIVATE /utf-8)
+endif()
+add_test(NAME extractpdf.output_file COMMAND extractpdf_test_output_file)
+set_tests_properties(extractpdf.output_file PROPERTIES TIMEOUT 30)
+```
+
+Also append `extractpdf_test_output_file` to the existing `if(WIN32 AND BUILD_SHARED_LIBS)` target list so `extractpdf.dll` is copied beside the new test executable.
+
+- [ ] **Step 3: Commit the test-only RED**
+
+```bash
+git add tests/test_output_file.c tests/CMakeLists.txt
+git commit -m "test: define immutable output file save contract"
+```
+
+Do not add the public declaration, root CMake source registration, or `src/output_file.c` in this commit.
+
+Record the exact commit SHA returned by the commit. This is the RED SHA for all later evidence.
+
+- [ ] **Step 4: Open the draft stacked PR**
+
+Create a draft PR with:
+
+```text
+base: feat/pdf-merge-outputs
+head: feat/output-save-file
+draft: true
+tracks: #29 / #2
+```
+
+The body must state that the exact current head is intentional RED and that `extractpdf_output_save_file(...)` is not declared or implemented yet. Record the numeric PR number returned by GitHub and reuse that same PR throughout the remainder of the plan.
+
+- [ ] **Step 5: Verify the RED is exactly the missing public save symbol**
+
+Use the PR-triggered workflow on the exact RED SHA.
+
+Expected Linux boundary:
+
+```text
+pinned MuPDF install                ✅
+configure                           ✅
+libextractpdf.a                     ✅
+all pre-existing test targets       ✅
+extractpdf_test_output_file         fails only because
+                                    extractpdf_output_save_file is absent
+```
+
+Expected diagnostic class:
+
+```text
+implicit declaration of function 'extractpdf_output_save_file'
+undefined reference to 'extractpdf_output_save_file'
+```
+
+If any existing test target fails, or the new test fails for fixture/path/test-code reasons, fix the RED before adding production code. The intended RED must be exact.
+
+---
+
+### Task 2: Implement the platform-aware terminal file adapter and turn RED GREEN
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Create: `src/output_file.c`
+- Modify: `CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: private `struct extractpdf_output { unsigned char *data; size_t size; }` from `src/internal.h`.
+- Produces: public non-consuming `extractpdf_output_save_file(...)` with strict UTF-8 Windows path handling and exact stdio completion semantics.
+
+- [ ] **Step 1: Add the public declaration**
+
+In `include/extractpdf/extractpdf.h`, place the declaration after `extractpdf_output_data(...)` and before unrelated page APIs:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename);
+```
+
+Do not add a new status code, options struct, callback, public file handle, or Windows type.
+
+- [ ] **Step 2: Create `src/output_file.c` with platform-specific open logic**
+
+Create:
+
+```c
+#include "internal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <stdint.h>
+#include <windows.h>
+#include <wchar.h>
+#endif
+
+static extractpdf_status extractpdf_open_output_file(
+    const char *filename,
+    FILE **out_file)
+{
+    *out_file = NULL;
+
+#ifdef _WIN32
+    {
+        wchar_t *wide_filename = NULL;
+        int wide_count;
+        int converted;
+        errno_t open_error;
+
+        wide_count = MultiByteToWideChar(
+            CP_UTF8,
+            MB_ERR_INVALID_CHARS,
+            filename,
+            -1,
+            NULL,
+            0);
+        if (wide_count <= 0)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        if ((size_t)wide_count > SIZE_MAX / sizeof(*wide_filename))
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        wide_filename = (wchar_t *)malloc(
+            (size_t)wide_count * sizeof(*wide_filename));
+        if (wide_filename == NULL)
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        converted = MultiByteToWideChar(
+            CP_UTF8,
+            MB_ERR_INVALID_CHARS,
+            filename,
+            -1,
+            wide_filename,
+            wide_count);
+        if (converted <= 0) {
+            free(wide_filename);
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        }
+
+        open_error = _wfopen_s(out_file, wide_filename, L"wb");
+        free(wide_filename);
+
+        if (open_error != 0 || *out_file == NULL)
+            return EXTRACTPDF_ERROR_IO;
+    }
+#else
+    *out_file = fopen(filename, "wb");
+    if (*out_file == NULL)
+        return EXTRACTPDF_ERROR_IO;
+#endif
+
+    return EXTRACTPDF_OK;
+}
+```
+
+The file may include `internal.h` to access the private output snapshot. It must not include MuPDF headers directly and must not call any MuPDF API.
+
+- [ ] **Step 3: Implement exact-write, flush, and close semantics in the same file**
+
+Append:
+
+```c
+extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename)
+{
+    FILE *file = NULL;
+    extractpdf_status status;
+    size_t offset = 0;
+
+    if (output == NULL || filename == NULL || filename[0] == '\0')
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_open_output_file(filename, &file);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    while (offset < output->size) {
+        size_t written = fwrite(
+            output->data + offset,
+            1,
+            output->size - offset,
+            file);
+
+        if (written == 0) {
+            status = EXTRACTPDF_ERROR_IO;
+            break;
+        }
+        offset += written;
+    }
+
+    if (status == EXTRACTPDF_OK && fflush(file) != 0)
+        status = EXTRACTPDF_ERROR_IO;
+
+    if (fclose(file) != 0 && status == EXTRACTPDF_OK)
+        status = EXTRACTPDF_ERROR_IO;
+
+    return status;
+}
+```
+
+Do not delete a partial target on failure. Do not retry by reopening. Do not call `fsync`, `FlushFileBuffers`, rename, or create parent directories.
+
+The private output invariant already guarantees a non-empty complete PDF snapshot for library-created outputs, so do not add new public validation for `output->data` or `output->size`.
+
+- [ ] **Step 4: Register `src/output_file.c` in root `CMakeLists.txt`**
+
+Keep the source grouping focused. Add the terminal adapter after the PDF composition sources, for example:
+
+```cmake
+  src/pdf_export.c
+  src/pdf_output.c
+  src/pdf_range.c
+  src/pdf_merge.c
+  src/output_file.c)
+```
+
+Do not edit `.github/workflows/ci.yml`, vcpkg files, or unrelated source lists.
+
+- [ ] **Step 5: Build and run only the new contract test first**
+
+Use the same Linux dependency configuration as CI:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build --target extractpdf_test_output_file --parallel 2
+ctest --test-dir build -R '^extractpdf\.output_file$' --output-on-failure
+```
+
+Expected: `extractpdf.output_file` passes the ASCII exact-byte/truncate, UTF-8 filename, missing-parent I/O, and output-lifetime cases.
+
+- [ ] **Step 6: Run all normal Linux tests**
+
+```bash
+cmake --build build --parallel 2
+ctest --test-dir build --output-on-failure
+```
+
+Expected: every existing test remains green, including all PDF composition tests and the new output-file test.
+
+- [ ] **Step 7: Run Linux ASan/UBSan from a fresh build directory**
+
+```bash
+cmake -S . -B build-asan \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+cmake --build build-asan --parallel 2
+ctest --test-dir build-asan --output-on-failure
+```
+
+Expected: all sanitizer CTests pass with no sanitizer diagnostics.
+
+- [ ] **Step 8: Commit the GREEN implementation**
+
+```bash
+git add \
+  include/extractpdf/extractpdf.h \
+  src/output_file.c \
+  CMakeLists.txt
+git commit -m "feat: save immutable outputs to UTF-8 paths"
+```
+
+Record the exact commit SHA returned by this commit as the GREEN SHA.
+
+Preserve the useful TDD history:
+
+```text
+spec
+plan
+RED contract test
+GREEN terminal adapter
+```
+
+Do not squash during normal feature execution.
+
+---
+
+### Task 3: Exact-head cross-platform verification and Phase 4 roadmap closure
+
+**Files:**
+- No source/test changes expected.
+- Update the draft Save PR, issue #29, and umbrella #2 only after exact-head verification succeeds.
+
+**Interfaces:**
+- Consumes: exact GREEN SHA from Task 2.
+- Produces: auditable Linux normal/sanitizer proof plus same-head Linux/macOS/Windows `full-ci`, with Phase 4 marked complete but all stacked PRs still unmerged.
+
+- [ ] **Step 1: Verify the final feature scope before trusting CI**
+
+Compare PR #28 exact base `a6d35b6f5d68207cf9c628b2b38c35addb868d82` to the GREEN SHA.
+
+The save slice must add only:
+
+```text
+docs/superpowers/specs/2026-08-28-extractpdf-output-save-file-design.md
+docs/superpowers/plans/2026-08-28-extractpdf-output-save-file.md
+include/extractpdf/extractpdf.h
+src/output_file.c
+CMakeLists.txt
+tests/test_output_file.c
+tests/CMakeLists.txt
+```
+
+Any change to `src/pdf_export.c`, `src/pdf_output.c`, `src/pdf_merge.c`, `src/internal.h`, vcpkg files, CI workflow files, or unrelated modules is a scope blocker and must be removed before final verification.
+
+Also confirm the draft Save PR remains:
+
+```text
+base ref: feat/pdf-merge-outputs
+base sha: a6d35b6f5d68207cf9c628b2b38c35addb868d82
+head ref: feat/output-save-file
+head sha: exact GREEN SHA
+draft: true
+merged: false
+```
+
+- [ ] **Step 2: Verify the exact GREEN SHA's normal PR workflow**
+
+Read the workflow run attached to the GREEN SHA and require Linux success for:
+
+```text
+Configure static build                ✅
+Build static library and tests        ✅
+Test static build                     ✅
+Configure sanitizer build             ✅
+Build sanitizer configuration         ✅
+Test sanitizer configuration          ✅
+```
+
+The normal pull-request run may skip macOS/Windows. Do not mark Phase 4 complete yet.
+
+- [ ] **Step 3: Update the draft PR body with RED/GREEN evidence**
+
+Record:
+
+```text
+public ABI
+RED exact SHA + workflow number/run id + missing-symbol boundary
+GREEN exact SHA + workflow number/run id + Linux normal/sanitizer success
+non-consuming ownership
+ASCII exact-byte/truncate proof
+UTF-8 path proof
+missing-parent IO proof
+Windows strict UTF-8 contract
+non-atomic/non-durable boundary
+exact file scope
+```
+
+Keep the PR draft and unmerged.
+
+- [ ] **Step 4: Apply the existing `full-ci` label without changing the head**
+
+Use the existing PR label. Do not edit `.github/workflows/ci.yml`.
+
+The resulting run must use the same exact GREEN SHA from Step 2.
+
+- [ ] **Step 5: Verify same-head Linux/macOS/Windows acceptance**
+
+Require:
+
+```text
+Linux:
+  static configure/build/tests             ✅
+  ASan/UBSan configure/build/tests          ✅
+
+macOS:
+  configure/build/tests                     ✅
+  UTF-8 save/reopen test                    ✅
+
+Windows:
+  DLL configure/build/tests                 ✅
+  extractpdf_output_save_file exported      ✅
+  UTF-8 filename save/reopen                ✅
+  invalid UTF-8 -> ARGUMENT                 ✅
+```
+
+The Windows CTest result is the evidence for both DLL export/link behavior and the platform-specific UTF-8 conversion branch.
+
+If any platform fails, invoke `superpowers:systematic-debugging`, identify the root cause, add the smallest necessary regression/fix, and repeat Linux + same-head full-ci on the new exact SHA.
+
+- [ ] **Step 6: Update issue #29 with final implementation evidence**
+
+Keep #29 open only for stacked integration bookkeeping. Record:
+
+```text
+implementation PR number
+RED SHA/workflow evidence
+GREEN SHA/Linux workflow evidence
+same-head full-ci workflow evidence
+final seven-file save-slice scope
+ownership/error/file semantics
+Windows UTF-8 behavior
+non-atomic/durability boundary
+```
+
+Do not close #29 while its stacked implementation PR remains unintegrated.
+
+- [ ] **Step 7: Close the Phase 4 checklist in umbrella #2**
+
+Only after same-head full-ci succeeds, change:
+
+```text
+[ ] Save/write with explicit ownership and error handling
+```
+
+to a checked line referencing `#29` and the exact numeric implementation PR number returned in Task 1.
+
+Add one concise Phase 4 save/write proof paragraph containing the exact GREEN SHA, Linux workflow evidence, and same-head full-ci evidence.
+
+Then label Phase 4 PDF Composition complete in prose. Leave Phase 5 and Phase 6 untouched/open, and leave the umbrella issue itself open.
+
+- [ ] **Step 8: Final completion gate**
+
+Freshly verify all four conditions:
+
+1. Save PR is open, draft, unmerged, based on `feat/pdf-merge-outputs`, with head exactly equal to GREEN SHA.
+2. Same-head full-ci jobs are all successful on Linux/macOS/Windows.
+3. Compare against PR #28 exact base contains only the seven scoped files listed in Step 1.
+4. #29 and #2 contain evidence matching the exact GREEN SHA; Phase 4 save/write is checked, while Phase 5/6 and stacked integration remain open.
+
+Only then report the Save/write implementation and Phase 4 feature roadmap complete. Do not merge PR #20/#22/#24/#26/#28 or the Save PR without explicit authorization.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-output-save-file-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-output-save-file-design.md
@@ -1,0 +1,717 @@
+# ExtractPDF Immutable Output File Save Design
+
+Date: 2026-08-28  
+Status: approved design  
+Tracks: #29, umbrella #2  
+Stacked base: #27 / PR #28 head `a6d35b6f5d68207cf9c628b2b38c35addb868d82`  
+Branch: `feat/output-save-file`
+
+## Goal
+
+Close the remaining Phase 4 PDF Composition `Save/write with explicit ownership and error handling` item without moving filenames into the composition engine.
+
+ExtractPDF already materializes every composition result as an immutable, ExtractPDF-owned `extractpdf_output` byte snapshot. V1 adds one optional terminal adapter that writes those already-materialized bytes to a filesystem path:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename);
+```
+
+The adapter is deliberately downstream of composition:
+
+```text
+source document(s)
+        |
+        v
+export / range / reorder / delete / duplicate / merge
+        |
+        v
+immutable extractpdf_output
+        |
+        +--> extractpdf_output_data(...)      borrowed bytes
+        |
+        +--> extractpdf_output_save_file(...) optional terminal adapter
+        |
+        v
+extractpdf_drop_output(...)
+```
+
+No export, range, delete, duplicate, or merge API gains a filename parameter.
+
+## Architectural decision
+
+V1 chooses a **file-save adapter on `extractpdf_output`** rather than a callback sink or a new composition-to-file path.
+
+Three approaches were considered.
+
+### 1. Output file adapter — selected
+
+```c
+extractpdf_output_save_file(output, filename);
+```
+
+Benefits:
+
+- composition remains memory-backed and filename-free;
+- the adapter consumes the exact immutable bytes already exposed by `extractpdf_output_data(...)`;
+- no second PDF writer, MuPDF context, or composition path is introduced;
+- C callers and .NET/PInvoke callers receive a simple status-based terminal operation;
+- the existing UTF-8 public path contract can be preserved explicitly;
+- ownership remains trivial because the output is not consumed.
+
+### 2. Generic write callback — rejected for V1
+
+A callback shape could write to files, sockets, streams, or custom storage, but would create a larger stable ABI contract around:
+
+- callback lifetime;
+- short writes;
+- callback failures;
+- reentrancy;
+- thread behavior;
+- user-data lifetime;
+- .NET delegate pinning/marshalling.
+
+The current output is already fully materialized in memory, so that complexity does not buy a meaningful V1 capability.
+
+### 3. No save API — rejected for roadmap closure
+
+Callers can already use `extractpdf_output_data(...)` and perform their own file I/O. Keeping only that surface would preserve the smallest possible ABI, but the library would still lack a common UTF-8 filesystem/error contract for the Phase 4 `Save/write` roadmap item.
+
+The selected adapter adds that terminal contract without changing composition semantics.
+
+## Public ABI
+
+The only new public declaration is:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename);
+```
+
+It belongs beside the existing `extractpdf_output_data(...)` lifecycle surface.
+
+No public struct, options object, callback type, file handle, MuPDF type, or save-session handle is introduced.
+
+## Terminal-adapter boundary
+
+`extractpdf_output_save_file(...)` is **not** a PDF composition primitive and is **not** a PDF serialization primitive.
+
+By the time it is called, `extractpdf_output` already contains the complete final PDF file image:
+
+```text
+struct extractpdf_output   // private
+    unsigned char *data
+    size_t size
+```
+
+The adapter only transfers those bytes to host filesystem storage.
+
+It must not:
+
+- call `pdf_write_document`;
+- create an `fz_context`;
+- open/reparse the PDF through MuPDF;
+- modify PDF contents;
+- regenerate document IDs;
+- change deterministic serialization options;
+- consume or replace the output object;
+- retain the filename after return.
+
+Therefore the adapter cannot alter page order, preservation policy, PDF metadata, or byte determinism established by the composition engine.
+
+## Ownership and lifetime
+
+The save operation is **non-consuming** on both success and failure.
+
+A valid call sequence is:
+
+```c
+extractpdf_output *output = NULL;
+
+/* produce output through export/merge */
+
+extractpdf_output_save_file(output, "first.pdf");
+extractpdf_output_save_file(output, "second.pdf");
+extractpdf_output_data(output, &data, &size);
+extractpdf_output_save_file(output, "third.pdf");
+extractpdf_drop_output(output);
+```
+
+The caller still owns the same `extractpdf_output` until `extractpdf_drop_output(...)`.
+
+`extractpdf_output_save_file(...)` never:
+
+- frees `output`;
+- frees or replaces `output->data`;
+- modifies `output->size`;
+- retains a borrowed pointer to the output;
+- creates another public handle.
+
+A failed save leaves the immutable output usable for another save, `extractpdf_output_data(...)`, or final drop.
+
+## Argument contract
+
+Return `EXTRACTPDF_ERROR_ARGUMENT` when:
+
+- `output == NULL`;
+- `filename == NULL`;
+- `filename[0] == '\0'`;
+- on Windows, `filename` is not valid UTF-8 under strict conversion.
+
+A non-NULL `extractpdf_output *` is treated according to the existing opaque-handle invariant. V1 does not expose private output fields or add a second public output-validity contract.
+
+## UTF-8 path contract
+
+All public ExtractPDF paths are UTF-8. The save adapter must preserve that contract explicitly on every supported platform.
+
+### Windows
+
+Do not pass the public UTF-8 string to narrow `fopen()` or `_fsopen()` and therefore do not depend on the active ANSI code page.
+
+The intended conversion is:
+
+```text
+UTF-8 filename
+      |
+      v
+MultiByteToWideChar(
+    CP_UTF8,
+    MB_ERR_INVALID_CHARS,
+    filename,
+    -1,
+    NULL,
+    0)
+      |
+      v
+allocate wchar_t buffer
+      |
+      v
+MultiByteToWideChar(... actual buffer ...)
+      |
+      v
+UTF-16 filename
+      |
+      v
+_wfopen_s(..., L"wb")
+```
+
+The first `MultiByteToWideChar` call determines the required UTF-16 character count including the terminator because the source length is `-1`.
+
+If strict UTF-8 conversion fails, return `EXTRACTPDF_ERROR_ARGUMENT`.
+
+If allocating the UTF-16 path buffer fails, return `EXTRACTPDF_ERROR_NOMEM`.
+
+The UTF-16 buffer is private temporary memory and is freed before return on every path.
+
+### Linux and macOS
+
+Use the public UTF-8 byte path directly with the host binary stdio open path:
+
+```c
+fopen(filename, "wb")
+```
+
+No locale-dependent conversion layer is introduced by ExtractPDF.
+
+The library does not attempt path normalization or reinterpret UTF-8 bytes beyond the platform rules already implied by the existing public path contract.
+
+## File creation and overwrite semantics
+
+The file is opened for binary write using ordinary truncate/create semantics:
+
+```text
+missing target
+    -> create
+
+existing regular file
+    -> truncate then write
+```
+
+V1 does not append.
+
+V1 does not automatically create missing parent directories.
+
+If the parent path does not exist or the target cannot be opened for writing, return `EXTRACTPDF_ERROR_IO`.
+
+## Exact-write requirement
+
+A successful save means **all** `output->size` bytes were accepted by stdio.
+
+The implementation must not assume one `fwrite` call always writes the complete output.
+
+Conceptually:
+
+```text
+offset = 0
+
+while offset < output->size:
+    written = fwrite(output->data + offset, 1, output->size - offset, file)
+
+    if written == 0:
+        fail with IO
+
+    offset += written
+```
+
+A positive short write is followed by another write attempt.
+
+A zero-byte write before the requested total is reached is an I/O failure. The implementation may consult `ferror(file)` for diagnostics/control, but the public status remains `EXTRACTPDF_ERROR_IO`.
+
+Because composition outputs are currently required to contain a non-empty complete PDF image, V1 does not add an empty-output special case.
+
+## Flush and close semantics
+
+`EXTRACTPDF_OK` is returned only after all three stages succeed:
+
+```text
+1. exact byte write
+2. fflush(file) succeeds
+3. fclose(file) succeeds
+```
+
+If exact writing succeeds but `fflush` fails, return `EXTRACTPDF_ERROR_IO`.
+
+The opened stream must still be closed after a write or flush failure. A save that already has an I/O failure remains `EXTRACTPDF_ERROR_IO` regardless of the close result.
+
+If writing and flushing succeed but `fclose` reports failure, return `EXTRACTPDF_ERROR_IO`.
+
+This makes close-time writeback errors observable rather than silently treating them as success.
+
+## What `EXTRACTPDF_OK` does not mean
+
+The success contract is deliberately limited to stdio completion:
+
+```text
+all bytes written
++ fflush succeeded
++ fclose succeeded
+```
+
+V1 does **not** promise:
+
+- `fsync`;
+- `fdatasync`;
+- Windows `FlushFileBuffers`;
+- macOS `F_FULLFSYNC`;
+- power-loss durability;
+- atomic replacement;
+- rollback after partial failure;
+- preservation of an old target if writing the replacement fails.
+
+Those are separate filesystem/durability policies and would require a different API contract.
+
+## Non-atomic failure semantics
+
+The V1 file adapter is intentionally not transactional.
+
+After an I/O failure, the target path may be:
+
+- absent;
+- newly created but empty;
+- truncated;
+- partially written.
+
+The adapter does not restore a previous target and does not remove a partial output automatically.
+
+This behavior is explicit so callers requiring atomic-replace semantics can implement an application-level temporary-file/rename policy without ExtractPDF pretending to provide guarantees it does not actually enforce.
+
+The input `extractpdf_output`, however, remains unchanged and reusable regardless of filesystem failure.
+
+## Error mapping
+
+The public mapping is:
+
+```text
+output == NULL                         -> EXTRACTPDF_ERROR_ARGUMENT
+filename == NULL                       -> EXTRACTPDF_ERROR_ARGUMENT
+filename == ""                         -> EXTRACTPDF_ERROR_ARGUMENT
+invalid UTF-8 path on Windows          -> EXTRACTPDF_ERROR_ARGUMENT
+Windows UTF-16 path allocation failure -> EXTRACTPDF_ERROR_NOMEM
+file open failure                      -> EXTRACTPDF_ERROR_IO
+short/failed write that cannot finish  -> EXTRACTPDF_ERROR_IO
+fflush failure                         -> EXTRACTPDF_ERROR_IO
+fclose failure                         -> EXTRACTPDF_ERROR_IO
+otherwise                              -> EXTRACTPDF_OK
+```
+
+No new status enum is introduced.
+
+No OS error code or `errno` value becomes part of the stable ABI in this slice.
+
+## Filesystem policy deliberately left to the host
+
+The adapter does not define special behavior for:
+
+- symlinks;
+- hard links;
+- ACLs;
+- inherited permissions;
+- file ownership;
+- network filesystems;
+- antivirus/file-lock interactions;
+- path canonicalization;
+- case sensitivity;
+- reserved Windows filenames;
+- maximum path policy beyond the selected CRT/Windows APIs.
+
+Those conditions either succeed according to the host or return `EXTRACTPDF_ERROR_IO` through the ordinary open/write/flush/close path.
+
+## Production responsibility split
+
+The expected implementation boundary is intentionally narrow:
+
+```text
+include/extractpdf/extractpdf.h
+    add extractpdf_output_save_file declaration
+
+src/output_file.c
+    validate arguments
+    perform platform-specific UTF-8 file open
+    exact write loop
+    flush
+    close
+    return ExtractPDF status
+
+CMakeLists.txt
+    register src/output_file.c
+```
+
+The new production file must not include MuPDF headers directly and must not call MuPDF APIs.
+
+No changes are expected in:
+
+```text
+src/pdf_export.c
+src/pdf_output.c
+src/pdf_merge.c
+src/pdf_range.c
+src/internal.h output layout
+```
+
+The private `extractpdf_output` definition remains exactly the current `data + size` snapshot.
+
+## Windows implementation boundary
+
+`src/output_file.c` may use compile-time platform branching:
+
+```c
+#ifdef _WIN32
+    /* strict UTF-8 -> UTF-16 + _wfopen_s */
+#else
+    /* fopen(filename, "wb") */
+#endif
+```
+
+Windows-only includes and helpers remain inside this terminal I/O implementation rather than creating a general platform subsystem before another feature needs one.
+
+No public Windows types appear in `extractpdf.h`.
+
+## Deterministic test strategy
+
+Add one focused test executable:
+
+```text
+extractpdf_test_output_file
+CTest: extractpdf.output_file
+```
+
+Reuse the existing deterministic fixture:
+
+```text
+tests/fixtures/composition-three-page.pdf
+
+page 0: PAGE-A, 200 x 200 pt
+page 1: PAGE-B, 240 x 180 pt
+page 2: PAGE-C, 300 x 150 pt
+```
+
+Create the test output through the public composition API:
+
+```c
+int indices[] = {2, 0};
+extractpdf_export_pages(document, indices, 2, &output);
+```
+
+Expected immutable output semantics are:
+
+```text
+PAGE-C, 300 x 150
+PAGE-A, 200 x 200
+```
+
+No new binary PDF fixture is required.
+
+## ASCII exact-byte and overwrite proof
+
+Use a build-directory target such as:
+
+```text
+composition-save-output.pdf
+```
+
+Before calling the save adapter, the test writes stale content that is longer than the final target representation, for example the current output bytes followed by an extra stale tail.
+
+Then call:
+
+```c
+extractpdf_output_save_file(output, ASCII_OUTPUT_PDF);
+```
+
+The test reads the ASCII target with ordinary test-side binary stdio and requires:
+
+```text
+on-disk size == output size
+on-disk bytes == extractpdf_output_data(...) bytes byte-for-byte
+```
+
+This proves both:
+
+- existing-file truncation removes stale trailing bytes;
+- the save adapter transfers the exact immutable snapshot rather than reserializing or altering it.
+
+Reopen the saved file through `extractpdf_open(...)` and verify:
+
+```text
+page_count = 2
+page 0 = PAGE-C, 300 x 150
+page 1 = PAGE-A, 200 x 200
+```
+
+## UTF-8 filename proof
+
+Use a separate build-directory filename containing non-ASCII UTF-8 text, for example:
+
+```text
+composition-save-测试.pdf
+```
+
+Call:
+
+```c
+extractpdf_output_save_file(output, UTF8_OUTPUT_PDF);
+```
+
+Do not use narrow Windows test-side `fopen()` to inspect this path, because that would make the test depend on the active ANSI code page.
+
+Instead reopen the result through the existing public UTF-8 path API:
+
+```c
+extractpdf_open(UTF8_OUTPUT_PDF, NULL, &saved_document);
+```
+
+Then verify the same two pages and geometry.
+
+On MSVC, compile the new test target with `/utf-8`, matching the existing `extractpdf.document` UTF-8 path test precedent.
+
+## Stable I/O failure proof
+
+Do not use file permissions to manufacture an I/O error; elevated CI users and platform permission behavior make such tests unreliable.
+
+Use a deterministic path whose parent directory is intentionally absent, for example:
+
+```text
+<build>/extractpdf-save-missing-parent/output.pdf
+```
+
+The test does not create that parent directory.
+
+Calling:
+
+```c
+extractpdf_output_save_file(output, MISSING_PARENT_PDF);
+```
+
+must return:
+
+```text
+EXTRACTPDF_ERROR_IO
+```
+
+The save adapter must not create the parent directory.
+
+A clean CI build directory makes this failure deterministic across Linux, macOS, and Windows.
+
+## Windows invalid-UTF-8 proof
+
+Under `_WIN32`, add a platform-specific path contract case using an invalid UTF-8 sequence, for example:
+
+```c
+const char invalid_utf8[] = { (char)0xC3, (char)0x28, '\0' };
+```
+
+Calling:
+
+```c
+extractpdf_output_save_file(output, invalid_utf8);
+```
+
+must return:
+
+```text
+EXTRACTPDF_ERROR_ARGUMENT
+```
+
+This directly proves `MB_ERR_INVALID_CHARS` behavior and prevents a regression to ANSI/narrow-path opening.
+
+No corresponding invalid-byte test is required on POSIX/macOS because this API defines the public string encoding as UTF-8 but deliberately passes the byte path through to the host rather than adding a cross-platform Unicode validator.
+
+## Ownership preservation proof
+
+The same output is reused through success and failure:
+
+```text
+create output
+    |
+    +--> save ASCII path -> OK
+    |
+    +--> save UTF-8 path -> OK
+    |
+    +--> save missing-parent path -> IO
+    |
+    +--> Windows invalid UTF-8 -> ARGUMENT
+    |
+    v
+extractpdf_output_data(output, ...)
+```
+
+Before the save calls, copy the original output bytes into test-owned memory.
+
+After all success/failure cases, require the current output size and bytes to match that snapshot exactly.
+
+This proves the terminal adapter does not consume or mutate its input on either success or failure.
+
+Finally drop the output exactly once through `extractpdf_drop_output(...)`.
+
+## Argument tests
+
+Required tests include:
+
+```text
+extractpdf_output_save_file(NULL, valid_path)
+    -> EXTRACTPDF_ERROR_ARGUMENT
+
+extractpdf_output_save_file(output, NULL)
+    -> EXTRACTPDF_ERROR_ARGUMENT
+
+extractpdf_output_save_file(output, "")
+    -> EXTRACTPDF_ERROR_ARGUMENT
+```
+
+No public output slot needs resetting because this function returns no handle or borrowed pointer.
+
+## TDD boundary
+
+This slice introduces real behavior and therefore requires a real RED.
+
+The first RED commit is test-only:
+
+```text
+tests/test_output_file.c
+tests/CMakeLists.txt
+```
+
+It must not add the public declaration or production implementation.
+
+Expected exact RED:
+
+- existing library source builds;
+- all pre-existing test executables build;
+- only `extractpdf_test_output_file` fails because `extractpdf_output_save_file` is absent;
+- no fixture, encoding, or unrelated regression is accepted as the RED boundary.
+
+The minimal GREEN then adds only:
+
+```text
+include/extractpdf/extractpdf.h
+src/output_file.c
+CMakeLists.txt
+```
+
+No composition-source refactor is expected.
+
+## CI policy
+
+Development remains Linux-first.
+
+Required sequence:
+
+```text
+RED exact head
+    -> only missing save-file API boundary
+
+GREEN exact head
+    -> Linux strict static build + all normal CTests
+    -> Linux ASan/UBSan build + all CTests
+
+same exact GREEN head + full-ci label
+    -> Linux static + sanitizers
+    -> macOS configure/build/test
+    -> Windows DLL configure/build/test
+```
+
+The cross-platform checkpoint is mandatory for this slice because:
+
+- `src/output_file.c` contains a dedicated Windows UTF-8 -> UTF-16 production path;
+- the new function is a public `EXTRACTPDF_API` DLL export;
+- the UTF-8 filename test must execute successfully on Windows, not merely compile.
+
+No success claim may reuse CI evidence from an earlier head.
+
+## Phase 4 closure rule
+
+After the implementation has a true RED, Linux GREEN, and same-head Linux/macOS/Windows full-ci evidence, the umbrella Phase 4 checklist may mark:
+
+```text
+[x] Save/write with explicit ownership and error handling
+```
+
+At that point every currently defined Phase 4 composition roadmap item is behavior/evidence complete.
+
+This does **not** authorize merging the stacked PR chain. The Save/write PR remains stacked on PR #28 and draft/unmerged until an explicit integration decision.
+
+## Expected stacked strategy
+
+The slice starts from the exact proven Merge head:
+
+```text
+master
+  |
+  +-- feat/pdf-export-pages       PR #20
+        |
+        +-- feat/pdf-export-range PR #22
+              |
+              +-- test/pdf-order-contract  PR #24
+                    |
+                    +-- test/pdf-delete-contract PR #26
+                          |
+                          +-- feat/pdf-merge-outputs PR #28
+                                |
+                                +-- feat/output-save-file #29 / future PR
+```
+
+The future Save/write PR base is `feat/pdf-merge-outputs` while PR #28 remains unmerged.
+
+## Non-goals
+
+This slice does not add:
+
+- filename parameters to export/merge APIs;
+- direct document-to-file composition;
+- callback/stream writer ABI;
+- output list/batch saving;
+- automatic parent-directory creation;
+- temporary-file management;
+- atomic replacement;
+- rollback of partially written files;
+- `fsync`/`fdatasync`/`FlushFileBuffers` durability;
+- append mode;
+- file permission/ACL options;
+- symlink policy;
+- path normalization/canonicalization API;
+- MuPDF-backed file output;
+- new PDF serialization options;
+- new output ownership semantics;
+- Phase 5 interactive preservation;
+- new concurrency guarantees.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -150,6 +150,10 @@ EXTRACTPDF_API extractpdf_status extractpdf_output_data(
     const unsigned char **out_data,
     size_t *out_size);
 
+EXTRACTPDF_API extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename);
+
 EXTRACTPDF_API extractpdf_status extractpdf_load_page(
     extractpdf_document *document,
     int page_index,

--- a/src/output_file.c
+++ b/src/output_file.c
@@ -1,0 +1,106 @@
+#include "internal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <stdint.h>
+#include <windows.h>
+#include <wchar.h>
+#endif
+
+static extractpdf_status extractpdf_open_output_file(
+    const char *filename,
+    FILE **out_file)
+{
+    *out_file = NULL;
+
+#ifdef _WIN32
+    {
+        wchar_t *wide_filename = NULL;
+        int wide_count;
+        int converted;
+        errno_t open_error;
+
+        wide_count = MultiByteToWideChar(
+            CP_UTF8,
+            MB_ERR_INVALID_CHARS,
+            filename,
+            -1,
+            NULL,
+            0);
+        if (wide_count <= 0)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        if ((size_t)wide_count > SIZE_MAX / sizeof(*wide_filename))
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        wide_filename = (wchar_t *)malloc(
+            (size_t)wide_count * sizeof(*wide_filename));
+        if (wide_filename == NULL)
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        converted = MultiByteToWideChar(
+            CP_UTF8,
+            MB_ERR_INVALID_CHARS,
+            filename,
+            -1,
+            wide_filename,
+            wide_count);
+        if (converted <= 0) {
+            free(wide_filename);
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        }
+
+        open_error = _wfopen_s(out_file, wide_filename, L"wb");
+        free(wide_filename);
+
+        if (open_error != 0 || *out_file == NULL)
+            return EXTRACTPDF_ERROR_IO;
+    }
+#else
+    *out_file = fopen(filename, "wb");
+    if (*out_file == NULL)
+        return EXTRACTPDF_ERROR_IO;
+#endif
+
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_output_save_file(
+    const extractpdf_output *output,
+    const char *filename)
+{
+    FILE *file = NULL;
+    extractpdf_status status;
+    size_t offset = 0;
+
+    if (output == NULL || filename == NULL || filename[0] == '\0')
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_open_output_file(filename, &file);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    while (offset < output->size) {
+        size_t written = fwrite(
+            output->data + offset,
+            1,
+            output->size - offset,
+            file);
+
+        if (written == 0) {
+            status = EXTRACTPDF_ERROR_IO;
+            break;
+        }
+        offset += written;
+    }
+
+    if (status == EXTRACTPDF_OK && fflush(file) != 0)
+        status = EXTRACTPDF_ERROR_IO;
+
+    if (fclose(file) != 0 && status == EXTRACTPDF_OK)
+        status = EXTRACTPDF_ERROR_IO;
+
+    return status;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,27 @@ target_compile_definitions(extractpdf_test_pdf_merge PRIVATE
 add_test(NAME extractpdf.pdf_merge COMMAND extractpdf_test_pdf_merge)
 set_tests_properties(extractpdf.pdf_merge PROPERTIES TIMEOUT 30)
 
+set(OUTPUT_FILE_ASCII "${CMAKE_CURRENT_BINARY_DIR}/composition-save-output.pdf")
+set(OUTPUT_FILE_UTF8 "${CMAKE_CURRENT_BINARY_DIR}/composition-save-测试.pdf")
+set(OUTPUT_FILE_MISSING_PARENT_DIR
+  "${CMAKE_CURRENT_BINARY_DIR}/extractpdf-save-missing-parent")
+set(OUTPUT_FILE_MISSING_PARENT
+  "${OUTPUT_FILE_MISSING_PARENT_DIR}/output.pdf")
+
+add_executable(extractpdf_test_output_file test_output_file.c)
+target_link_libraries(extractpdf_test_output_file PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_output_file PRIVATE
+  COMPOSITION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  ASCII_OUTPUT_PDF="${OUTPUT_FILE_ASCII}"
+  UTF8_OUTPUT_PDF="${OUTPUT_FILE_UTF8}"
+  MISSING_PARENT_DIR="${OUTPUT_FILE_MISSING_PARENT_DIR}"
+  MISSING_PARENT_PDF="${OUTPUT_FILE_MISSING_PARENT}")
+if(MSVC)
+  target_compile_options(extractpdf_test_output_file PRIVATE /utf-8)
+endif()
+add_test(NAME extractpdf.output_file COMMAND extractpdf_test_output_file)
+set_tests_properties(extractpdf.output_file PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -137,7 +158,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_pdf_range
       extractpdf_test_pdf_order
       extractpdf_test_pdf_delete
-      extractpdf_test_pdf_merge)
+      extractpdf_test_pdf_merge
+      extractpdf_test_output_file)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/test_output_file.c
+++ b/tests/test_output_file.c
@@ -1,0 +1,195 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int write_stale_file(
+    const char *path,
+    const unsigned char *data,
+    size_t size)
+{
+    static const unsigned char stale_tail[] =
+        "THIS-STALE-TRAILING-DATA-MUST-BE-TRUNCATED";
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    if (fwrite(stale_tail, 1, sizeof(stale_tail), file) != sizeof(stale_tail)) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static void expect_exact_file_bytes(
+    const char *path,
+    const unsigned char *expected,
+    size_t expected_size)
+{
+    FILE *file = fopen(path, "rb");
+    unsigned char *actual = NULL;
+    int next;
+
+    CHECK(file != NULL);
+    CHECK(expected_size > 0);
+
+    actual = (unsigned char *)malloc(expected_size);
+    CHECK(actual != NULL);
+    CHECK(fread(actual, 1, expected_size, file) == expected_size);
+    CHECK(memcmp(actual, expected, expected_size) == 0);
+
+    next = fgetc(file);
+    CHECK(next == EOF);
+    CHECK(feof(file) != 0);
+    CHECK(ferror(file) == 0);
+    CHECK(fclose(file) == 0);
+    free(actual);
+}
+
+static void expect_page(
+    extractpdf_document *document,
+    int page_index,
+    const char *needle,
+    float width,
+    float height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds;
+    char *text = NULL;
+    size_t text_size = 0;
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+    CHECK(bounds.x0 == 0.0f);
+    CHECK(bounds.y0 == 0.0f);
+    CHECK(bounds.x1 == width);
+    CHECK(bounds.y1 == height);
+    CHECK(extractpdf_extract_text(page, &text, &text_size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(strstr(text, needle) != NULL);
+
+    extractpdf_free(text);
+    extractpdf_drop_page(page);
+}
+
+static void expect_saved_pdf(
+    const char *path,
+    const char *first_text,
+    float first_width,
+    float first_height,
+    const char *second_text,
+    float second_width,
+    float second_height)
+{
+    extractpdf_document *document = NULL;
+    int page_count = 0;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_count(document, &page_count) == EXTRACTPDF_OK);
+    CHECK(page_count == 2);
+    expect_page(document, 0, first_text, first_width, first_height);
+    expect_page(document, 1, second_text, second_width, second_height);
+    extractpdf_close(document);
+}
+
+static void remove_missing_parent_if_empty(void)
+{
+    (void)remove(MISSING_PARENT_PDF);
+#ifdef _WIN32
+    (void)_rmdir(MISSING_PARENT_DIR);
+#else
+    (void)rmdir(MISSING_PARENT_DIR);
+#endif
+}
+
+int main(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_output *output = NULL;
+    const unsigned char *before_data = NULL;
+    const unsigned char *after_data = NULL;
+    size_t before_size = 0;
+    size_t after_size = 0;
+    int indices[] = {2, 0};
+
+    (void)remove(ASCII_OUTPUT_PDF);
+    remove_missing_parent_if_empty();
+
+    CHECK(extractpdf_output_save_file(NULL, ASCII_OUTPUT_PDF) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_open(COMPOSITION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_export_pages(source, indices, 2, &output) == EXTRACTPDF_OK);
+    CHECK(output != NULL);
+    extractpdf_close(source);
+    source = NULL;
+
+    CHECK(extractpdf_output_data(output, &before_data, &before_size) ==
+          EXTRACTPDF_OK);
+    CHECK(before_data != NULL);
+    CHECK(before_size > 0);
+
+    CHECK(extractpdf_output_save_file(output, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_output_save_file(output, "") ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(write_stale_file(ASCII_OUTPUT_PDF, before_data, before_size));
+    CHECK(extractpdf_output_save_file(output, ASCII_OUTPUT_PDF) ==
+          EXTRACTPDF_OK);
+    expect_exact_file_bytes(ASCII_OUTPUT_PDF, before_data, before_size);
+    expect_saved_pdf(
+        ASCII_OUTPUT_PDF,
+        "PAGE-C", 300.0f, 150.0f,
+        "PAGE-A", 200.0f, 200.0f);
+
+    CHECK(extractpdf_output_save_file(output, UTF8_OUTPUT_PDF) ==
+          EXTRACTPDF_OK);
+    expect_saved_pdf(
+        UTF8_OUTPUT_PDF,
+        "PAGE-C", 300.0f, 150.0f,
+        "PAGE-A", 200.0f, 200.0f);
+
+    remove_missing_parent_if_empty();
+    CHECK(extractpdf_output_save_file(output, MISSING_PARENT_PDF) ==
+          EXTRACTPDF_ERROR_IO);
+
+#ifdef _WIN32
+    {
+        const char invalid_utf8[] = { (char)0xC3, (char)0x28, '\0' };
+        CHECK(extractpdf_output_save_file(output, invalid_utf8) ==
+              EXTRACTPDF_ERROR_ARGUMENT);
+    }
+#endif
+
+    CHECK(extractpdf_output_data(output, &after_data, &after_size) ==
+          EXTRACTPDF_OK);
+    CHECK(after_data != NULL);
+    CHECK(after_size == before_size);
+    CHECK(memcmp(after_data, before_data, before_size) == 0);
+
+    extractpdf_drop_output(output);
+    (void)remove(ASCII_OUTPUT_PDF);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 4 PDF Composition terminal-I/O slice for #29 / #2, stacked on #27 / PR #28.

## Public ABI

```c
extractpdf_status extractpdf_output_save_file(
    const extractpdf_output *output,
    const char *filename);
```

This is a terminal adapter over the already-materialized immutable output bytes. It does not call MuPDF, reserialize PDF data, consume the output, create directories, or add atomic/durable filesystem policy.

## RED evidence

Exact RED head: `bc7e55873a583e40bc62592bbe3e29c1fa95f175`.

Workflow #157 (`33136394404`) configured and built the library plus every pre-existing test target through `extractpdf_test_pdf_merge`, then failed only on the new save contract target because `extractpdf_output_save_file` was absent:
- implicit declaration of `extractpdf_output_save_file`
- undefined references to `extractpdf_output_save_file`

## GREEN evidence

Exact GREEN head: `f9007d68f0c0411740c989b8bac16de6334e75ab`.

Normal workflow #158 (`33136542208`) completed Linux successfully:
- strict static configure/build ✅
- all normal CTests, including `extractpdf.output_file` ✅
- ASan/UBSan configure/build ✅
- all sanitizer CTests ✅

Architecture-checkpoint `full-ci` workflow #159 (`33136606238`) ran on the same exact GREEN head:
- Linux static configure/build/tests ✅
- Linux ASan/UBSan configure/build/tests ✅
- macOS configure/build/tests ✅
- Windows DLL configure/build/tests ✅

The Windows result proves the new `EXTRACTPDF_API extractpdf_output_save_file` surface exports, links, and executes through the shared-library build, including UTF-8 filename save/reopen and invalid UTF-8 -> `EXTRACTPDF_ERROR_ARGUMENT`.

## Contract proof

The output-file test proves:
- overwrite/truncate removes stale trailing bytes
- saved ASCII file bytes equal `extractpdf_output_data(...)` byte-for-byte
- saved PDF reopens with PAGE-C / PAGE-A content and geometry
- UTF-8 filename save/reopen works through the public UTF-8 path contract
- missing parent returns `EXTRACTPDF_ERROR_IO` and is not created
- output remains unchanged/reusable after success and failure

## Platform/file contract

- Windows: strict UTF-8 -> UTF-16 using `MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, ...)`, then wide-character binary open
- invalid Windows UTF-8 -> `EXTRACTPDF_ERROR_ARGUMENT`
- Windows path-buffer allocation failure -> `EXTRACTPDF_ERROR_NOMEM`
- Linux/macOS: `fopen(filename, "wb")`
- success requires exact write + `fflush` + `fclose`
- open/write/flush/close failure -> `EXTRACTPDF_ERROR_IO`
- existing target truncate/overwrite; missing target create
- no automatic parent-directory creation
- non-consuming output ownership on success/failure
- V1 is non-atomic and non-durable: no temp-file/rename rollback, fsync/FlushFileBuffers, ACL/symlink policy, or power-loss guarantee

## Scope

Relative to PR #28 exact GREEN head `a6d35b6f5d68207cf9c628b2b38c35addb868d82`, the diff is exactly seven scoped files:
- `docs/superpowers/specs/2026-08-28-extractpdf-output-save-file-design.md`
- `docs/superpowers/plans/2026-08-28-extractpdf-output-save-file.md`
- `include/extractpdf/extractpdf.h`
- `src/output_file.c`
- `CMakeLists.txt`
- `tests/test_output_file.c`
- `tests/CMakeLists.txt`

No PDF composition implementation, `src/internal.h`, dependency, or workflow file changed.

Keep draft and unmerged pending explicit integration.