### PR TITLE
feat: expose immutable PDF outline snapshot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(extractpdf
   src/pdf_range.c
   src/pdf_merge.c
   src/output_file.c
-  src/pdf_metadata.c)
+  src/pdf_metadata.c
+  src/pdf_outline.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/docs/superpowers/plans/2026-08-28-extractpdf-document-outline.md
+++ b/docs/superpowers/plans/2026-08-28-extractpdf-document-outline.md
@@ -1,0 +1,1152 @@
+# ExtractPDF PDF Outline / Bookmarks V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a PDF-only immutable outline/bookmarks snapshot with flat preorder hierarchy indices, stable navigation semantics, strict read-only structural validation, document-independent lifetime, and a bounded MuPDF 1.28.2 recursion envelope.
+
+**Architecture:** Reuse the existing opaque `extractpdf_document`. Before creating MuPDF's PDF outline iterator, perform an ExtractPDF-owned iterative read-only preflight over `/Root/Outlines` that rejects repairable structural inconsistencies and cycles and records maximum depth; only valid trees at depth <= 256 may enter MuPDF's recursive iterator validation. Flatten decoded items iteratively into one ExtractPDF-owned snapshot containing a node array plus UTF-8 string arena; no MuPDF pointer survives publication.
+
+**Tech Stack:** C11, MuPDF 1.28.2 pinned through the existing vcpkg overlay, PDF object/Fitz outline APIs, CMake/CTest, Linux ASan/UBSan, macOS CI, Windows DLL CI, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-document-outline-design.md`
+
+## Global Constraints
+
+- Base is integrated `master` exact SHA `cb0f50b0734bcae00fedd529e4f13701c0852866`.
+- Work on `feat/document-outline`; child issue is #33; umbrella is #2.
+- V1 is PDF-only. Non-PDF documents return `EXTRACTPDF_ERROR_UNSUPPORTED`.
+- Reuse `extractpdf_document`; do not introduce a second public PDF document handle.
+- Public hierarchy is one immutable `extractpdf_outline` snapshot in global preorder with snapshot-local `parent_index`, `first_child_index`, and `next_sibling_index` relations.
+- `SIZE_MAX` means no parent, no first child, or no next sibling. Do not add an `EXTRACTPDF_INDEX_NONE` macro.
+- Destination kinds are NONE / INTERNAL / URI. INTERNAL exposes zero-based flat PDF page index + Fitz page-space x/y. URI exposes snapshot-owned borrowed UTF-8.
+- Titles are snapshot-owned borrowed UTF-8 and distinguish absent (`NULL/0`) from present-empty (non-NULL empty string, size 0).
+- V1 exposes only `is_open`; bold/italic/RGB presentation fields remain deferred.
+- Empty PDF outline is success with a non-NULL snapshot whose count is zero.
+- The completed snapshot remains valid after source document close and retains no MuPDF/document pointer.
+- ExtractPDF-owned preflight and flattening are iterative and heap-backed.
+- Preflight rejects any structure MuPDF would otherwise repair: bad Parent/Prev/parent-Last relationships, non-indirect outline items, repeated nodes, or cycles -> `EXTRACTPDF_ERROR_FORMAT`.
+- Preflight validates the entire tree before choosing the depth result: malformed always wins `FORMAT`; only a structurally valid tree whose maximum depth exceeds 256 returns `EXTRACTPDF_ERROR_UNSUPPORTED`.
+- Do not invoke MuPDF's outline iterator for a tree that failed preflight or whose valid maximum depth is > 256.
+- A non-null internal destination that cannot resolve to a valid PDF page makes the whole extraction `EXTRACTPDF_ERROR_FORMAT`.
+- No partial snapshot may be published on any failure.
+- Snapshot indices are never persistent bookmark IDs, PDF object numbers, cross-snapshot identities, or future mutation handles.
+- Do not modify `src/document.c`, `src/internal.h`, `src/links.c`, `src/pdf_metadata.c`, Phase 4 composition/output implementation, or existing Page/Render/Text/Search/Image/Links behavior.
+- MuPDF types never cross the public C ABI.
+- Preserve a real RED commit before adding any public outline declaration or production implementation.
+- Final acceptance requires the exact GREEN head to pass Linux strict static/all CTests, Linux ASan/UBSan/all CTests, macOS configure/build/test, and Windows DLL configure/build/test.
+- Do not merge this slice during plan execution; leave the implementation PR draft/open for an explicit integration decision.
+
+---
+
+## File Structure
+
+**Create during RED**
+- `tests/fixtures/outline-tree.pdf`
+- `tests/fixtures/outline-repairable-bad.pdf`
+- `tests/fixtures/outline-cycle.pdf`
+- `tests/fixtures/outline-depth-257.pdf`
+- `tests/test_pdf_outline.c`
+
+**Modify during RED**
+- `tests/CMakeLists.txt`
+
+**Create during GREEN**
+- `src/pdf_outline.c`
+
+**Modify during GREEN**
+- `include/extractpdf/extractpdf.h`
+- `CMakeLists.txt`
+
+**Reuse unchanged**
+- `src/pdf_internal.h`
+- `src/document.c`
+- `tests/fixtures/composition-three-page.pdf`
+- `tests/fixtures/composition-non-pdf.txt`
+- `.github/workflows/ci.yml`
+
+---
+
+### Task 1: Strict RED for the immutable PDF outline contract
+
+**Files:**
+- Create: `tests/fixtures/outline-tree.pdf`
+- Create: `tests/fixtures/outline-repairable-bad.pdf`
+- Create: `tests/fixtures/outline-cycle.pdf`
+- Create: `tests/fixtures/outline-depth-257.pdf`
+- Create: `tests/test_pdf_outline.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: existing `extractpdf_open`, `extractpdf_close`, `extractpdf_point`, `extractpdf_status`, and existing fixture paths.
+- Produces: failing compile references to `extractpdf_outline`, `extractpdf_outline_destination_kind`, `extractpdf_outline_info`, `extractpdf_document_outline`, `extractpdf_outline_count`, `extractpdf_outline_get_info`, `extractpdf_outline_title`, `extractpdf_outline_uri`, and `extractpdf_drop_outline`. No production outline declaration or implementation exists in this task.
+
+- [ ] **Step 1: Generate and check in all four deterministic PDF fixtures**
+
+Run this once from the repository root; commit only the resulting PDFs, not a generator file:
+
+```python
+from pathlib import Path
+
+FIXTURES = Path("tests/fixtures")
+FIXTURES.mkdir(parents=True, exist_ok=True)
+
+
+def text_hex(value: str) -> str:
+    return "<FEFF" + value.encode("utf-16-be").hex().upper() + ">"
+
+
+def write_pdf(name: str, objects: list[str]) -> None:
+    data = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0] * (len(objects) + 1)
+
+    for number, body in enumerate(objects, 1):
+        offsets[number] = len(data)
+        data.extend(f"{number} 0 obj\n".encode("ascii"))
+        data.extend(body.encode("ascii"))
+        data.extend(b"\nendobj\n")
+
+    xref = len(data)
+    data.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    data.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        data.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    data.extend(
+        (
+            f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+            f"startxref\n{xref}\n%%EOF\n"
+        ).encode("ascii")
+    )
+
+    path = FIXTURES / name
+    path.write_bytes(data)
+    assert path.read_bytes() == data
+
+
+write_pdf(
+    "outline-tree.pdf",
+    [
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 6 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "<< /Type /Outlines /First 7 0 R /Last 11 0 R >>",
+        (
+            f"<< /Title {text_hex('Chapter 1 Café')} /Parent 6 0 R "
+            "/Next 11 0 R /First 8 0 R /Last 10 0 R /Count 3 "
+            "/Dest [3 0 R /XYZ 30 150 1] >>"
+        ),
+        (
+            "<< /Title (Section 1.1) /Parent 7 0 R /Next 9 0 R "
+            "/Dest [4 0 R /XYZ 10 180 1] >>"
+        ),
+        (
+            "<< /Title (Website) /Parent 7 0 R /Prev 8 0 R /Next 10 0 R "
+            "/A << /S /URI /URI (https://example.com/extractpdf-outline) >> >>"
+        ),
+        "<< /Parent 7 0 R /Prev 9 0 R >>",
+        (
+            "<< /Title (Chapter 2) /Parent 6 0 R /Prev 7 0 R "
+            "/First 12 0 R /Last 12 0 R /Count -1 "
+            "/Dest [5 0 R /XYZ 40 160 1] >>"
+        ),
+        "<< /Title () /Parent 11 0 R >>",
+    ],
+)
+
+write_pdf(
+    "outline-repairable-bad.pdf",
+    [
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 6 0 R >>",
+        "<< /Title (First) /Parent 4 0 R /Next 6 0 R >>",
+        "<< /Title (Second) /Parent 4 0 R >>",
+    ],
+)
+
+write_pdf(
+    "outline-cycle.pdf",
+    [
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title (Cycle) /Parent 4 0 R /Next 5 0 R >>",
+    ],
+)
+
+depth_objects = [
+    "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+    "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+]
+for level in range(257):
+    number = 5 + level
+    parent = 4 if level == 0 else number - 1
+    parts = [f"<< /Title (Depth {level + 1}) /Parent {parent} 0 R"]
+    if level < 256:
+        child = number + 1
+        parts.append(f"/First {child} 0 R /Last {child} 0 R /Count 1")
+    parts.append(">>")
+    depth_objects.append(" ".join(parts))
+write_pdf("outline-depth-257.pdf", depth_objects)
+
+assert len(depth_objects) == 261
+```
+
+Locked semantic shape of `outline-tree.pdf`:
+
+```text
+0 Chapter 1 Café    INTERNAL -> page 0, Fitz (30,50), open
+1   Section 1.1     INTERNAL -> page 1, Fitz (10,20)
+2   Website         URI      -> https://example.com/extractpdf-outline
+3   [title absent]  NONE
+4 Chapter 2         INTERNAL -> page 2, Fitz (40,40), closed
+5   ""              NONE, present-empty title
+```
+
+`outline-repairable-bad.pdf` deliberately omits `/Prev 5 0 R` on its second top-level item. MuPDF's normal PDF outline constructor would repair it; ExtractPDF must return `FORMAT` without invoking that repair path. `outline-cycle.pdf` has `/Next` self-reference. `outline-depth-257.pdf` is structurally valid and must return `UNSUPPORTED`, not `FORMAT`.
+
+- [ ] **Step 2: Add the failing public contract test**
+
+Create `tests/test_pdf_outline.c`:
+
+```c
+#include <extractpdf/extractpdf.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    if (d < 0.0f)
+        d = -d;
+    return d < 0.01f;
+}
+
+static void expect_info(
+    const extractpdf_outline *outline,
+    size_t index,
+    size_t parent_index,
+    size_t first_child_index,
+    size_t next_sibling_index,
+    extractpdf_outline_destination_kind kind,
+    int target_page,
+    float x,
+    float y,
+    int is_open)
+{
+    extractpdf_outline_info info = { 0 };
+    info.struct_size = sizeof(info);
+
+    CHECK(extractpdf_outline_get_info(outline, index, &info) == EXTRACTPDF_OK);
+    CHECK(info.struct_size == sizeof(info));
+    CHECK(info.parent_index == parent_index);
+    CHECK(info.first_child_index == first_child_index);
+    CHECK(info.next_sibling_index == next_sibling_index);
+    CHECK(info.destination_kind == kind);
+    CHECK(info.target_page == target_page);
+    CHECK(close_float(info.target.x, x));
+    CHECK(close_float(info.target.y, y));
+    CHECK(info.is_open == is_open);
+}
+
+static void expect_title(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char *expected)
+{
+    const char *text = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_outline_title(outline, index, &text, &size) == EXTRACTPDF_OK);
+    if (expected == NULL) {
+        CHECK(text == NULL);
+        CHECK(size == 0);
+        return;
+    }
+    CHECK(text != NULL);
+    CHECK(size == strlen(expected));
+    CHECK(memcmp(text, expected, size) == 0);
+    CHECK(text[size] == '\0');
+}
+
+static void expect_uri(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char *expected)
+{
+    const char *uri = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_outline_uri(outline, index, &uri, &size) == EXTRACTPDF_OK);
+    CHECK(uri != NULL);
+    CHECK(size == strlen(expected));
+    CHECK(memcmp(uri, expected, size) == 0);
+    CHECK(uri[size] == '\0');
+}
+
+static void expect_uri_unavailable(
+    const extractpdf_outline *outline,
+    size_t index)
+{
+    const char *uri = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_outline_uri(outline, index, &uri, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(uri == NULL);
+    CHECK(size == 0);
+}
+
+static void test_valid_outline_and_independent_lifetime(void)
+{
+    static const char unicode_title[] = "Chapter 1 Caf\xC3\xA9";
+    static const char uri[] = "https://example.com/extractpdf-outline";
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = NULL;
+    size_t count = 0;
+
+    CHECK(extractpdf_open(OUTLINE_TREE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+    extractpdf_close(document);
+
+    CHECK(extractpdf_outline_count(outline, &count) == EXTRACTPDF_OK);
+    CHECK(count == 6);
+
+    expect_info(outline, 0, SIZE_MAX, 1, 4,
+                EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL,
+                0, 30.0f, 50.0f, 1);
+    expect_info(outline, 1, 0, SIZE_MAX, 2,
+                EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL,
+                1, 10.0f, 20.0f, 0);
+    expect_info(outline, 2, 0, SIZE_MAX, 3,
+                EXTRACTPDF_OUTLINE_DESTINATION_URI,
+                -1, 0.0f, 0.0f, 0);
+    expect_info(outline, 3, 0, SIZE_MAX, SIZE_MAX,
+                EXTRACTPDF_OUTLINE_DESTINATION_NONE,
+                -1, 0.0f, 0.0f, 0);
+    expect_info(outline, 4, SIZE_MAX, 5, SIZE_MAX,
+                EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL,
+                2, 40.0f, 40.0f, 0);
+    expect_info(outline, 5, 4, SIZE_MAX, SIZE_MAX,
+                EXTRACTPDF_OUTLINE_DESTINATION_NONE,
+                -1, 0.0f, 0.0f, 0);
+
+    expect_title(outline, 0, unicode_title);
+    expect_title(outline, 1, "Section 1.1");
+    expect_title(outline, 2, "Website");
+    expect_title(outline, 3, NULL);
+    expect_title(outline, 4, "Chapter 2");
+    expect_title(outline, 5, "");
+
+    expect_uri(outline, 2, uri);
+    expect_uri_unavailable(outline, 0);
+    expect_uri_unavailable(outline, 3);
+
+    extractpdf_drop_outline(outline);
+}
+
+static void test_empty_outline(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = NULL;
+    size_t count = 99;
+
+    CHECK(extractpdf_open(EMPTY_OUTLINE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+    extractpdf_close(document);
+
+    CHECK(extractpdf_outline_count(outline, &count) == EXTRACTPDF_OK);
+    CHECK(count == 0);
+    extractpdf_drop_outline(outline);
+}
+
+static void test_repairable_outline_is_rejected_without_repair(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = (extractpdf_outline *)&sentinel;
+
+    CHECK(extractpdf_open(OUTLINE_REPAIRABLE_BAD_PDF, NULL, &document) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(outline == NULL);
+
+    outline = (extractpdf_outline *)&sentinel;
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+}
+
+static void test_cycle_depth_and_pdf_only_boundaries(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = (extractpdf_outline *)&sentinel;
+
+    CHECK(extractpdf_open(OUTLINE_CYCLE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+
+    document = NULL;
+    outline = (extractpdf_outline *)&sentinel;
+    CHECK(extractpdf_open(OUTLINE_DEPTH_257_PDF, NULL, &document) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+
+    document = NULL;
+    outline = (extractpdf_outline *)&sentinel;
+    CHECK(extractpdf_open(COMPOSITION_NON_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+}
+
+static void test_argument_and_reset_contract(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = (extractpdf_outline *)&sentinel;
+    extractpdf_outline_info info = { 0 };
+    extractpdf_outline_info small = { 0 };
+    const char *text = (const char *)&sentinel;
+    size_t size = 99;
+    size_t count = 99;
+
+    CHECK(extractpdf_document_outline(NULL, &outline) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(outline == NULL);
+    CHECK(extractpdf_document_outline(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_open(OUTLINE_TREE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+
+    CHECK(extractpdf_outline_count(NULL, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_outline_count(outline, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    small.struct_size = offsetof(extractpdf_outline_info, is_open);
+    CHECK(extractpdf_outline_get_info(outline, 0, &small) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    info.struct_size = sizeof(info);
+    info.parent_index = 0;
+    info.first_child_index = 0;
+    info.next_sibling_index = 0;
+    info.destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_URI;
+    info.target_page = 99;
+    info.target.x = 99.0f;
+    info.target.y = 99.0f;
+    info.is_open = 99;
+    CHECK(extractpdf_outline_get_info(outline, 99, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.parent_index == SIZE_MAX);
+    CHECK(info.first_child_index == SIZE_MAX);
+    CHECK(info.next_sibling_index == SIZE_MAX);
+    CHECK(info.destination_kind == EXTRACTPDF_OUTLINE_DESTINATION_NONE);
+    CHECK(info.target_page == -1);
+    CHECK(close_float(info.target.x, 0.0f));
+    CHECK(close_float(info.target.y, 0.0f));
+    CHECK(info.is_open == 0);
+
+    info.parent_index = 0;
+    CHECK(extractpdf_outline_get_info(NULL, 0, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.parent_index == SIZE_MAX);
+
+    CHECK(extractpdf_outline_get_info(NULL, 0, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_outline_title(NULL, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_outline_title(outline, 99, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_outline_uri(outline, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_outline_uri(NULL, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    CHECK(extractpdf_outline_uri(outline, 2, NULL, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    extractpdf_close(document);
+    extractpdf_drop_outline(outline);
+    extractpdf_drop_outline(NULL);
+}
+
+int main(void)
+{
+    test_valid_outline_and_independent_lifetime();
+    test_empty_outline();
+    test_repairable_outline_is_rejected_without_repair();
+    test_cycle_depth_and_pdf_only_boundaries();
+    test_argument_and_reset_contract();
+    return EXIT_SUCCESS;
+}
+```
+
+No public outline declaration and no `src/pdf_outline.c` may exist in this RED commit.
+
+- [ ] **Step 3: Register only the new failing target and Windows DLL-copy wiring**
+
+Add after the metadata test in `tests/CMakeLists.txt`:
+
+```cmake
+add_executable(extractpdf_test_pdf_outline test_pdf_outline.c)
+target_link_libraries(extractpdf_test_pdf_outline PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_outline PRIVATE
+  OUTLINE_TREE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-tree.pdf"
+  OUTLINE_REPAIRABLE_BAD_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-repairable-bad.pdf"
+  OUTLINE_CYCLE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-cycle.pdf"
+  OUTLINE_DEPTH_257_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-depth-257.pdf"
+  EMPTY_OUTLINE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  COMPOSITION_NON_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-non-pdf.txt")
+add_test(NAME extractpdf.pdf_outline COMMAND extractpdf_test_pdf_outline)
+set_tests_properties(extractpdf.pdf_outline PROPERTIES TIMEOUT 30)
+```
+
+Add `extractpdf_test_pdf_outline` immediately after `extractpdf_test_pdf_metadata` in the existing Windows shared-library `foreach(test_target IN ITEMS ...)` list.
+
+- [ ] **Step 4: Prove every pre-existing target/test remains green on the RED tree**
+
+Configure Linux/static exactly like CI, then explicitly build every pre-existing target and exclude the new test from CTest:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
+
+cmake --build build --parallel 2 --target \
+  extractpdf_test_status \
+  extractpdf_test_document \
+  extractpdf_test_render \
+  extractpdf_test_text \
+  extractpdf_test_structured_text \
+  extractpdf_test_text_search \
+  extractpdf_test_images \
+  extractpdf_test_image_bitmap \
+  extractpdf_test_links \
+  extractpdf_test_pdf_export \
+  extractpdf_test_pdf_range \
+  extractpdf_test_pdf_order \
+  extractpdf_test_pdf_delete \
+  extractpdf_test_pdf_merge \
+  extractpdf_test_output_file \
+  extractpdf_test_pdf_metadata
+
+ctest --test-dir build --output-on-failure -E '^extractpdf\.pdf_outline$'
+```
+
+Required: every existing target builds/links and every existing CTest passes.
+
+- [ ] **Step 5: Prove only the new target is RED for the intended API boundary**
+
+Run:
+
+```bash
+cmake --build build --parallel 2 --target extractpdf_test_pdf_outline
+```
+
+Accept only compile failures caused by the absent outline type/enum/functions. Fixture parse errors, unrelated production failures, crashes, or timeouts are invalid RED.
+
+- [ ] **Step 6: Commit RED and capture exact SHA**
+
+```bash
+git add \
+  tests/fixtures/outline-tree.pdf \
+  tests/fixtures/outline-repairable-bad.pdf \
+  tests/fixtures/outline-cycle.pdf \
+  tests/fixtures/outline-depth-257.pdf \
+  tests/test_pdf_outline.c \
+  tests/CMakeLists.txt
+
+git commit -m "test: define PDF outline snapshot contract"
+RED_SHA=$(git rev-parse HEAD)
+printf '%s\n' "$RED_SHA"
+```
+
+The RED commit contains only those six paths relative to the plan head.
+
+- [ ] **Step 7: Push RED and open one draft PR**
+
+Push `feat/document-outline` and create one draft PR against `master`, referencing #33 and #2. Save the actual numeric PR number returned by GitHub/forge tooling as `PR_NUMBER`; never predict it.
+
+State in the PR body that the exact `RED_SHA` has no public outline declaration and no production outline implementation.
+
+- [ ] **Step 8: Capture exact-head RED CI evidence**
+
+Find the pull-request workflow run whose head SHA equals `RED_SHA`; save its actual run ID as `RED_RUN_ID`. Require Linux to fail only at the absent outline API boundary after the library/existing targets remain buildable. Record the compiler diagnostics in the PR and #33.
+
+---
+
+### Task 2: Minimal read-only PDF outline snapshot GREEN
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Create: `src/pdf_outline.c`
+- Modify: `CMakeLists.txt`
+- Test: `tests/test_pdf_outline.c` unchanged from accepted RED
+
+**Interfaces:**
+- Consumes: `extractpdf_document`, `extractpdf_status_from_mupdf`, `extractpdf_point`, `pdf_specifics`, `pdf_trailer`, PDF dictionary APIs, `pdf_mark_bits`, `fz_new_outline_iterator`, `fz_outline_iterator_item/next/up/down`, `fz_is_external_link`, `fz_resolve_link_dest`, `fz_page_number_from_location`, and `fz_count_pages`.
+- Produces the exact ABI below.
+
+- [ ] **Step 1: Add the public ABI exactly as specified**
+
+In `include/extractpdf/extractpdf.h`, add:
+
+```c
+typedef struct extractpdf_outline extractpdf_outline;
+
+typedef enum extractpdf_outline_destination_kind {
+    EXTRACTPDF_OUTLINE_DESTINATION_NONE = 0,
+    EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL = 1,
+    EXTRACTPDF_OUTLINE_DESTINATION_URI = 2
+} extractpdf_outline_destination_kind;
+
+typedef struct extractpdf_outline_info {
+    size_t struct_size;
+    size_t parent_index;
+    size_t first_child_index;
+    size_t next_sibling_index;
+    extractpdf_outline_destination_kind destination_kind;
+    int target_page;
+    extractpdf_point target;
+    int is_open;
+} extractpdf_outline_info;
+```
+
+Add declarations:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_document_outline(
+    extractpdf_document *document,
+    extractpdf_outline **out_outline);
+EXTRACTPDF_API extractpdf_status extractpdf_outline_count(
+    const extractpdf_outline *outline,
+    size_t *out_count);
+EXTRACTPDF_API extractpdf_status extractpdf_outline_get_info(
+    const extractpdf_outline *outline,
+    size_t index,
+    extractpdf_outline_info *out_info);
+EXTRACTPDF_API extractpdf_status extractpdf_outline_title(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+EXTRACTPDF_API extractpdf_status extractpdf_outline_uri(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+EXTRACTPDF_API void extractpdf_drop_outline(
+    extractpdf_outline *outline);
+```
+
+Do not add a public sentinel macro.
+
+- [ ] **Step 2: Create private snapshot storage and string-arena helpers in `src/pdf_outline.c`**
+
+Start the file with:
+
+```c
+#include "pdf_internal.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EXTRACTPDF_OUTLINE_MAX_DEPTH 256u
+
+typedef struct extractpdf_outline_node_internal {
+    size_t parent_index;
+    size_t first_child_index;
+    size_t next_sibling_index;
+    extractpdf_outline_destination_kind destination_kind;
+    int target_page;
+    extractpdf_point target;
+    size_t title_offset;
+    size_t title_size;
+    size_t uri_offset;
+    size_t uri_size;
+    int has_title;
+    int is_open;
+} extractpdf_outline_node_internal;
+
+struct extractpdf_outline {
+    extractpdf_outline_node_internal *nodes;
+    char *strings;
+    size_t count;
+    size_t string_size;
+    size_t string_capacity;
+};
+
+typedef struct extractpdf_outline_preflight_frame {
+    pdf_obj *parent;
+    pdf_obj *node;
+    pdf_obj *expected_prev;
+    size_t depth;
+} extractpdf_outline_preflight_frame;
+```
+
+Implement these exact ownership rules:
+
+```c
+static void extractpdf_dispose_outline(extractpdf_outline *outline)
+{
+    if (outline == NULL)
+        return;
+    free(outline->nodes);
+    free(outline->strings);
+    free(outline);
+}
+
+static void extractpdf_init_outline_node(extractpdf_outline_node_internal *node)
+{
+    memset(node, 0, sizeof(*node));
+    node->parent_index = SIZE_MAX;
+    node->first_child_index = SIZE_MAX;
+    node->next_sibling_index = SIZE_MAX;
+    node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_NONE;
+    node->target_page = -1;
+}
+```
+
+Allocate the handle plus exact node array with overflow checks. Grow one UTF-8 string arena with `realloc`, checking `string_size + strlen(text) + 1` and capacity multiplication for `SIZE_MAX` overflow before every growth. Each appended title/URI is copied including its NUL terminator; store offset and byte size excluding NUL. `has_title` is required so absent title remains distinguishable from an appended empty string.
+
+- [ ] **Step 3: Implement iterative read-only structural preflight**
+
+Use a heap-backed stack of `extractpdf_outline_preflight_frame` and `pdf_new_mark_bits()`/`pdf_mark_bits_set()` for temporary visited-state. The stack growth helper must reject multiplication/doubling overflow and return `EXTRACTPDF_ERROR_NOMEM` through the caller instead of mutating PDF objects.
+
+For each popped frame, perform exactly this validation order:
+
+```c
+if (!pdf_is_dict(ctx, frame.node) || !pdf_is_indirect(ctx, frame.node))
+    return FORMAT;
+if (pdf_mark_bits_set(ctx, marks, frame.node))
+    return FORMAT;
+if (pdf_objcmp(ctx,
+               pdf_dict_get(ctx, frame.node, PDF_NAME(Parent)),
+               frame.parent) != 0)
+    return FORMAT;
+if (pdf_objcmp(ctx,
+               pdf_dict_get(ctx, frame.node, PDF_NAME(Prev)),
+               frame.expected_prev) != 0)
+    return FORMAT;
+```
+
+Then increment node count with overflow protection, record `too_deep = 1` when `frame.depth > 256`, fetch `Next` and `First`, and for a node with no `Next` require:
+
+```c
+pdf_objcmp(ctx,
+           pdf_dict_get(ctx, frame.parent, PDF_NAME(Last)),
+           frame.node) == 0
+```
+
+Push the next sibling with `expected_prev = frame.node`, and push the first child with `parent = frame.node`, `expected_prev = NULL`, `depth = frame.depth + 1`. Push sibling first and child second so the LIFO worklist remains preorder-compatible.
+
+Important: do **not** return `UNSUPPORTED` as soon as depth 257 is observed. Continue validating the full reachable tree. After traversal:
+
+```text
+any structural failure -> FORMAT
+allocation/overflow    -> NOMEM
+otherwise too_deep     -> UNSUPPORTED
+otherwise              -> OK + exact node_count
+```
+
+If `/Root/Outlines` is absent, or exists as a dictionary but has no `/First`, return `OK` with node count 0. If `/Root` or present `/Outlines` is not a dictionary, return `FORMAT`.
+
+Wrap mark-bit lifetime in `fz_try/fz_always/fz_catch` so MuPDF exceptions cannot leak temporary state. Do not call `fz_new_outline_iterator()` inside preflight.
+
+- [ ] **Step 4: Implement bounded iterative projection through MuPDF's outline iterator**
+
+Only call this helper after preflight returned `OK` and exact `node_count > 0`.
+
+Allocate a heap-backed `size_t` parent-context stack with 256 entries. Create `fz_new_outline_iterator(ctx, document)` inside `fz_try`, and always drop it with `fz_drop_outline_iterator()`.
+
+Process each `fz_outline_item` before moving the iterator:
+
+```c
+node->parent_index = parent_index;
+node->is_open = item->is_open != 0;
+
+if (parent_index != SIZE_MAX &&
+    outline->nodes[parent_index].first_child_index == SIZE_MAX)
+    outline->nodes[parent_index].first_child_index = current_index;
+if (last_sibling_index != SIZE_MAX)
+    outline->nodes[last_sibling_index].next_sibling_index = current_index;
+```
+
+If `item->title != NULL`, append it to the snapshot arena and set `has_title = 1` even when `strlen(item->title) == 0`.
+
+Destination projection is exact:
+
+```c
+if (item->uri == NULL) {
+    node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_NONE;
+} else if (fz_is_external_link(ctx, item->uri)) {
+    node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_URI;
+    /* copy item->uri into the snapshot arena */
+} else {
+    fz_link_dest destination = fz_resolve_link_dest(ctx, document, item->uri);
+    int page;
+
+    if (destination.loc.chapter < 0 || destination.loc.page < 0)
+        return EXTRACTPDF_ERROR_FORMAT;
+    page = fz_page_number_from_location(ctx, document, destination.loc);
+    if (page < 0 || page >= page_count)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL;
+    node->target_page = page;
+    node->target.x = destination.x;
+    node->target.y = destination.y;
+}
+```
+
+Traverse without recursion using `fz_outline_iterator_down/next/up` and the heap parent stack:
+
+```text
+down == 0 -> push old parent context, descend, reset last_sibling
+ down == 1 -> up once to restore current PDF item, then try next
+next == 0 -> process sibling at same parent
+next == 1 -> climb until a parent has a next sibling or root is exhausted
+any negative movement result in a structurally preflighted PDF -> FORMAT
+```
+
+When climbing from a child level, set `last_sibling_index` to the parent node just returned to, then restore the parent's parent index from the stack. At completion require the number of decoded iterator items to equal the exact preflight node count; mismatch -> `FORMAT`.
+
+Any standard allocation failure from the snapshot arena -> `NOMEM`. Any MuPDF exception -> existing `extractpdf_status_from_mupdf()` mapping. Do not retain the iterator/document in the snapshot.
+
+- [ ] **Step 5: Implement the extraction entry point with strict output atomicity**
+
+Implement:
+
+```c
+extractpdf_status extractpdf_document_outline(
+    extractpdf_document *document,
+    extractpdf_outline **out_outline)
+{
+    fz_context *ctx;
+    pdf_document *pdf = NULL;
+    extractpdf_outline *outline;
+    extractpdf_status preflight_status = EXTRACTPDF_OK;
+    extractpdf_status flatten_status;
+    size_t count = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_outline == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_outline = NULL;
+
+    if (document == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = document->ctx;
+    fz_var(pdf);
+    fz_var(preflight_status);
+    fz_var(count);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        pdf = pdf_specifics(ctx, document->doc);
+        if (pdf != NULL)
+            preflight_status = extractpdf_preflight_pdf_outline(
+                ctx, pdf, &count);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (pdf == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    if (preflight_status != EXTRACTPDF_OK)
+        return preflight_status;
+
+    outline = extractpdf_allocate_outline(count);
+    if (outline == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    if (count != 0) {
+        flatten_status = extractpdf_flatten_pdf_outline(
+            ctx, document->doc, outline);
+        if (flatten_status != EXTRACTPDF_OK) {
+            extractpdf_dispose_outline(outline);
+            return flatten_status;
+        }
+    }
+
+    *out_outline = outline;
+    return EXTRACTPDF_OK;
+}
+```
+
+This ordering is mandatory: non-PDF gate -> complete preflight/depth decision -> allocation -> iterator projection -> publish.
+
+- [ ] **Step 6: Implement accessors and cleanup with deterministic resets**
+
+`extractpdf_outline_count()` resets `*out_count = 0` before validating the handle.
+
+`extractpdf_outline_get_info()` computes:
+
+```c
+minimum_size = offsetof(extractpdf_outline_info, is_open) +
+    sizeof(out_info->is_open);
+```
+
+Reject smaller structs before writing any other field. For an accepted struct size, reset all known fields before handle/index validation:
+
+```c
+out_info->parent_index = SIZE_MAX;
+out_info->first_child_index = SIZE_MAX;
+out_info->next_sibling_index = SIZE_MAX;
+out_info->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_NONE;
+out_info->target_page = -1;
+out_info->target.x = 0.0f;
+out_info->target.y = 0.0f;
+out_info->is_open = 0;
+```
+
+On success copy the corresponding internal record; never modify `out_info->struct_size`.
+
+`extractpdf_outline_title()` and `extractpdf_outline_uri()` reset supplied outputs to `NULL/0` before validation. Title returns `OK + NULL/0` for `has_title == 0`; otherwise return `outline->strings + title_offset` and byte size. URI succeeds only for `DESTINATION_URI`; NONE/INTERNAL -> `ARGUMENT + NULL/0`. `extractpdf_drop_outline(NULL)` is a no-op.
+
+- [ ] **Step 7: Register the new production file only in root CMake**
+
+Change:
+
+```cmake
+  src/output_file.c
+  src/pdf_metadata.c)
+```
+
+to:
+
+```cmake
+  src/output_file.c
+  src/pdf_metadata.c
+  src/pdf_outline.c)
+```
+
+Do not modify `src/pdf_internal.h`, `src/internal.h`, or `src/document.c`.
+
+- [ ] **Step 8: Prove the RED contract turns GREEN without weakening tests**
+
+Run:
+
+```bash
+cmake --build build --parallel 2 --target extractpdf_test_pdf_outline
+ctest --test-dir build --output-on-failure -R '^extractpdf\.pdf_outline$'
+```
+
+Required: target builds/links and `extractpdf.pdf_outline` passes with the RED fixtures/assertions unchanged.
+
+- [ ] **Step 9: Prove Linux strict static + all tests and sanitizer + all tests**
+
+Run:
+
+```bash
+cmake --build build --parallel 2
+ctest --test-dir build --output-on-failure
+
+cmake -S . -B build-asan \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+cmake --build build-asan --parallel 2
+ctest --test-dir build-asan --output-on-failure
+```
+
+Required: all normal and sanitizer CTests pass.
+
+- [ ] **Step 10: Commit minimal GREEN and capture exact SHA**
+
+Verify the production delta from RED is exactly:
+
+```text
+include/extractpdf/extractpdf.h
+src/pdf_outline.c
+CMakeLists.txt
+```
+
+Then:
+
+```bash
+git add include/extractpdf/extractpdf.h src/pdf_outline.c CMakeLists.txt
+git commit -m "feat: expose immutable PDF outline snapshot"
+GREEN_SHA=$(git rev-parse HEAD)
+printf '%s\n' "$GREEN_SHA"
+```
+
+Do not edit RED tests/fixtures between accepted RED and GREEN.
+
+- [ ] **Step 11: Push GREEN and capture normal exact-head Linux CI**
+
+Push `GREEN_SHA` to the existing draft PR. Find the PR workflow whose head SHA equals `GREEN_SHA`; save its actual run ID as `GREEN_RUN_ID`.
+
+Require:
+
+```text
+Linux strict static build + all CTests ✅
+Linux ASan/UBSan build + all CTests   ✅
+```
+
+Do not change code after this proof before `full-ci`.
+
+---
+
+### Task 3: Same-head platform proof, review gate, and bookkeeping
+
+**Files:**
+- No code changes.
+- Update only GitHub PR/issue/roadmap metadata after CI evidence is known.
+
+**Interfaces:**
+- Consumes: `RED_SHA`, `RED_RUN_ID`, `GREEN_SHA`, `GREEN_RUN_ID`, `PR_NUMBER`.
+- Produces: same-head Linux/macOS/Windows evidence and a draft/open/unmerged PR ready for explicit integration.
+
+- [ ] **Step 1: Verify exact final scope before platform CI**
+
+Compare base `cb0f50b0734bcae00fedd529e4f13701c0852866` to `GREEN_SHA`.
+
+The complete feature diff must contain exactly **11 changed paths**:
+
+```text
+docs/superpowers/specs/2026-08-28-extractpdf-document-outline-design.md
+docs/superpowers/plans/2026-08-28-extractpdf-document-outline.md
+include/extractpdf/extractpdf.h
+src/pdf_outline.c
+CMakeLists.txt
+tests/CMakeLists.txt
+tests/test_pdf_outline.c
+tests/fixtures/outline-tree.pdf
+tests/fixtures/outline-repairable-bad.pdf
+tests/fixtures/outline-cycle.pdf
+tests/fixtures/outline-depth-257.pdf
+```
+
+Any other changed path is a scope blocker. Explicitly reject changes to `src/document.c`, `src/internal.h`, `src/links.c`, `src/pdf_metadata.c`, `src/pdf_export.c`, `src/pdf_merge.c`, `src/pdf_output.c`, or `src/output_file.c`.
+
+- [ ] **Step 2: Trigger same-head `full-ci` without a code change**
+
+Add the existing `full-ci` label to the draft PR. Re-read the PR head and require it still equals `GREEN_SHA`. Save the label-triggered workflow run ID as `FULL_RUN_ID`, and require that run's head SHA also equals `GREEN_SHA`.
+
+- [ ] **Step 3: Require all platform jobs on that exact head**
+
+Require `FULL_RUN_ID` to complete successfully with:
+
+```text
+Linux static configure/build/all CTests       ✅
+Linux ASan/UBSan configure/build/all CTests   ✅
+macOS configure/build/test                    ✅
+Windows DLL configure/build/test              ✅
+```
+
+On Windows, verify `extractpdf_test_pdf_outline` is in the DLL-copy list and `extractpdf.pdf_outline` passes through the shared-library build.
+
+- [ ] **Step 4: Perform a fresh exact-diff review against the spec**
+
+Review `cb0f50b...GREEN_SHA` and explicitly verify:
+
+```text
+public ABI exactly matches the spec
+PDF-only gate precedes outline extraction
+preflight is read-only, iterative, and cycle/repeated-node safe
+preflight validates the full tree before choosing depth UNSUPPORTED
+bad Parent/Prev/Last -> FORMAT without silent repair
+valid 257-level tree -> UNSUPPORTED before iterator creation
+empty outline -> non-NULL count-0 snapshot
+preorder parent/child/sibling indices are exact
+internal destination -> flat page + Fitz x/y
+URI/title strings are snapshot-owned only
+absent title != present-empty title
+snapshot survives document close
+no MuPDF/document pointer survives publication
+all failures publish NULL / reset accessor outputs
+indices are snapshot-local only, never mutation identities
+no unrelated Phase 3/4 implementation changed
+```
+
+Any Critical/Important finding requires a new GREEN SHA and fresh Linux + same-head full-ci evidence.
+
+- [ ] **Step 5: Update the draft PR with actual evidence**
+
+Use the captured values `RED_SHA`, `RED_RUN_ID`, `GREEN_SHA`, `GREEN_RUN_ID`, and `FULL_RUN_ID`. Do not invent run or PR numbers. Record:
+
+```text
+RED: existing targets/tests green; only outline API target absent
+GREEN: Linux static + all CTests ✅; ASan/UBSan + all CTests ✅
+full-ci same head: Linux ✅; macOS ✅; Windows DLL ✅
+```
+
+Keep the PR draft/open/unmerged.
+
+- [ ] **Step 6: Update #33 but keep it open**
+
+Write the actual captured PR number, RED/GREEN/full-ci evidence, final scope, and locked safety semantics into #33. State that implementation/evidence closure is complete but the issue remains open for integration bookkeeping.
+
+- [ ] **Step 7: Update umbrella #2 conservatively**
+
+Mark only the Phase 5 Outline/bookmarks implementation line complete, link #33 and the captured PR number, and record `GREEN_SHA` + `FULL_RUN_ID` while stating the PR is still draft/open/unmerged. Do not mark annotation enumeration, annotation mutation, forms/widgets, or the interactive-mutation architecture decision complete.
+
+- [ ] **Step 8: Stop at the integration decision gate**
+
+Report the draft/open/unmerged PR state, mergeability, `GREEN_SHA`, RED run, Linux GREEN run, same-head full-ci run, and remaining Phase 5 items. Do not mark ready and do not merge without explicit later authorization.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-document-outline-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-document-outline-design.md
@@ -1,0 +1,427 @@
+# ExtractPDF PDF Outline / Bookmarks V1 Design
+
+## Status
+
+Approved architectural design for Phase 5 Interactive PDF child issue #33 under roadmap #2.
+
+Base: integrated `master` exact SHA `cb0f50b0734bcae00fedd529e4f13701c0852866`.
+
+This slice defines a PDF-only, read-only document-outline snapshot. Outline editing/mutation remains a separate future architecture.
+
+## Goals
+
+- Reuse the existing opaque `extractpdf_document`.
+- Expose no MuPDF types, `fz_location`, PDF object pointers, or PDF destination syntax.
+- Return an ExtractPDF-owned immutable outline snapshot independent of document lifetime.
+- Preserve hierarchy through flat preorder indices, not a public pointer graph.
+- Map internal destinations to the existing zero-based flat PDF page index plus Fitz page-space x/y.
+- Distinguish no destination, internal destination, and external URI destination.
+- Refuse malformed/cyclic/repairable PDF outline structures instead of silently repairing the live PDF.
+- Keep ExtractPDF-owned preflight and flattening iterative.
+- Bound MuPDF 1.28.2's unavoidable recursive PDF-outline validation before invoking it.
+
+## Non-goals
+
+V1 does not provide outline mutation, persistent bookmark IDs, non-PDF outline semantics, chapter/layout locations, raw PDF destination/action objects, style decoration, JavaScript execution, remote-document loading, or a second public PDF-document handle.
+
+## PDF-only Boundary
+
+MuPDF can expose outlines for multiple formats, but non-PDF handlers may use chapter/page locations and reflow/layout semantics. ExtractPDF currently exposes a stable flat page model only.
+
+```text
+PDF document      -> outline snapshot API
+non-PDF document  -> EXTRACTPDF_ERROR_UNSUPPORTED
+```
+
+## Public ABI
+
+```c
+typedef struct extractpdf_outline extractpdf_outline;
+
+typedef enum extractpdf_outline_destination_kind {
+    EXTRACTPDF_OUTLINE_DESTINATION_NONE = 0,
+    EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL = 1,
+    EXTRACTPDF_OUTLINE_DESTINATION_URI = 2
+} extractpdf_outline_destination_kind;
+
+typedef struct extractpdf_outline_info {
+    size_t struct_size;
+
+    size_t parent_index;
+    size_t first_child_index;
+    size_t next_sibling_index;
+
+    extractpdf_outline_destination_kind destination_kind;
+    int target_page;
+    extractpdf_point target;
+
+    int is_open;
+} extractpdf_outline_info;
+
+EXTRACTPDF_API extractpdf_status extractpdf_document_outline(
+    extractpdf_document *document,
+    extractpdf_outline **out_outline);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_count(
+    const extractpdf_outline *outline,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_get_info(
+    const extractpdf_outline *outline,
+    size_t index,
+    extractpdf_outline_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_title(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_uri(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API void extractpdf_drop_outline(
+    extractpdf_outline *outline);
+```
+
+`extractpdf_link_kind` is not reused because outline nodes have a legal no-destination state and may evolve independently from page links.
+
+## Hierarchy Representation
+
+Nodes are stored in global preorder traversal order.
+
+```text
+0 Chapter 1
+1   Section 1.1
+2   Section 1.2
+3     Section 1.2.1
+4 Chapter 2
+```
+
+Each node exposes `parent_index`, `first_child_index`, and `next_sibling_index`.
+
+```text
+SIZE_MAX = no parent / no first child / no next sibling
+```
+
+No extra public `EXTRACTPDF_INDEX_NONE` macro is added.
+
+Indices are snapshot-local coordinates only. They are not PDF object numbers, persistent bookmark IDs, cross-snapshot identities, or valid mutation handles.
+
+## `struct_size` Compatibility
+
+Callers initialize:
+
+```c
+extractpdf_outline_info info = {0};
+info.struct_size = sizeof(info);
+```
+
+V1 requires the supplied struct to cover through `is_open`. Larger structs are accepted; V1 writes only fields it knows.
+
+After `struct_size` validation and before later handle/index validation, known fields are reset to:
+
+```text
+parent_index       = SIZE_MAX
+first_child_index  = SIZE_MAX
+next_sibling_index = SIZE_MAX
+destination_kind   = NONE
+target_page        = -1
+target             = {0,0}
+is_open            = 0
+```
+
+Future style fields can be appended ABI-safely.
+
+## Destination Contract
+
+### NONE
+
+```text
+destination_kind = NONE
+target_page      = -1
+target            = {0,0}
+outline_uri()     = unavailable
+```
+
+### INTERNAL
+
+```text
+destination_kind = INTERNAL
+target_page      = zero-based flat PDF page index
+target            = Fitz page-space x/y
+outline_uri()     = unavailable
+```
+
+The public ABI never exposes `fz_location` or raw PDF destination syntax. A non-null internal destination that cannot resolve to a valid PDF page causes the entire extraction to fail with `EXTRACTPDF_ERROR_FORMAT`; V1 never publishes `INTERNAL + target_page = -1`.
+
+### URI
+
+```text
+destination_kind = URI
+target_page      = -1
+target            = {0,0}
+outline_uri()     = snapshot-owned borrowed UTF-8 URI
+```
+
+ExtractPDF never executes or fetches the URI.
+
+## Title and URI Ownership
+
+Strings are copied once into snapshot-owned storage.
+
+`extractpdf_outline_title()`:
+
+```text
+absent title        -> EXTRACTPDF_OK, NULL, 0
+present empty title -> EXTRACTPDF_OK, borrowed "", 0
+present title       -> EXTRACTPDF_OK, borrowed UTF-8, byte size excluding NUL
+```
+
+`extractpdf_outline_uri()`:
+
+```text
+URI node             -> EXTRACTPDF_OK + borrowed URI
+NONE / INTERNAL      -> EXTRACTPDF_ERROR_ARGUMENT + NULL + 0
+invalid handle/index -> EXTRACTPDF_ERROR_ARGUMENT + NULL + 0
+```
+
+Pointers remain valid until `extractpdf_drop_outline()`.
+
+## Display State
+
+V1 exposes only `is_open`. Bold, italic, RGB color, and other presentation decoration are deferred.
+
+## Empty Outline
+
+No `/Outlines`, or an outline root with no first item, is a valid empty collection:
+
+```text
+extractpdf_document_outline() -> EXTRACTPDF_OK
+*out_outline                  -> non-NULL snapshot
+extractpdf_outline_count()    -> 0
+```
+
+Success always returns a valid snapshot handle; failure leaves `*out_outline == NULL`.
+
+## Snapshot Lifetime
+
+The completed snapshot must retain no MuPDF/document state. Conceptually:
+
+```text
+extractpdf_outline
+  ├── nodes[]
+  └── strings[]
+```
+
+Internal records contain relation indices, destination data, state, and string offsets/sizes. The snapshot retains no `fz_outline*`, iterator, `pdf_obj*`, `fz_document*`, or `extractpdf_document*`.
+
+Therefore the source document may be closed immediately after extraction and all snapshot accessors remain valid.
+
+`extractpdf_drop_outline(NULL)` is a safe no-op.
+
+## Read-only PDF Structural Preflight
+
+MuPDF 1.28.2's PDF outline iterator constructor validates the outline tree and may repair inconsistent `Parent`, `Prev`, and parent `Last` relationships. It rejects cycles. ExtractPDF's read API must not trigger that silent repair behavior.
+
+Before invoking the MuPDF iterator, ExtractPDF performs an iterative, read-only walk of `/Root/Outlines` and verifies at minimum:
+
+- every traversed outline item is an indirect dictionary;
+- expected `Parent` is correct;
+- expected `Prev` is correct;
+- each parent's `Last` matches the final entry in its child/sibling chain;
+- every node is visited at most once;
+- cycles/repeated nodes are rejected;
+- sibling/child traversal terminates;
+- node/depth/allocation accounting cannot overflow.
+
+Any inconsistency MuPDF would otherwise repair returns `EXTRACTPDF_ERROR_FORMAT`. The read API never intentionally changes PDF outline objects.
+
+ExtractPDF-owned preflight and preorder flattening use explicit heap-backed stack/worklist state, not recursion driven by attacker-controlled outline depth.
+
+## MuPDF 1.28.2 Recursive Validation Safety Bound
+
+Pinned MuPDF 1.28.2 still performs a recursive validation pass inside its PDF outline iterator constructor. ExtractPDF calculates maximum depth during iterative preflight and refuses excessive valid trees before invoking that constructor.
+
+```text
+maximum accepted outline depth = 256 levels
+
+malformed / cyclic / inconsistent tree -> EXTRACTPDF_ERROR_FORMAT
+valid depth <= 256                      -> continue
+valid depth > 256                       -> EXTRACTPDF_ERROR_UNSUPPORTED
+```
+
+The numeric bound is a private V1 implementation capability, not a public struct field or persistent ABI guarantee. The public semantic distinction is stable: `FORMAT` means malformed; `UNSUPPORTED` means structurally valid but outside this V1 safety capability.
+
+Pinned MuPDF 1.28.2's public `pdf_load_page_tree()` entry point is currently a no-op, so it introduces no additional page-tree repair requirement for this slice.
+
+## MuPDF Integration Boundary
+
+After PDF-only gating, successful iterative preflight, and depth validation:
+
+```text
+extractpdf_document
+    ↓
+pdf_specifics()
+    ↓
+iterative read-only outline preflight
+    ↓
+depth <= 256
+    ↓
+MuPDF outline iterator/item decoding
+    ↓
+resolve destination
+    ↓
+iterative preorder flatten + deep copy
+    ↓
+extractpdf_outline snapshot
+```
+
+MuPDF destination/action parsing is reused internally rather than duplicated. No MuPDF pointer survives in the published snapshot.
+
+## Error Atomicity
+
+`extractpdf_document_outline()` resets `*out_outline = NULL` before validation/fallible work.
+
+```text
+out_outline == NULL                  -> ARGUMENT
+document == NULL                     -> ARGUMENT
+non-PDF                              -> UNSUPPORTED
+valid empty                          -> OK + empty snapshot
+repairable structure inconsistency  -> FORMAT
+cycle / repeated node                -> FORMAT
+malformed outline data               -> existing MuPDF format mapping
+unresolvable internal destination    -> FORMAT
+valid depth > 256                    -> UNSUPPORTED
+allocation / size overflow           -> NOMEM
+other MuPDF exception                -> existing status mapper
+```
+
+No partial snapshot is ever published. Temporary MuPDF state and partial ExtractPDF allocations are released on failure.
+
+## Implementation Boundary
+
+Production scope:
+
+```text
+Modify: include/extractpdf/extractpdf.h
+Create: src/pdf_outline.c
+Modify: CMakeLists.txt
+```
+
+Do not modify for this slice:
+
+```text
+src/document.c
+src/internal.h
+src/links.c
+src/pdf_metadata.c
+Phase 4 composition/output implementation
+existing Page/Render/Text/Search/Image/Links behavior
+```
+
+`src/pdf_outline.c` privately owns all outline snapshot records, structural preflight, flattening, string arena, and cleanup logic. No generic PDF-root helper is introduced solely for this feature.
+
+## Deterministic Test Fixtures
+
+### `outline-tree.pdf`
+
+A three-page PDF with deterministic preorder:
+
+```text
+0 Chapter 1
+1   Section 1.1
+2   Website
+3   No target
+4 Chapter 2
+```
+
+It must prove exact preorder indices, hierarchy relations, `SIZE_MAX`, Unicode and ordinary titles, one absent title, one present-empty title, internal page+x/y, external URI, no-destination, open/closed nodes, and post-document-close snapshot lifetime.
+
+### `outline-repairable-bad.pdf`
+
+Contains a deterministic `Parent`, `Prev`, or parent `Last` inconsistency that MuPDF would normally attempt to repair. Expected: `EXTRACTPDF_ERROR_FORMAT` and NULL output.
+
+### `outline-cycle.pdf`
+
+Contains a deterministic `Next` and/or child cycle. Expected: `FORMAT`, NULL output, deterministic termination.
+
+### Existing no-outline PDF
+
+Reuse an existing valid PDF to prove `OK + non-NULL snapshot + count 0`.
+
+### `outline-depth-257.pdf`
+
+A deterministic valid PDF with exactly 257 nested outline levels. This checked-in fixture is required, not optional. Expected: `EXTRACTPDF_ERROR_UNSUPPORTED` and NULL output.
+
+## Strict TDD Boundary
+
+```text
+master cb0f50b0734bcae00fedd529e4f13701c0852866
+  ↓
+feat/document-outline
+```
+
+RED contains only:
+
+```text
+tests/fixtures/outline-tree.pdf
+tests/fixtures/outline-repairable-bad.pdf
+tests/fixtures/outline-cycle.pdf
+tests/fixtures/outline-depth-257.pdf
+tests/test_pdf_outline.c
+tests/CMakeLists.txt
+```
+
+No public outline declaration or production implementation may exist at RED.
+
+Acceptable RED: library and every pre-existing test target build/link; only the new outline target fails because the outline type/enum/API are absent. Fixture parse errors, unrelated regressions, crashes, or timeouts are invalid RED.
+
+GREEN adds only:
+
+```text
+include/extractpdf/extractpdf.h
+src/pdf_outline.c
+CMakeLists.txt
+```
+
+Exact GREEN head must pass:
+
+```text
+Linux strict static + all CTests       ✅
+Linux ASan/UBSan + all CTests          ✅
+same-head macOS configure/build/test   ✅
+same-head Windows DLL build/test       ✅
+```
+
+Windows must execute the outline CTest through the shared-library build so the ABI is proven exported, linkable, and runnable.
+
+## Future Mutation Isolation
+
+MuPDF has editable outline iterators, but V1 exposes no mutation path and snapshot indices are never mutation identities. Future insert/rename/move/delete/destination/style operations require a separate design covering mutable document state, transaction/rollback behavior, save/rewrite integration, stable selector identity, and interaction with pre-existing snapshots.
+
+## Architecture Summary
+
+```text
+PDF-only
++ existing extractpdf_document
++ immutable extractpdf_outline snapshot
++ preorder flat node table
++ parent / first-child / next-sibling indices
++ SIZE_MAX relation sentinel
++ NONE / INTERNAL / URI destinations
++ flat PDF page + Fitz x/y internal targets
++ snapshot-owned title / external URI
++ is_open only
++ valid empty snapshot
++ iterative read-only structural preflight
++ no silent outline repair
++ cycle/repeated-node rejection
++ private 256-level safety bound
++ document-independent snapshot lifetime
++ snapshot-local indices only
++ mutation deferred to a separate architecture
+```

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -25,6 +25,7 @@ typedef struct extractpdf_text_page extractpdf_text_page;
 typedef struct extractpdf_image_page extractpdf_image_page;
 typedef struct extractpdf_link_page extractpdf_link_page;
 typedef struct extractpdf_output extractpdf_output;
+typedef struct extractpdf_outline extractpdf_outline;
 
 typedef struct extractpdf_point {
     float x;
@@ -108,6 +109,23 @@ typedef struct extractpdf_link_info {
     extractpdf_point target;
 } extractpdf_link_info;
 
+typedef enum extractpdf_outline_destination_kind {
+    EXTRACTPDF_OUTLINE_DESTINATION_NONE = 0,
+    EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL = 1,
+    EXTRACTPDF_OUTLINE_DESTINATION_URI = 2
+} extractpdf_outline_destination_kind;
+
+typedef struct extractpdf_outline_info {
+    size_t struct_size;
+    size_t parent_index;
+    size_t first_child_index;
+    size_t next_sibling_index;
+    extractpdf_outline_destination_kind destination_kind;
+    int target_page;
+    extractpdf_point target;
+    int is_open;
+} extractpdf_outline_info;
+
 typedef enum extractpdf_metadata_field {
     EXTRACTPDF_METADATA_TITLE = 1,
     EXTRACTPDF_METADATA_AUTHOR = 2,
@@ -143,6 +161,31 @@ EXTRACTPDF_API extractpdf_status extractpdf_document_metadata(
     extractpdf_document *document,
     extractpdf_metadata_field field,
     char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API extractpdf_status extractpdf_document_outline(
+    extractpdf_document *document,
+    extractpdf_outline **out_outline);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_count(
+    const extractpdf_outline *outline,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_get_info(
+    const extractpdf_outline *outline,
+    size_t index,
+    extractpdf_outline_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_title(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API extractpdf_status extractpdf_outline_uri(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
     size_t *out_size);
 
 EXTRACTPDF_API extractpdf_status extractpdf_export_pages(
@@ -323,6 +366,9 @@ EXTRACTPDF_API void extractpdf_drop_image_page(
 
 EXTRACTPDF_API void extractpdf_drop_link_page(
     extractpdf_link_page *links);
+
+EXTRACTPDF_API void extractpdf_drop_outline(
+    extractpdf_outline *outline);
 
 EXTRACTPDF_API void extractpdf_drop_bitmap(
     extractpdf_bitmap *bitmap);

--- a/src/pdf_outline.c
+++ b/src/pdf_outline.c
@@ -1,0 +1,692 @@
+#include "pdf_internal.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EXTRACTPDF_OUTLINE_MAX_DEPTH 256u
+
+typedef struct extractpdf_outline_node_internal {
+    size_t parent_index;
+    size_t first_child_index;
+    size_t next_sibling_index;
+    extractpdf_outline_destination_kind destination_kind;
+    int target_page;
+    extractpdf_point target;
+    size_t title_offset;
+    size_t title_size;
+    size_t uri_offset;
+    size_t uri_size;
+    int has_title;
+    int is_open;
+} extractpdf_outline_node_internal;
+
+struct extractpdf_outline {
+    extractpdf_outline_node_internal *nodes;
+    char *strings;
+    size_t count;
+    size_t string_size;
+    size_t string_capacity;
+};
+
+typedef struct extractpdf_outline_preflight_frame {
+    pdf_obj *parent;
+    pdf_obj *node;
+    pdf_obj *expected_prev;
+    size_t depth;
+} extractpdf_outline_preflight_frame;
+
+typedef struct extractpdf_outline_preflight {
+    extractpdf_outline_preflight_frame *stack;
+    size_t stack_count;
+    size_t stack_capacity;
+    size_t node_count;
+    int too_deep;
+} extractpdf_outline_preflight;
+
+static void extractpdf_dispose_outline(extractpdf_outline *outline)
+{
+    if (outline == NULL)
+        return;
+    free(outline->nodes);
+    free(outline->strings);
+    free(outline);
+}
+
+static void extractpdf_init_outline_node(extractpdf_outline_node_internal *node)
+{
+    memset(node, 0, sizeof(*node));
+    node->parent_index = SIZE_MAX;
+    node->first_child_index = SIZE_MAX;
+    node->next_sibling_index = SIZE_MAX;
+    node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_NONE;
+    node->target_page = -1;
+}
+
+static extractpdf_outline *extractpdf_allocate_outline(size_t count)
+{
+    extractpdf_outline *outline;
+    size_t index;
+
+    outline = (extractpdf_outline *)calloc(1, sizeof(*outline));
+    if (outline == NULL)
+        return NULL;
+
+    if (count != 0) {
+        if (count > SIZE_MAX / sizeof(*outline->nodes)) {
+            free(outline);
+            return NULL;
+        }
+        outline->nodes = (extractpdf_outline_node_internal *)calloc(
+            count, sizeof(*outline->nodes));
+        if (outline->nodes == NULL) {
+            free(outline);
+            return NULL;
+        }
+        for (index = 0; index < count; ++index)
+            extractpdf_init_outline_node(&outline->nodes[index]);
+    }
+
+    outline->count = count;
+    return outline;
+}
+
+static extractpdf_status extractpdf_outline_append_string(
+    extractpdf_outline *outline,
+    const char *text,
+    size_t *out_offset,
+    size_t *out_size)
+{
+    size_t size;
+    size_t required;
+    size_t capacity;
+    char *grown;
+
+    size = strlen(text);
+    if (size == SIZE_MAX || outline->string_size > SIZE_MAX - size - 1)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    required = outline->string_size + size + 1;
+    if (required > outline->string_capacity) {
+        capacity = outline->string_capacity != 0 ?
+            outline->string_capacity : 64;
+        while (capacity < required) {
+            if (capacity > SIZE_MAX / 2) {
+                capacity = required;
+                break;
+            }
+            capacity *= 2;
+        }
+        if (capacity < required)
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        grown = (char *)realloc(outline->strings, capacity);
+        if (grown == NULL)
+            return EXTRACTPDF_ERROR_NOMEM;
+        outline->strings = grown;
+        outline->string_capacity = capacity;
+    }
+
+    *out_offset = outline->string_size;
+    *out_size = size;
+    memcpy(outline->strings + outline->string_size, text, size + 1);
+    outline->string_size = required;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_preflight_push(
+    extractpdf_outline_preflight *preflight,
+    const extractpdf_outline_preflight_frame *frame)
+{
+    size_t capacity;
+    extractpdf_outline_preflight_frame *grown;
+
+    if (preflight->stack_count == preflight->stack_capacity) {
+        if (preflight->stack_capacity == 0) {
+            capacity = 32;
+        } else {
+            if (preflight->stack_capacity > SIZE_MAX / 2)
+                return EXTRACTPDF_ERROR_NOMEM;
+            capacity = preflight->stack_capacity * 2;
+        }
+        if (capacity > SIZE_MAX / sizeof(*preflight->stack))
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        grown = (extractpdf_outline_preflight_frame *)realloc(
+            preflight->stack, capacity * sizeof(*preflight->stack));
+        if (grown == NULL)
+            return EXTRACTPDF_ERROR_NOMEM;
+        preflight->stack = grown;
+        preflight->stack_capacity = capacity;
+    }
+
+    preflight->stack[preflight->stack_count++] = *frame;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_preflight_pdf_outline(
+    fz_context *ctx,
+    pdf_document *pdf,
+    size_t *out_count)
+{
+    pdf_obj *trailer;
+    pdf_obj *root;
+    pdf_obj *outlines;
+    pdf_obj *first;
+    pdf_obj *last;
+    pdf_mark_bits *marks = NULL;
+    extractpdf_outline_preflight *preflight;
+    extractpdf_outline_preflight_frame frame;
+    extractpdf_status status = EXTRACTPDF_OK;
+    int caught_code = FZ_ERROR_NONE;
+    size_t node_count;
+    int too_deep;
+
+    *out_count = 0;
+
+    preflight = (extractpdf_outline_preflight *)calloc(1, sizeof(*preflight));
+    if (preflight == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    fz_var(marks);
+    fz_var(status);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        trailer = pdf_trailer(ctx, pdf);
+        root = pdf_dict_get(ctx, trailer, PDF_NAME(Root));
+        if (!pdf_is_dict(ctx, root)) {
+            status = EXTRACTPDF_ERROR_FORMAT;
+        } else {
+            outlines = pdf_dict_get(ctx, root, PDF_NAME(Outlines));
+            if (outlines == NULL) {
+                status = EXTRACTPDF_OK;
+            } else if (!pdf_is_dict(ctx, outlines)) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+            } else {
+                first = pdf_dict_get(ctx, outlines, PDF_NAME(First));
+                last = pdf_dict_get(ctx, outlines, PDF_NAME(Last));
+                if ((first == NULL) != (last == NULL)) {
+                    status = EXTRACTPDF_ERROR_FORMAT;
+                } else if (first != NULL) {
+                    marks = pdf_new_mark_bits(ctx, pdf);
+                    frame.parent = outlines;
+                    frame.node = first;
+                    frame.expected_prev = NULL;
+                    frame.depth = 1;
+                    status = extractpdf_preflight_push(preflight, &frame);
+                }
+            }
+        }
+
+        while (status == EXTRACTPDF_OK && preflight->stack_count != 0) {
+            pdf_obj *next;
+            pdf_obj *child;
+            pdf_obj *child_last;
+
+            frame = preflight->stack[--preflight->stack_count];
+
+            if (!pdf_is_dict(ctx, frame.node) ||
+                !pdf_is_indirect(ctx, frame.node)) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+            if (pdf_mark_bits_set(ctx, marks, frame.node)) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+            if (pdf_objcmp(
+                    ctx,
+                    pdf_dict_get(ctx, frame.node, PDF_NAME(Parent)),
+                    frame.parent) != 0) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+            if (pdf_objcmp(
+                    ctx,
+                    pdf_dict_get(ctx, frame.node, PDF_NAME(Prev)),
+                    frame.expected_prev) != 0) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+            if (preflight->node_count == SIZE_MAX) {
+                status = EXTRACTPDF_ERROR_NOMEM;
+                break;
+            }
+
+            ++preflight->node_count;
+            if (frame.depth > EXTRACTPDF_OUTLINE_MAX_DEPTH)
+                preflight->too_deep = 1;
+
+            next = pdf_dict_get(ctx, frame.node, PDF_NAME(Next));
+            child = pdf_dict_get(ctx, frame.node, PDF_NAME(First));
+            child_last = pdf_dict_get(ctx, frame.node, PDF_NAME(Last));
+
+            if ((child == NULL) != (child_last == NULL)) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+
+            if (next == NULL &&
+                pdf_objcmp(
+                    ctx,
+                    pdf_dict_get(ctx, frame.parent, PDF_NAME(Last)),
+                    frame.node) != 0) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+
+            if (next != NULL) {
+                extractpdf_outline_preflight_frame sibling = frame;
+                sibling.node = next;
+                sibling.expected_prev = frame.node;
+                status = extractpdf_preflight_push(preflight, &sibling);
+                if (status != EXTRACTPDF_OK)
+                    break;
+            }
+
+            if (child != NULL) {
+                extractpdf_outline_preflight_frame child_frame;
+                if (frame.depth == SIZE_MAX) {
+                    status = EXTRACTPDF_ERROR_NOMEM;
+                    break;
+                }
+                child_frame.parent = frame.node;
+                child_frame.node = child;
+                child_frame.expected_prev = NULL;
+                child_frame.depth = frame.depth + 1;
+                status = extractpdf_preflight_push(preflight, &child_frame);
+            }
+        }
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    node_count = preflight->node_count;
+    too_deep = preflight->too_deep;
+    if (marks != NULL)
+        pdf_drop_mark_bits(ctx, marks);
+    free(preflight->stack);
+    free(preflight);
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (status != EXTRACTPDF_OK)
+        return status;
+    if (too_deep)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    *out_count = node_count;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_decode_outline_item(
+    fz_context *ctx,
+    fz_document *document,
+    int page_count,
+    extractpdf_outline *outline,
+    size_t index,
+    size_t parent_index,
+    size_t previous_sibling_index,
+    const fz_outline_item *item)
+{
+    extractpdf_outline_node_internal *node = &outline->nodes[index];
+    extractpdf_status status;
+
+    node->parent_index = parent_index;
+    if (parent_index != SIZE_MAX &&
+        outline->nodes[parent_index].first_child_index == SIZE_MAX)
+        outline->nodes[parent_index].first_child_index = index;
+    if (previous_sibling_index != SIZE_MAX)
+        outline->nodes[previous_sibling_index].next_sibling_index = index;
+
+    node->is_open = item->is_open != 0;
+
+    if (item->title != NULL) {
+        status = extractpdf_outline_append_string(
+            outline, item->title, &node->title_offset, &node->title_size);
+        if (status != EXTRACTPDF_OK)
+            return status;
+        node->has_title = 1;
+    }
+
+    if (item->uri == NULL) {
+        node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_NONE;
+        return EXTRACTPDF_OK;
+    }
+
+    if (fz_is_external_link(ctx, item->uri)) {
+        node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_URI;
+        return extractpdf_outline_append_string(
+            outline, item->uri, &node->uri_offset, &node->uri_size);
+    }
+
+    {
+        fz_link_dest destination = fz_resolve_link_dest(ctx, document, item->uri);
+        int page;
+
+        if (destination.loc.chapter < 0 || destination.loc.page < 0)
+            return EXTRACTPDF_ERROR_FORMAT;
+
+        page = fz_page_number_from_location(ctx, document, destination.loc);
+        if (page < 0 || page >= page_count)
+            return EXTRACTPDF_ERROR_FORMAT;
+
+        node->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL;
+        node->target_page = page;
+        node->target.x = destination.x;
+        node->target.y = destination.y;
+    }
+
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_flatten_pdf_outline(
+    fz_context *ctx,
+    fz_document *document,
+    extractpdf_outline *outline)
+{
+    fz_outline_iterator *iter = NULL;
+    size_t *parent_stack;
+    size_t stack_count = 0;
+    size_t index = 0;
+    size_t parent_index = SIZE_MAX;
+    size_t previous_sibling_index = SIZE_MAX;
+    int page_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+    extractpdf_status status = EXTRACTPDF_OK;
+
+    parent_stack = (size_t *)malloc(
+        EXTRACTPDF_OUTLINE_MAX_DEPTH * sizeof(*parent_stack));
+    if (parent_stack == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    fz_var(iter);
+    fz_var(index);
+    fz_var(stack_count);
+    fz_var(parent_index);
+    fz_var(previous_sibling_index);
+    fz_var(page_count);
+    fz_var(caught_code);
+    fz_var(status);
+
+    fz_try(ctx)
+    {
+        page_count = fz_count_pages(ctx, document);
+        iter = fz_new_outline_iterator(ctx, document);
+        if (iter == NULL)
+            status = EXTRACTPDF_ERROR_FORMAT;
+
+        while (status == EXTRACTPDF_OK && index < outline->count) {
+            fz_outline_item *item;
+            size_t current_index = index;
+            size_t cursor_index = current_index;
+            int move;
+            int exhausted = 0;
+
+            item = fz_outline_iterator_item(ctx, iter);
+            if (item == NULL) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+
+            status = extractpdf_decode_outline_item(
+                ctx,
+                document,
+                page_count,
+                outline,
+                current_index,
+                parent_index,
+                previous_sibling_index,
+                item);
+            if (status != EXTRACTPDF_OK)
+                break;
+
+            move = fz_outline_iterator_down(ctx, iter);
+            if (move == FZ_OUTLINE_ITERATOR_AT_ITEM) {
+                if (stack_count >= EXTRACTPDF_OUTLINE_MAX_DEPTH) {
+                    status = EXTRACTPDF_ERROR_UNSUPPORTED;
+                    break;
+                }
+                parent_stack[stack_count++] = parent_index;
+                parent_index = current_index;
+                previous_sibling_index = SIZE_MAX;
+                ++index;
+                continue;
+            }
+            if (move == FZ_OUTLINE_ITERATOR_AT_EMPTY) {
+                if (fz_outline_iterator_up(ctx, iter) !=
+                    FZ_OUTLINE_ITERATOR_AT_ITEM) {
+                    status = EXTRACTPDF_ERROR_FORMAT;
+                    break;
+                }
+            } else {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+
+            while (status == EXTRACTPDF_OK) {
+                move = fz_outline_iterator_next(ctx, iter);
+                if (move == FZ_OUTLINE_ITERATOR_AT_ITEM) {
+                    previous_sibling_index = cursor_index;
+                    ++index;
+                    break;
+                }
+                if (move == FZ_OUTLINE_ITERATOR_AT_EMPTY) {
+                    if (stack_count == 0) {
+                        ++index;
+                        exhausted = 1;
+                        break;
+                    }
+                    if (fz_outline_iterator_up(ctx, iter) !=
+                        FZ_OUTLINE_ITERATOR_AT_ITEM) {
+                        status = EXTRACTPDF_ERROR_FORMAT;
+                        break;
+                    }
+                    cursor_index = parent_index;
+                    parent_index = parent_stack[--stack_count];
+                    continue;
+                }
+
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+
+            if (exhausted)
+                break;
+        }
+
+        if (status == EXTRACTPDF_OK && index != outline->count)
+            status = EXTRACTPDF_ERROR_FORMAT;
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (iter != NULL)
+        fz_drop_outline_iterator(ctx, iter);
+    free(parent_stack);
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    return status;
+}
+
+extractpdf_status extractpdf_document_outline(
+    extractpdf_document *document,
+    extractpdf_outline **out_outline)
+{
+    fz_context *ctx;
+    pdf_document *pdf = NULL;
+    extractpdf_outline *outline;
+    extractpdf_status preflight_status = EXTRACTPDF_OK;
+    extractpdf_status flatten_status;
+    size_t count = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_outline == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_outline = NULL;
+
+    if (document == NULL || document->ctx == NULL || document->doc == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = document->ctx;
+    fz_var(pdf);
+    fz_var(preflight_status);
+    fz_var(count);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        pdf = pdf_specifics(ctx, document->doc);
+        if (pdf != NULL)
+            preflight_status = extractpdf_preflight_pdf_outline(
+                ctx, pdf, &count);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (pdf == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    if (preflight_status != EXTRACTPDF_OK)
+        return preflight_status;
+
+    outline = extractpdf_allocate_outline(count);
+    if (outline == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    if (count != 0) {
+        flatten_status = extractpdf_flatten_pdf_outline(
+            ctx, document->doc, outline);
+        if (flatten_status != EXTRACTPDF_OK) {
+            extractpdf_dispose_outline(outline);
+            return flatten_status;
+        }
+    }
+
+    *out_outline = outline;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_outline_count(
+    const extractpdf_outline *outline,
+    size_t *out_count)
+{
+    if (out_count != NULL)
+        *out_count = 0;
+
+    if (outline == NULL || out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_count = outline->count;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_outline_get_info(
+    const extractpdf_outline *outline,
+    size_t index,
+    extractpdf_outline_info *out_info)
+{
+    const extractpdf_outline_node_internal *node;
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_outline_info, is_open) +
+        sizeof(out_info->is_open);
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->parent_index = SIZE_MAX;
+    out_info->first_child_index = SIZE_MAX;
+    out_info->next_sibling_index = SIZE_MAX;
+    out_info->destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_NONE;
+    out_info->target_page = -1;
+    out_info->target.x = 0.0f;
+    out_info->target.y = 0.0f;
+    out_info->is_open = 0;
+
+    if (outline == NULL || index >= outline->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    node = &outline->nodes[index];
+    out_info->parent_index = node->parent_index;
+    out_info->first_child_index = node->first_child_index;
+    out_info->next_sibling_index = node->next_sibling_index;
+    out_info->destination_kind = node->destination_kind;
+    out_info->target_page = node->target_page;
+    out_info->target = node->target;
+    out_info->is_open = node->is_open;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_outline_title(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size)
+{
+    const extractpdf_outline_node_internal *node;
+
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
+
+    if (outline == NULL || out_utf8 == NULL || out_size == NULL ||
+        index >= outline->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    node = &outline->nodes[index];
+    if (!node->has_title)
+        return EXTRACTPDF_OK;
+
+    *out_utf8 = outline->strings + node->title_offset;
+    *out_size = node->title_size;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_outline_uri(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size)
+{
+    const extractpdf_outline_node_internal *node;
+
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
+
+    if (outline == NULL || out_utf8 == NULL || out_size == NULL ||
+        index >= outline->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    node = &outline->nodes[index];
+    if (node->destination_kind != EXTRACTPDF_OUTLINE_DESTINATION_URI)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_utf8 = outline->strings + node->uri_offset;
+    *out_size = node->uri_size;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_outline(extractpdf_outline *outline)
+{
+    extractpdf_dispose_outline(outline);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,18 @@ target_compile_definitions(extractpdf_test_pdf_metadata PRIVATE
 add_test(NAME extractpdf.pdf_metadata COMMAND extractpdf_test_pdf_metadata)
 set_tests_properties(extractpdf.pdf_metadata PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_pdf_outline test_pdf_outline.c)
+target_link_libraries(extractpdf_test_pdf_outline PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_outline PRIVATE
+  OUTLINE_TREE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-tree.pdf"
+  OUTLINE_REPAIRABLE_BAD_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-repairable-bad.pdf"
+  OUTLINE_CYCLE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-cycle.pdf"
+  OUTLINE_DEPTH_257_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-depth-257.pdf"
+  EMPTY_OUTLINE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-three-page.pdf"
+  COMPOSITION_NON_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-non-pdf.txt")
+add_test(NAME extractpdf.pdf_outline COMMAND extractpdf_test_pdf_outline)
+set_tests_properties(extractpdf.pdf_outline PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -168,7 +180,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_pdf_delete
       extractpdf_test_pdf_merge
       extractpdf_test_output_file
-      extractpdf_test_pdf_metadata)
+      extractpdf_test_pdf_metadata
+      extractpdf_test_pdf_outline)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/outline-cycle.pdf
+++ b/tests/fixtures/outline-cycle.pdf
@@ -1,0 +1,30 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+4 0 obj
+<< /Type /Outlines /First 5 0 R /Last 5 0 R >>
+endobj
+5 0 obj
+<< /Title (Cycle) /Parent 4 0 R /Next 5 0 R >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000208 00000 n 
+0000000270 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+332
+%%EOF

--- a/tests/fixtures/outline-depth-257.pdf
+++ b/tests/fixtures/outline-depth-257.pdf
@@ -1,0 +1,1054 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+4 0 obj
+<< /Type /Outlines /First 5 0 R /Last 5 0 R >>
+endobj
+5 0 obj
+<< /Title (Depth 1) /Parent 4 0 R /First 6 0 R /Last 6 0 R /Count 1 >>
+endobj
+6 0 obj
+<< /Title (Depth 2) /Parent 5 0 R /First 7 0 R /Last 7 0 R /Count 1 >>
+endobj
+7 0 obj
+<< /Title (Depth 3) /Parent 6 0 R /First 8 0 R /Last 8 0 R /Count 1 >>
+endobj
+8 0 obj
+<< /Title (Depth 4) /Parent 7 0 R /First 9 0 R /Last 9 0 R /Count 1 >>
+endobj
+9 0 obj
+<< /Title (Depth 5) /Parent 8 0 R /First 10 0 R /Last 10 0 R /Count 1 >>
+endobj
+10 0 obj
+<< /Title (Depth 6) /Parent 9 0 R /First 11 0 R /Last 11 0 R /Count 1 >>
+endobj
+11 0 obj
+<< /Title (Depth 7) /Parent 10 0 R /First 12 0 R /Last 12 0 R /Count 1 >>
+endobj
+12 0 obj
+<< /Title (Depth 8) /Parent 11 0 R /First 13 0 R /Last 13 0 R /Count 1 >>
+endobj
+13 0 obj
+<< /Title (Depth 9) /Parent 12 0 R /First 14 0 R /Last 14 0 R /Count 1 >>
+endobj
+14 0 obj
+<< /Title (Depth 10) /Parent 13 0 R /First 15 0 R /Last 15 0 R /Count 1 >>
+endobj
+15 0 obj
+<< /Title (Depth 11) /Parent 14 0 R /First 16 0 R /Last 16 0 R /Count 1 >>
+endobj
+16 0 obj
+<< /Title (Depth 12) /Parent 15 0 R /First 17 0 R /Last 17 0 R /Count 1 >>
+endobj
+17 0 obj
+<< /Title (Depth 13) /Parent 16 0 R /First 18 0 R /Last 18 0 R /Count 1 >>
+endobj
+18 0 obj
+<< /Title (Depth 14) /Parent 17 0 R /First 19 0 R /Last 19 0 R /Count 1 >>
+endobj
+19 0 obj
+<< /Title (Depth 15) /Parent 18 0 R /First 20 0 R /Last 20 0 R /Count 1 >>
+endobj
+20 0 obj
+<< /Title (Depth 16) /Parent 19 0 R /First 21 0 R /Last 21 0 R /Count 1 >>
+endobj
+21 0 obj
+<< /Title (Depth 17) /Parent 20 0 R /First 22 0 R /Last 22 0 R /Count 1 >>
+endobj
+22 0 obj
+<< /Title (Depth 18) /Parent 21 0 R /First 23 0 R /Last 23 0 R /Count 1 >>
+endobj
+23 0 obj
+<< /Title (Depth 19) /Parent 22 0 R /First 24 0 R /Last 24 0 R /Count 1 >>
+endobj
+24 0 obj
+<< /Title (Depth 20) /Parent 23 0 R /First 25 0 R /Last 25 0 R /Count 1 >>
+endobj
+25 0 obj
+<< /Title (Depth 21) /Parent 24 0 R /First 26 0 R /Last 26 0 R /Count 1 >>
+endobj
+26 0 obj
+<< /Title (Depth 22) /Parent 25 0 R /First 27 0 R /Last 27 0 R /Count 1 >>
+endobj
+27 0 obj
+<< /Title (Depth 23) /Parent 26 0 R /First 28 0 R /Last 28 0 R /Count 1 >>
+endobj
+28 0 obj
+<< /Title (Depth 24) /Parent 27 0 R /First 29 0 R /Last 29 0 R /Count 1 >>
+endobj
+29 0 obj
+<< /Title (Depth 25) /Parent 28 0 R /First 30 0 R /Last 30 0 R /Count 1 >>
+endobj
+30 0 obj
+<< /Title (Depth 26) /Parent 29 0 R /First 31 0 R /Last 31 0 R /Count 1 >>
+endobj
+31 0 obj
+<< /Title (Depth 27) /Parent 30 0 R /First 32 0 R /Last 32 0 R /Count 1 >>
+endobj
+32 0 obj
+<< /Title (Depth 28) /Parent 31 0 R /First 33 0 R /Last 33 0 R /Count 1 >>
+endobj
+33 0 obj
+<< /Title (Depth 29) /Parent 32 0 R /First 34 0 R /Last 34 0 R /Count 1 >>
+endobj
+34 0 obj
+<< /Title (Depth 30) /Parent 33 0 R /First 35 0 R /Last 35 0 R /Count 1 >>
+endobj
+35 0 obj
+<< /Title (Depth 31) /Parent 34 0 R /First 36 0 R /Last 36 0 R /Count 1 >>
+endobj
+36 0 obj
+<< /Title (Depth 32) /Parent 35 0 R /First 37 0 R /Last 37 0 R /Count 1 >>
+endobj
+37 0 obj
+<< /Title (Depth 33) /Parent 36 0 R /First 38 0 R /Last 38 0 R /Count 1 >>
+endobj
+38 0 obj
+<< /Title (Depth 34) /Parent 37 0 R /First 39 0 R /Last 39 0 R /Count 1 >>
+endobj
+39 0 obj
+<< /Title (Depth 35) /Parent 38 0 R /First 40 0 R /Last 40 0 R /Count 1 >>
+endobj
+40 0 obj
+<< /Title (Depth 36) /Parent 39 0 R /First 41 0 R /Last 41 0 R /Count 1 >>
+endobj
+41 0 obj
+<< /Title (Depth 37) /Parent 40 0 R /First 42 0 R /Last 42 0 R /Count 1 >>
+endobj
+42 0 obj
+<< /Title (Depth 38) /Parent 41 0 R /First 43 0 R /Last 43 0 R /Count 1 >>
+endobj
+43 0 obj
+<< /Title (Depth 39) /Parent 42 0 R /First 44 0 R /Last 44 0 R /Count 1 >>
+endobj
+44 0 obj
+<< /Title (Depth 40) /Parent 43 0 R /First 45 0 R /Last 45 0 R /Count 1 >>
+endobj
+45 0 obj
+<< /Title (Depth 41) /Parent 44 0 R /First 46 0 R /Last 46 0 R /Count 1 >>
+endobj
+46 0 obj
+<< /Title (Depth 42) /Parent 45 0 R /First 47 0 R /Last 47 0 R /Count 1 >>
+endobj
+47 0 obj
+<< /Title (Depth 43) /Parent 46 0 R /First 48 0 R /Last 48 0 R /Count 1 >>
+endobj
+48 0 obj
+<< /Title (Depth 44) /Parent 47 0 R /First 49 0 R /Last 49 0 R /Count 1 >>
+endobj
+49 0 obj
+<< /Title (Depth 45) /Parent 48 0 R /First 50 0 R /Last 50 0 R /Count 1 >>
+endobj
+50 0 obj
+<< /Title (Depth 46) /Parent 49 0 R /First 51 0 R /Last 51 0 R /Count 1 >>
+endobj
+51 0 obj
+<< /Title (Depth 47) /Parent 50 0 R /First 52 0 R /Last 52 0 R /Count 1 >>
+endobj
+52 0 obj
+<< /Title (Depth 48) /Parent 51 0 R /First 53 0 R /Last 53 0 R /Count 1 >>
+endobj
+53 0 obj
+<< /Title (Depth 49) /Parent 52 0 R /First 54 0 R /Last 54 0 R /Count 1 >>
+endobj
+54 0 obj
+<< /Title (Depth 50) /Parent 53 0 R /First 55 0 R /Last 55 0 R /Count 1 >>
+endobj
+55 0 obj
+<< /Title (Depth 51) /Parent 54 0 R /First 56 0 R /Last 56 0 R /Count 1 >>
+endobj
+56 0 obj
+<< /Title (Depth 52) /Parent 55 0 R /First 57 0 R /Last 57 0 R /Count 1 >>
+endobj
+57 0 obj
+<< /Title (Depth 53) /Parent 56 0 R /First 58 0 R /Last 58 0 R /Count 1 >>
+endobj
+58 0 obj
+<< /Title (Depth 54) /Parent 57 0 R /First 59 0 R /Last 59 0 R /Count 1 >>
+endobj
+59 0 obj
+<< /Title (Depth 55) /Parent 58 0 R /First 60 0 R /Last 60 0 R /Count 1 >>
+endobj
+60 0 obj
+<< /Title (Depth 56) /Parent 59 0 R /First 61 0 R /Last 61 0 R /Count 1 >>
+endobj
+61 0 obj
+<< /Title (Depth 57) /Parent 60 0 R /First 62 0 R /Last 62 0 R /Count 1 >>
+endobj
+62 0 obj
+<< /Title (Depth 58) /Parent 61 0 R /First 63 0 R /Last 63 0 R /Count 1 >>
+endobj
+63 0 obj
+<< /Title (Depth 59) /Parent 62 0 R /First 64 0 R /Last 64 0 R /Count 1 >>
+endobj
+64 0 obj
+<< /Title (Depth 60) /Parent 63 0 R /First 65 0 R /Last 65 0 R /Count 1 >>
+endobj
+65 0 obj
+<< /Title (Depth 61) /Parent 64 0 R /First 66 0 R /Last 66 0 R /Count 1 >>
+endobj
+66 0 obj
+<< /Title (Depth 62) /Parent 65 0 R /First 67 0 R /Last 67 0 R /Count 1 >>
+endobj
+67 0 obj
+<< /Title (Depth 63) /Parent 66 0 R /First 68 0 R /Last 68 0 R /Count 1 >>
+endobj
+68 0 obj
+<< /Title (Depth 64) /Parent 67 0 R /First 69 0 R /Last 69 0 R /Count 1 >>
+endobj
+69 0 obj
+<< /Title (Depth 65) /Parent 68 0 R /First 70 0 R /Last 70 0 R /Count 1 >>
+endobj
+70 0 obj
+<< /Title (Depth 66) /Parent 69 0 R /First 71 0 R /Last 71 0 R /Count 1 >>
+endobj
+71 0 obj
+<< /Title (Depth 67) /Parent 70 0 R /First 72 0 R /Last 72 0 R /Count 1 >>
+endobj
+72 0 obj
+<< /Title (Depth 68) /Parent 71 0 R /First 73 0 R /Last 73 0 R /Count 1 >>
+endobj
+73 0 obj
+<< /Title (Depth 69) /Parent 72 0 R /First 74 0 R /Last 74 0 R /Count 1 >>
+endobj
+74 0 obj
+<< /Title (Depth 70) /Parent 73 0 R /First 75 0 R /Last 75 0 R /Count 1 >>
+endobj
+75 0 obj
+<< /Title (Depth 71) /Parent 74 0 R /First 76 0 R /Last 76 0 R /Count 1 >>
+endobj
+76 0 obj
+<< /Title (Depth 72) /Parent 75 0 R /First 77 0 R /Last 77 0 R /Count 1 >>
+endobj
+77 0 obj
+<< /Title (Depth 73) /Parent 76 0 R /First 78 0 R /Last 78 0 R /Count 1 >>
+endobj
+78 0 obj
+<< /Title (Depth 74) /Parent 77 0 R /First 79 0 R /Last 79 0 R /Count 1 >>
+endobj
+79 0 obj
+<< /Title (Depth 75) /Parent 78 0 R /First 80 0 R /Last 80 0 R /Count 1 >>
+endobj
+80 0 obj
+<< /Title (Depth 76) /Parent 79 0 R /First 81 0 R /Last 81 0 R /Count 1 >>
+endobj
+81 0 obj
+<< /Title (Depth 77) /Parent 80 0 R /First 82 0 R /Last 82 0 R /Count 1 >>
+endobj
+82 0 obj
+<< /Title (Depth 78) /Parent 81 0 R /First 83 0 R /Last 83 0 R /Count 1 >>
+endobj
+83 0 obj
+<< /Title (Depth 79) /Parent 82 0 R /First 84 0 R /Last 84 0 R /Count 1 >>
+endobj
+84 0 obj
+<< /Title (Depth 80) /Parent 83 0 R /First 85 0 R /Last 85 0 R /Count 1 >>
+endobj
+85 0 obj
+<< /Title (Depth 81) /Parent 84 0 R /First 86 0 R /Last 86 0 R /Count 1 >>
+endobj
+86 0 obj
+<< /Title (Depth 82) /Parent 85 0 R /First 87 0 R /Last 87 0 R /Count 1 >>
+endobj
+87 0 obj
+<< /Title (Depth 83) /Parent 86 0 R /First 88 0 R /Last 88 0 R /Count 1 >>
+endobj
+88 0 obj
+<< /Title (Depth 84) /Parent 87 0 R /First 89 0 R /Last 89 0 R /Count 1 >>
+endobj
+89 0 obj
+<< /Title (Depth 85) /Parent 88 0 R /First 90 0 R /Last 90 0 R /Count 1 >>
+endobj
+90 0 obj
+<< /Title (Depth 86) /Parent 89 0 R /First 91 0 R /Last 91 0 R /Count 1 >>
+endobj
+91 0 obj
+<< /Title (Depth 87) /Parent 90 0 R /First 92 0 R /Last 92 0 R /Count 1 >>
+endobj
+92 0 obj
+<< /Title (Depth 88) /Parent 91 0 R /First 93 0 R /Last 93 0 R /Count 1 >>
+endobj
+93 0 obj
+<< /Title (Depth 89) /Parent 92 0 R /First 94 0 R /Last 94 0 R /Count 1 >>
+endobj
+94 0 obj
+<< /Title (Depth 90) /Parent 93 0 R /First 95 0 R /Last 95 0 R /Count 1 >>
+endobj
+95 0 obj
+<< /Title (Depth 91) /Parent 94 0 R /First 96 0 R /Last 96 0 R /Count 1 >>
+endobj
+96 0 obj
+<< /Title (Depth 92) /Parent 95 0 R /First 97 0 R /Last 97 0 R /Count 1 >>
+endobj
+97 0 obj
+<< /Title (Depth 93) /Parent 96 0 R /First 98 0 R /Last 98 0 R /Count 1 >>
+endobj
+98 0 obj
+<< /Title (Depth 94) /Parent 97 0 R /First 99 0 R /Last 99 0 R /Count 1 >>
+endobj
+99 0 obj
+<< /Title (Depth 95) /Parent 98 0 R /First 100 0 R /Last 100 0 R /Count 1 >>
+endobj
+100 0 obj
+<< /Title (Depth 96) /Parent 99 0 R /First 101 0 R /Last 101 0 R /Count 1 >>
+endobj
+101 0 obj
+<< /Title (Depth 97) /Parent 100 0 R /First 102 0 R /Last 102 0 R /Count 1 >>
+endobj
+102 0 obj
+<< /Title (Depth 98) /Parent 101 0 R /First 103 0 R /Last 103 0 R /Count 1 >>
+endobj
+103 0 obj
+<< /Title (Depth 99) /Parent 102 0 R /First 104 0 R /Last 104 0 R /Count 1 >>
+endobj
+104 0 obj
+<< /Title (Depth 100) /Parent 103 0 R /First 105 0 R /Last 105 0 R /Count 1 >>
+endobj
+105 0 obj
+<< /Title (Depth 101) /Parent 104 0 R /First 106 0 R /Last 106 0 R /Count 1 >>
+endobj
+106 0 obj
+<< /Title (Depth 102) /Parent 105 0 R /First 107 0 R /Last 107 0 R /Count 1 >>
+endobj
+107 0 obj
+<< /Title (Depth 103) /Parent 106 0 R /First 108 0 R /Last 108 0 R /Count 1 >>
+endobj
+108 0 obj
+<< /Title (Depth 104) /Parent 107 0 R /First 109 0 R /Last 109 0 R /Count 1 >>
+endobj
+109 0 obj
+<< /Title (Depth 105) /Parent 108 0 R /First 110 0 R /Last 110 0 R /Count 1 >>
+endobj
+110 0 obj
+<< /Title (Depth 106) /Parent 109 0 R /First 111 0 R /Last 111 0 R /Count 1 >>
+endobj
+111 0 obj
+<< /Title (Depth 107) /Parent 110 0 R /First 112 0 R /Last 112 0 R /Count 1 >>
+endobj
+112 0 obj
+<< /Title (Depth 108) /Parent 111 0 R /First 113 0 R /Last 113 0 R /Count 1 >>
+endobj
+113 0 obj
+<< /Title (Depth 109) /Parent 112 0 R /First 114 0 R /Last 114 0 R /Count 1 >>
+endobj
+114 0 obj
+<< /Title (Depth 110) /Parent 113 0 R /First 115 0 R /Last 115 0 R /Count 1 >>
+endobj
+115 0 obj
+<< /Title (Depth 111) /Parent 114 0 R /First 116 0 R /Last 116 0 R /Count 1 >>
+endobj
+116 0 obj
+<< /Title (Depth 112) /Parent 115 0 R /First 117 0 R /Last 117 0 R /Count 1 >>
+endobj
+117 0 obj
+<< /Title (Depth 113) /Parent 116 0 R /First 118 0 R /Last 118 0 R /Count 1 >>
+endobj
+118 0 obj
+<< /Title (Depth 114) /Parent 117 0 R /First 119 0 R /Last 119 0 R /Count 1 >>
+endobj
+119 0 obj
+<< /Title (Depth 115) /Parent 118 0 R /First 120 0 R /Last 120 0 R /Count 1 >>
+endobj
+120 0 obj
+<< /Title (Depth 116) /Parent 119 0 R /First 121 0 R /Last 121 0 R /Count 1 >>
+endobj
+121 0 obj
+<< /Title (Depth 117) /Parent 120 0 R /First 122 0 R /Last 122 0 R /Count 1 >>
+endobj
+122 0 obj
+<< /Title (Depth 118) /Parent 121 0 R /First 123 0 R /Last 123 0 R /Count 1 >>
+endobj
+123 0 obj
+<< /Title (Depth 119) /Parent 122 0 R /First 124 0 R /Last 124 0 R /Count 1 >>
+endobj
+124 0 obj
+<< /Title (Depth 120) /Parent 123 0 R /First 125 0 R /Last 125 0 R /Count 1 >>
+endobj
+125 0 obj
+<< /Title (Depth 121) /Parent 124 0 R /First 126 0 R /Last 126 0 R /Count 1 >>
+endobj
+126 0 obj
+<< /Title (Depth 122) /Parent 125 0 R /First 127 0 R /Last 127 0 R /Count 1 >>
+endobj
+127 0 obj
+<< /Title (Depth 123) /Parent 126 0 R /First 128 0 R /Last 128 0 R /Count 1 >>
+endobj
+128 0 obj
+<< /Title (Depth 124) /Parent 127 0 R /First 129 0 R /Last 129 0 R /Count 1 >>
+endobj
+129 0 obj
+<< /Title (Depth 125) /Parent 128 0 R /First 130 0 R /Last 130 0 R /Count 1 >>
+endobj
+130 0 obj
+<< /Title (Depth 126) /Parent 129 0 R /First 131 0 R /Last 131 0 R /Count 1 >>
+endobj
+131 0 obj
+<< /Title (Depth 127) /Parent 130 0 R /First 132 0 R /Last 132 0 R /Count 1 >>
+endobj
+132 0 obj
+<< /Title (Depth 128) /Parent 131 0 R /First 133 0 R /Last 133 0 R /Count 1 >>
+endobj
+133 0 obj
+<< /Title (Depth 129) /Parent 132 0 R /First 134 0 R /Last 134 0 R /Count 1 >>
+endobj
+134 0 obj
+<< /Title (Depth 130) /Parent 133 0 R /First 135 0 R /Last 135 0 R /Count 1 >>
+endobj
+135 0 obj
+<< /Title (Depth 131) /Parent 134 0 R /First 136 0 R /Last 136 0 R /Count 1 >>
+endobj
+136 0 obj
+<< /Title (Depth 132) /Parent 135 0 R /First 137 0 R /Last 137 0 R /Count 1 >>
+endobj
+137 0 obj
+<< /Title (Depth 133) /Parent 136 0 R /First 138 0 R /Last 138 0 R /Count 1 >>
+endobj
+138 0 obj
+<< /Title (Depth 134) /Parent 137 0 R /First 139 0 R /Last 139 0 R /Count 1 >>
+endobj
+139 0 obj
+<< /Title (Depth 135) /Parent 138 0 R /First 140 0 R /Last 140 0 R /Count 1 >>
+endobj
+140 0 obj
+<< /Title (Depth 136) /Parent 139 0 R /First 141 0 R /Last 141 0 R /Count 1 >>
+endobj
+141 0 obj
+<< /Title (Depth 137) /Parent 140 0 R /First 142 0 R /Last 142 0 R /Count 1 >>
+endobj
+142 0 obj
+<< /Title (Depth 138) /Parent 141 0 R /First 143 0 R /Last 143 0 R /Count 1 >>
+endobj
+143 0 obj
+<< /Title (Depth 139) /Parent 142 0 R /First 144 0 R /Last 144 0 R /Count 1 >>
+endobj
+144 0 obj
+<< /Title (Depth 140) /Parent 143 0 R /First 145 0 R /Last 145 0 R /Count 1 >>
+endobj
+145 0 obj
+<< /Title (Depth 141) /Parent 144 0 R /First 146 0 R /Last 146 0 R /Count 1 >>
+endobj
+146 0 obj
+<< /Title (Depth 142) /Parent 145 0 R /First 147 0 R /Last 147 0 R /Count 1 >>
+endobj
+147 0 obj
+<< /Title (Depth 143) /Parent 146 0 R /First 148 0 R /Last 148 0 R /Count 1 >>
+endobj
+148 0 obj
+<< /Title (Depth 144) /Parent 147 0 R /First 149 0 R /Last 149 0 R /Count 1 >>
+endobj
+149 0 obj
+<< /Title (Depth 145) /Parent 148 0 R /First 150 0 R /Last 150 0 R /Count 1 >>
+endobj
+150 0 obj
+<< /Title (Depth 146) /Parent 149 0 R /First 151 0 R /Last 151 0 R /Count 1 >>
+endobj
+151 0 obj
+<< /Title (Depth 147) /Parent 150 0 R /First 152 0 R /Last 152 0 R /Count 1 >>
+endobj
+152 0 obj
+<< /Title (Depth 148) /Parent 151 0 R /First 153 0 R /Last 153 0 R /Count 1 >>
+endobj
+153 0 obj
+<< /Title (Depth 149) /Parent 152 0 R /First 154 0 R /Last 154 0 R /Count 1 >>
+endobj
+154 0 obj
+<< /Title (Depth 150) /Parent 153 0 R /First 155 0 R /Last 155 0 R /Count 1 >>
+endobj
+155 0 obj
+<< /Title (Depth 151) /Parent 154 0 R /First 156 0 R /Last 156 0 R /Count 1 >>
+endobj
+156 0 obj
+<< /Title (Depth 152) /Parent 155 0 R /First 157 0 R /Last 157 0 R /Count 1 >>
+endobj
+157 0 obj
+<< /Title (Depth 153) /Parent 156 0 R /First 158 0 R /Last 158 0 R /Count 1 >>
+endobj
+158 0 obj
+<< /Title (Depth 154) /Parent 157 0 R /First 159 0 R /Last 159 0 R /Count 1 >>
+endobj
+159 0 obj
+<< /Title (Depth 155) /Parent 158 0 R /First 160 0 R /Last 160 0 R /Count 1 >>
+endobj
+160 0 obj
+<< /Title (Depth 156) /Parent 159 0 R /First 161 0 R /Last 161 0 R /Count 1 >>
+endobj
+161 0 obj
+<< /Title (Depth 157) /Parent 160 0 R /First 162 0 R /Last 162 0 R /Count 1 >>
+endobj
+162 0 obj
+<< /Title (Depth 158) /Parent 161 0 R /First 163 0 R /Last 163 0 R /Count 1 >>
+endobj
+163 0 obj
+<< /Title (Depth 159) /Parent 162 0 R /First 164 0 R /Last 164 0 R /Count 1 >>
+endobj
+164 0 obj
+<< /Title (Depth 160) /Parent 163 0 R /First 165 0 R /Last 165 0 R /Count 1 >>
+endobj
+165 0 obj
+<< /Title (Depth 161) /Parent 164 0 R /First 166 0 R /Last 166 0 R /Count 1 >>
+endobj
+166 0 obj
+<< /Title (Depth 162) /Parent 165 0 R /First 167 0 R /Last 167 0 R /Count 1 >>
+endobj
+167 0 obj
+<< /Title (Depth 163) /Parent 166 0 R /First 168 0 R /Last 168 0 R /Count 1 >>
+endobj
+168 0 obj
+<< /Title (Depth 164) /Parent 167 0 R /First 169 0 R /Last 169 0 R /Count 1 >>
+endobj
+169 0 obj
+<< /Title (Depth 165) /Parent 168 0 R /First 170 0 R /Last 170 0 R /Count 1 >>
+endobj
+170 0 obj
+<< /Title (Depth 166) /Parent 169 0 R /First 171 0 R /Last 171 0 R /Count 1 >>
+endobj
+171 0 obj
+<< /Title (Depth 167) /Parent 170 0 R /First 172 0 R /Last 172 0 R /Count 1 >>
+endobj
+172 0 obj
+<< /Title (Depth 168) /Parent 171 0 R /First 173 0 R /Last 173 0 R /Count 1 >>
+endobj
+173 0 obj
+<< /Title (Depth 169) /Parent 172 0 R /First 174 0 R /Last 174 0 R /Count 1 >>
+endobj
+174 0 obj
+<< /Title (Depth 170) /Parent 173 0 R /First 175 0 R /Last 175 0 R /Count 1 >>
+endobj
+175 0 obj
+<< /Title (Depth 171) /Parent 174 0 R /First 176 0 R /Last 176 0 R /Count 1 >>
+endobj
+176 0 obj
+<< /Title (Depth 172) /Parent 175 0 R /First 177 0 R /Last 177 0 R /Count 1 >>
+endobj
+177 0 obj
+<< /Title (Depth 173) /Parent 176 0 R /First 178 0 R /Last 178 0 R /Count 1 >>
+endobj
+178 0 obj
+<< /Title (Depth 174) /Parent 177 0 R /First 179 0 R /Last 179 0 R /Count 1 >>
+endobj
+179 0 obj
+<< /Title (Depth 175) /Parent 178 0 R /First 180 0 R /Last 180 0 R /Count 1 >>
+endobj
+180 0 obj
+<< /Title (Depth 176) /Parent 179 0 R /First 181 0 R /Last 181 0 R /Count 1 >>
+endobj
+181 0 obj
+<< /Title (Depth 177) /Parent 180 0 R /First 182 0 R /Last 182 0 R /Count 1 >>
+endobj
+182 0 obj
+<< /Title (Depth 178) /Parent 181 0 R /First 183 0 R /Last 183 0 R /Count 1 >>
+endobj
+183 0 obj
+<< /Title (Depth 179) /Parent 182 0 R /First 184 0 R /Last 184 0 R /Count 1 >>
+endobj
+184 0 obj
+<< /Title (Depth 180) /Parent 183 0 R /First 185 0 R /Last 185 0 R /Count 1 >>
+endobj
+185 0 obj
+<< /Title (Depth 181) /Parent 184 0 R /First 186 0 R /Last 186 0 R /Count 1 >>
+endobj
+186 0 obj
+<< /Title (Depth 182) /Parent 185 0 R /First 187 0 R /Last 187 0 R /Count 1 >>
+endobj
+187 0 obj
+<< /Title (Depth 183) /Parent 186 0 R /First 188 0 R /Last 188 0 R /Count 1 >>
+endobj
+188 0 obj
+<< /Title (Depth 184) /Parent 187 0 R /First 189 0 R /Last 189 0 R /Count 1 >>
+endobj
+189 0 obj
+<< /Title (Depth 185) /Parent 188 0 R /First 190 0 R /Last 190 0 R /Count 1 >>
+endobj
+190 0 obj
+<< /Title (Depth 186) /Parent 189 0 R /First 191 0 R /Last 191 0 R /Count 1 >>
+endobj
+191 0 obj
+<< /Title (Depth 187) /Parent 190 0 R /First 192 0 R /Last 192 0 R /Count 1 >>
+endobj
+192 0 obj
+<< /Title (Depth 188) /Parent 191 0 R /First 193 0 R /Last 193 0 R /Count 1 >>
+endobj
+193 0 obj
+<< /Title (Depth 189) /Parent 192 0 R /First 194 0 R /Last 194 0 R /Count 1 >>
+endobj
+194 0 obj
+<< /Title (Depth 190) /Parent 193 0 R /First 195 0 R /Last 195 0 R /Count 1 >>
+endobj
+195 0 obj
+<< /Title (Depth 191) /Parent 194 0 R /First 196 0 R /Last 196 0 R /Count 1 >>
+endobj
+196 0 obj
+<< /Title (Depth 192) /Parent 195 0 R /First 197 0 R /Last 197 0 R /Count 1 >>
+endobj
+197 0 obj
+<< /Title (Depth 193) /Parent 196 0 R /First 198 0 R /Last 198 0 R /Count 1 >>
+endobj
+198 0 obj
+<< /Title (Depth 194) /Parent 197 0 R /First 199 0 R /Last 199 0 R /Count 1 >>
+endobj
+199 0 obj
+<< /Title (Depth 195) /Parent 198 0 R /First 200 0 R /Last 200 0 R /Count 1 >>
+endobj
+200 0 obj
+<< /Title (Depth 196) /Parent 199 0 R /First 201 0 R /Last 201 0 R /Count 1 >>
+endobj
+201 0 obj
+<< /Title (Depth 197) /Parent 200 0 R /First 202 0 R /Last 202 0 R /Count 1 >>
+endobj
+202 0 obj
+<< /Title (Depth 198) /Parent 201 0 R /First 203 0 R /Last 203 0 R /Count 1 >>
+endobj
+203 0 obj
+<< /Title (Depth 199) /Parent 202 0 R /First 204 0 R /Last 204 0 R /Count 1 >>
+endobj
+204 0 obj
+<< /Title (Depth 200) /Parent 203 0 R /First 205 0 R /Last 205 0 R /Count 1 >>
+endobj
+205 0 obj
+<< /Title (Depth 201) /Parent 204 0 R /First 206 0 R /Last 206 0 R /Count 1 >>
+endobj
+206 0 obj
+<< /Title (Depth 202) /Parent 205 0 R /First 207 0 R /Last 207 0 R /Count 1 >>
+endobj
+207 0 obj
+<< /Title (Depth 203) /Parent 206 0 R /First 208 0 R /Last 208 0 R /Count 1 >>
+endobj
+208 0 obj
+<< /Title (Depth 204) /Parent 207 0 R /First 209 0 R /Last 209 0 R /Count 1 >>
+endobj
+209 0 obj
+<< /Title (Depth 205) /Parent 208 0 R /First 210 0 R /Last 210 0 R /Count 1 >>
+endobj
+210 0 obj
+<< /Title (Depth 206) /Parent 209 0 R /First 211 0 R /Last 211 0 R /Count 1 >>
+endobj
+211 0 obj
+<< /Title (Depth 207) /Parent 210 0 R /First 212 0 R /Last 212 0 R /Count 1 >>
+endobj
+212 0 obj
+<< /Title (Depth 208) /Parent 211 0 R /First 213 0 R /Last 213 0 R /Count 1 >>
+endobj
+213 0 obj
+<< /Title (Depth 209) /Parent 212 0 R /First 214 0 R /Last 214 0 R /Count 1 >>
+endobj
+214 0 obj
+<< /Title (Depth 210) /Parent 213 0 R /First 215 0 R /Last 215 0 R /Count 1 >>
+endobj
+215 0 obj
+<< /Title (Depth 211) /Parent 214 0 R /First 216 0 R /Last 216 0 R /Count 1 >>
+endobj
+216 0 obj
+<< /Title (Depth 212) /Parent 215 0 R /First 217 0 R /Last 217 0 R /Count 1 >>
+endobj
+217 0 obj
+<< /Title (Depth 213) /Parent 216 0 R /First 218 0 R /Last 218 0 R /Count 1 >>
+endobj
+218 0 obj
+<< /Title (Depth 214) /Parent 217 0 R /First 219 0 R /Last 219 0 R /Count 1 >>
+endobj
+219 0 obj
+<< /Title (Depth 215) /Parent 218 0 R /First 220 0 R /Last 220 0 R /Count 1 >>
+endobj
+220 0 obj
+<< /Title (Depth 216) /Parent 219 0 R /First 221 0 R /Last 221 0 R /Count 1 >>
+endobj
+221 0 obj
+<< /Title (Depth 217) /Parent 220 0 R /First 222 0 R /Last 222 0 R /Count 1 >>
+endobj
+222 0 obj
+<< /Title (Depth 218) /Parent 221 0 R /First 223 0 R /Last 223 0 R /Count 1 >>
+endobj
+223 0 obj
+<< /Title (Depth 219) /Parent 222 0 R /First 224 0 R /Last 224 0 R /Count 1 >>
+endobj
+224 0 obj
+<< /Title (Depth 220) /Parent 223 0 R /First 225 0 R /Last 225 0 R /Count 1 >>
+endobj
+225 0 obj
+<< /Title (Depth 221) /Parent 224 0 R /First 226 0 R /Last 226 0 R /Count 1 >>
+endobj
+226 0 obj
+<< /Title (Depth 222) /Parent 225 0 R /First 227 0 R /Last 227 0 R /Count 1 >>
+endobj
+227 0 obj
+<< /Title (Depth 223) /Parent 226 0 R /First 228 0 R /Last 228 0 R /Count 1 >>
+endobj
+228 0 obj
+<< /Title (Depth 224) /Parent 227 0 R /First 229 0 R /Last 229 0 R /Count 1 >>
+endobj
+229 0 obj
+<< /Title (Depth 225) /Parent 228 0 R /First 230 0 R /Last 230 0 R /Count 1 >>
+endobj
+230 0 obj
+<< /Title (Depth 226) /Parent 229 0 R /First 231 0 R /Last 231 0 R /Count 1 >>
+endobj
+231 0 obj
+<< /Title (Depth 227) /Parent 230 0 R /First 232 0 R /Last 232 0 R /Count 1 >>
+endobj
+232 0 obj
+<< /Title (Depth 228) /Parent 231 0 R /First 233 0 R /Last 233 0 R /Count 1 >>
+endobj
+233 0 obj
+<< /Title (Depth 229) /Parent 232 0 R /First 234 0 R /Last 234 0 R /Count 1 >>
+endobj
+234 0 obj
+<< /Title (Depth 230) /Parent 233 0 R /First 235 0 R /Last 235 0 R /Count 1 >>
+endobj
+235 0 obj
+<< /Title (Depth 231) /Parent 234 0 R /First 236 0 R /Last 236 0 R /Count 1 >>
+endobj
+236 0 obj
+<< /Title (Depth 232) /Parent 235 0 R /First 237 0 R /Last 237 0 R /Count 1 >>
+endobj
+237 0 obj
+<< /Title (Depth 233) /Parent 236 0 R /First 238 0 R /Last 238 0 R /Count 1 >>
+endobj
+238 0 obj
+<< /Title (Depth 234) /Parent 237 0 R /First 239 0 R /Last 239 0 R /Count 1 >>
+endobj
+239 0 obj
+<< /Title (Depth 235) /Parent 238 0 R /First 240 0 R /Last 240 0 R /Count 1 >>
+endobj
+240 0 obj
+<< /Title (Depth 236) /Parent 239 0 R /First 241 0 R /Last 241 0 R /Count 1 >>
+endobj
+241 0 obj
+<< /Title (Depth 237) /Parent 240 0 R /First 242 0 R /Last 242 0 R /Count 1 >>
+endobj
+242 0 obj
+<< /Title (Depth 238) /Parent 241 0 R /First 243 0 R /Last 243 0 R /Count 1 >>
+endobj
+243 0 obj
+<< /Title (Depth 239) /Parent 242 0 R /First 244 0 R /Last 244 0 R /Count 1 >>
+endobj
+244 0 obj
+<< /Title (Depth 240) /Parent 243 0 R /First 245 0 R /Last 245 0 R /Count 1 >>
+endobj
+245 0 obj
+<< /Title (Depth 241) /Parent 244 0 R /First 246 0 R /Last 246 0 R /Count 1 >>
+endobj
+246 0 obj
+<< /Title (Depth 242) /Parent 245 0 R /First 247 0 R /Last 247 0 R /Count 1 >>
+endobj
+247 0 obj
+<< /Title (Depth 243) /Parent 246 0 R /First 248 0 R /Last 248 0 R /Count 1 >>
+endobj
+248 0 obj
+<< /Title (Depth 244) /Parent 247 0 R /First 249 0 R /Last 249 0 R /Count 1 >>
+endobj
+249 0 obj
+<< /Title (Depth 245) /Parent 248 0 R /First 250 0 R /Last 250 0 R /Count 1 >>
+endobj
+250 0 obj
+<< /Title (Depth 246) /Parent 249 0 R /First 251 0 R /Last 251 0 R /Count 1 >>
+endobj
+251 0 obj
+<< /Title (Depth 247) /Parent 250 0 R /First 252 0 R /Last 252 0 R /Count 1 >>
+endobj
+252 0 obj
+<< /Title (Depth 248) /Parent 251 0 R /First 253 0 R /Last 253 0 R /Count 1 >>
+endobj
+253 0 obj
+<< /Title (Depth 249) /Parent 252 0 R /First 254 0 R /Last 254 0 R /Count 1 >>
+endobj
+254 0 obj
+<< /Title (Depth 250) /Parent 253 0 R /First 255 0 R /Last 255 0 R /Count 1 >>
+endobj
+255 0 obj
+<< /Title (Depth 251) /Parent 254 0 R /First 256 0 R /Last 256 0 R /Count 1 >>
+endobj
+256 0 obj
+<< /Title (Depth 252) /Parent 255 0 R /First 257 0 R /Last 257 0 R /Count 1 >>
+endobj
+257 0 obj
+<< /Title (Depth 253) /Parent 256 0 R /First 258 0 R /Last 258 0 R /Count 1 >>
+endobj
+258 0 obj
+<< /Title (Depth 254) /Parent 257 0 R /First 259 0 R /Last 259 0 R /Count 1 >>
+endobj
+259 0 obj
+<< /Title (Depth 255) /Parent 258 0 R /First 260 0 R /Last 260 0 R /Count 1 >>
+endobj
+260 0 obj
+<< /Title (Depth 256) /Parent 259 0 R /First 261 0 R /Last 261 0 R /Count 1 >>
+endobj
+261 0 obj
+<< /Title (Depth 257) /Parent 260 0 R >>
+endobj
+xref
+0 262
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000208 00000 n 
+0000000270 00000 n 
+0000000356 00000 n 
+0000000442 00000 n 
+0000000528 00000 n 
+0000000614 00000 n 
+0000000702 00000 n 
+0000000791 00000 n 
+0000000881 00000 n 
+0000000971 00000 n 
+0000001061 00000 n 
+0000001152 00000 n 
+0000001243 00000 n 
+0000001334 00000 n 
+0000001425 00000 n 
+0000001516 00000 n 
+0000001607 00000 n 
+0000001698 00000 n 
+0000001789 00000 n 
+0000001880 00000 n 
+0000001971 00000 n 
+0000002062 00000 n 
+0000002153 00000 n 
+0000002244 00000 n 
+0000002335 00000 n 
+0000002426 00000 n 
+0000002517 00000 n 
+0000002608 00000 n 
+0000002699 00000 n 
+0000002790 00000 n 
+0000002881 00000 n 
+0000002972 00000 n 
+0000003063 00000 n 
+0000003154 00000 n 
+0000003245 00000 n 
+0000003336 00000 n 
+0000003427 00000 n 
+0000003518 00000 n 
+0000003609 00000 n 
+0000003700 00000 n 
+0000003791 00000 n 
+0000003882 00000 n 
+0000003973 00000 n 
+0000004064 00000 n 
+0000004155 00000 n 
+0000004246 00000 n 
+0000004337 00000 n 
+0000004428 00000 n 
+0000004519 00000 n 
+0000004610 00000 n 
+0000004701 00000 n 
+0000004792 00000 n 
+0000004883 00000 n 
+0000004974 00000 n 
+0000005065 00000 n 
+0000005156 00000 n 
+0000005247 00000 n 
+0000005338 00000 n 
+0000005429 00000 n 
+0000005520 00000 n 
+0000005611 00000 n 
+0000005702 00000 n 
+0000005793 00000 n 
+0000005884 00000 n 
+0000005975 00000 n 
+0000006066 00000 n 
+0000006157 00000 n 
+0000006248 00000 n 
+0000006339 00000 n 
+0000006430 00000 n 
+0000006521 00000 n 
+0000006612 00000 n 
+0000006703 00000 n 
+0000006794 00000 n 
+0000006885 00000 n 
+0000006976 00000 n 
+0000007067 00000 n 
+0000007158 00000 n 
+0000007249 00000 n 
+0000007340 00000 n 
+0000007431 00000 n 
+0000007522 00000 n 
+0000007613 00000 n 
+0000007704 00000 n 
+0000007795 00000 n 
+0000007886 00000 n 
+0000007977 00000 n 
+0000008068 00000 n 
+0000008159 00000 n 
+0000008250 00000 n 
+0000008341 00000 n 
+0000008432 00000 n 
+0000008523 00000 n 
+0000008614 00000 n 
+0000008705 00000 n 
+0000008796 00000 n 
+0000008889 00000 n 
+0000008983 00000 n 
+0000009078 00000 n 
+0000009173 00000 n 
+0000009268 00000 n 
+0000009364 00000 n 
+0000009460 00000 n 
+0000009556 00000 n 
+0000009652 00000 n 
+0000009748 00000 n 
+0000009844 00000 n 
+0000009940 00000 n 
+0000010036 00000 n 
+0000010132 00000 n 
+0000010228 00000 n 
+0000010324 00000 n 
+0000010420 00000 n 
+0000010516 00000 n 
+0000010612 00000 n 
+0000010708 00000 n 
+0000010804 00000 n 
+0000010900 00000 n 
+0000010996 00000 n 
+0000011092 00000 n 
+0000011188 00000 n 
+0000011284 00000 n 
+0000011380 00000 n 
+0000011476 00000 n 
+0000011572 00000 n 
+0000011668 00000 n 
+0000011764 00000 n 
+0000011860 00000 n 
+0000011956 00000 n 
+0000012052 00000 n 
+0000012148 00000 n 
+0000012244 00000 n 
+0000012340 00000 n 
+0000012436 00000 n 
+0000012532 00000 n 
+0000012628 00000 n 
+0000012724 00000 n 
+0000012820 00000 n 
+0000012916 00000 n 
+0000013012 00000 n 
+0000013108 00000 n 
+0000013204 00000 n 
+0000013300 00000 n 
+0000013396 00000 n 
+0000013492 00000 n 
+0000013588 00000 n 
+0000013684 00000 n 
+0000013780 00000 n 
+0000013876 00000 n 
+0000013972 00000 n 
+0000014068 00000 n 
+0000014164 00000 n 
+0000014260 00000 n 
+0000014356 00000 n 
+0000014452 00000 n 
+0000014548 00000 n 
+0000014644 00000 n 
+0000014740 00000 n 
+0000014836 00000 n 
+0000014932 00000 n 
+0000015028 00000 n 
+0000015124 00000 n 
+0000015220 00000 n 
+0000015316 00000 n 
+0000015412 00000 n 
+0000015508 00000 n 
+0000015604 00000 n 
+0000015700 00000 n 
+0000015796 00000 n 
+0000015892 00000 n 
+0000015988 00000 n 
+0000016084 00000 n 
+0000016180 00000 n 
+0000016276 00000 n 
+0000016372 00000 n 
+0000016468 00000 n 
+0000016564 00000 n 
+0000016660 00000 n 
+0000016756 00000 n 
+0000016852 00000 n 
+0000016948 00000 n 
+0000017044 00000 n 
+0000017140 00000 n 
+0000017236 00000 n 
+0000017332 00000 n 
+0000017428 00000 n 
+0000017524 00000 n 
+0000017620 00000 n 
+0000017716 00000 n 
+0000017812 00000 n 
+0000017908 00000 n 
+0000018004 00000 n 
+0000018100 00000 n 
+0000018196 00000 n 
+0000018292 00000 n 
+0000018388 00000 n 
+0000018484 00000 n 
+0000018580 00000 n 
+0000018676 00000 n 
+0000018772 00000 n 
+0000018868 00000 n 
+0000018964 00000 n 
+0000019060 00000 n 
+0000019156 00000 n 
+0000019252 00000 n 
+0000019348 00000 n 
+0000019444 00000 n 
+0000019540 00000 n 
+0000019636 00000 n 
+0000019732 00000 n 
+0000019828 00000 n 
+0000019924 00000 n 
+0000020020 00000 n 
+0000020116 00000 n 
+0000020212 00000 n 
+0000020308 00000 n 
+0000020404 00000 n 
+0000020500 00000 n 
+0000020596 00000 n 
+0000020692 00000 n 
+0000020788 00000 n 
+0000020884 00000 n 
+0000020980 00000 n 
+0000021076 00000 n 
+0000021172 00000 n 
+0000021268 00000 n 
+0000021364 00000 n 
+0000021460 00000 n 
+0000021556 00000 n 
+0000021652 00000 n 
+0000021748 00000 n 
+0000021844 00000 n 
+0000021940 00000 n 
+0000022036 00000 n 
+0000022132 00000 n 
+0000022228 00000 n 
+0000022324 00000 n 
+0000022420 00000 n 
+0000022516 00000 n 
+0000022612 00000 n 
+0000022708 00000 n 
+0000022804 00000 n 
+0000022900 00000 n 
+0000022996 00000 n 
+0000023092 00000 n 
+0000023188 00000 n 
+0000023284 00000 n 
+0000023380 00000 n 
+0000023476 00000 n 
+0000023572 00000 n 
+0000023668 00000 n 
+0000023764 00000 n 
+0000023860 00000 n 
+0000023956 00000 n 
+0000024052 00000 n 
+0000024148 00000 n 
+0000024244 00000 n 
+0000024340 00000 n 
+trailer
+<< /Size 262 /Root 1 0 R >>
+startxref
+24398
+%%EOF

--- a/tests/fixtures/outline-repairable-bad.pdf
+++ b/tests/fixtures/outline-repairable-bad.pdf
@@ -1,0 +1,34 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+4 0 obj
+<< /Type /Outlines /First 5 0 R /Last 6 0 R >>
+endobj
+5 0 obj
+<< /Title (First) /Parent 4 0 R /Next 6 0 R >>
+endobj
+6 0 obj
+<< /Title (Second) /Parent 4 0 R >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000208 00000 n 
+0000000270 00000 n 
+0000000332 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+383
+%%EOF

--- a/tests/fixtures/outline-tree.pdf
+++ b/tests/fixtures/outline-tree.pdf
@@ -1,0 +1,58 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Outlines 6 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+endobj
+6 0 obj
+<< /Type /Outlines /First 7 0 R /Last 11 0 R >>
+endobj
+7 0 obj
+<< /Title <FEFF004300680061007000740065007200200031002000430061006600E9> /Parent 6 0 R /Next 11 0 R /First 8 0 R /Last 10 0 R /Count 3 /Dest [3 0 R /XYZ 30 150 1] >>
+endobj
+8 0 obj
+<< /Title (Section 1.1) /Parent 7 0 R /Next 9 0 R /Dest [4 0 R /XYZ 10 180 1] >>
+endobj
+9 0 obj
+<< /Title (Website) /Parent 7 0 R /Prev 8 0 R /Next 10 0 R /A << /S /URI /URI (https://example.com/extractpdf-outline) >> >>
+endobj
+10 0 obj
+<< /Parent 7 0 R /Prev 9 0 R >>
+endobj
+11 0 obj
+<< /Title (Chapter 2) /Parent 6 0 R /Prev 7 0 R /First 12 0 R /Last 12 0 R /Count -1 /Dest [5 0 R /XYZ 40 160 1] >>
+endobj
+12 0 obj
+<< /Title () /Parent 11 0 R >>
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000149 00000 n 
+0000000220 00000 n 
+0000000291 00000 n 
+0000000362 00000 n 
+0000000425 00000 n 
+0000000606 00000 n 
+0000000702 00000 n 
+0000000842 00000 n 
+0000000890 00000 n 
+0000001022 00000 n 
+trailer
+<< /Size 13 /Root 1 0 R >>
+startxref
+1069
+%%EOF

--- a/tests/test_pdf_outline.c
+++ b/tests/test_pdf_outline.c
@@ -1,0 +1,315 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    if (d < 0.0f)
+        d = -d;
+    return d < 0.01f;
+}
+
+static void expect_info(
+    const extractpdf_outline *outline,
+    size_t index,
+    size_t parent_index,
+    size_t first_child_index,
+    size_t next_sibling_index,
+    extractpdf_outline_destination_kind kind,
+    int target_page,
+    float x,
+    float y,
+    int is_open)
+{
+    extractpdf_outline_info info = { 0 };
+    info.struct_size = sizeof(info);
+
+    CHECK(extractpdf_outline_get_info(outline, index, &info) == EXTRACTPDF_OK);
+    CHECK(info.struct_size == sizeof(info));
+    CHECK(info.parent_index == parent_index);
+    CHECK(info.first_child_index == first_child_index);
+    CHECK(info.next_sibling_index == next_sibling_index);
+    CHECK(info.destination_kind == kind);
+    CHECK(info.target_page == target_page);
+    CHECK(close_float(info.target.x, x));
+    CHECK(close_float(info.target.y, y));
+    CHECK(info.is_open == is_open);
+}
+
+static void expect_title(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char *expected)
+{
+    const char *text = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_outline_title(outline, index, &text, &size) == EXTRACTPDF_OK);
+    if (expected == NULL) {
+        CHECK(text == NULL);
+        CHECK(size == 0);
+        return;
+    }
+    CHECK(text != NULL);
+    CHECK(size == strlen(expected));
+    CHECK(memcmp(text, expected, size) == 0);
+    CHECK(text[size] == '\0');
+}
+
+static void expect_uri(
+    const extractpdf_outline *outline,
+    size_t index,
+    const char *expected)
+{
+    const char *uri = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_outline_uri(outline, index, &uri, &size) == EXTRACTPDF_OK);
+    CHECK(uri != NULL);
+    CHECK(size == strlen(expected));
+    CHECK(memcmp(uri, expected, size) == 0);
+    CHECK(uri[size] == '\0');
+}
+
+static void expect_uri_unavailable(
+    const extractpdf_outline *outline,
+    size_t index)
+{
+    const char *uri = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_outline_uri(outline, index, &uri, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(uri == NULL);
+    CHECK(size == 0);
+}
+
+static void test_valid_outline_and_independent_lifetime(void)
+{
+    static const char unicode_title[] = "Chapter 1 Caf\xC3\xA9";
+    static const char uri[] = "https://example.com/extractpdf-outline";
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = NULL;
+    size_t count = 0;
+
+    CHECK(extractpdf_open(OUTLINE_TREE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+    extractpdf_close(document);
+
+    CHECK(extractpdf_outline_count(outline, &count) == EXTRACTPDF_OK);
+    CHECK(count == 6);
+
+    expect_info(outline, 0, SIZE_MAX, 1, 4,
+                EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL,
+                0, 30.0f, 50.0f, 1);
+    expect_info(outline, 1, 0, SIZE_MAX, 2,
+                EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL,
+                1, 10.0f, 20.0f, 0);
+    expect_info(outline, 2, 0, SIZE_MAX, 3,
+                EXTRACTPDF_OUTLINE_DESTINATION_URI,
+                -1, 0.0f, 0.0f, 0);
+    expect_info(outline, 3, 0, SIZE_MAX, SIZE_MAX,
+                EXTRACTPDF_OUTLINE_DESTINATION_NONE,
+                -1, 0.0f, 0.0f, 0);
+    expect_info(outline, 4, SIZE_MAX, 5, SIZE_MAX,
+                EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL,
+                2, 40.0f, 40.0f, 0);
+    expect_info(outline, 5, 4, SIZE_MAX, SIZE_MAX,
+                EXTRACTPDF_OUTLINE_DESTINATION_NONE,
+                -1, 0.0f, 0.0f, 0);
+
+    expect_title(outline, 0, unicode_title);
+    expect_title(outline, 1, "Section 1.1");
+    expect_title(outline, 2, "Website");
+    expect_title(outline, 3, NULL);
+    expect_title(outline, 4, "Chapter 2");
+    expect_title(outline, 5, "");
+
+    expect_uri(outline, 2, uri);
+    expect_uri_unavailable(outline, 0);
+    expect_uri_unavailable(outline, 3);
+
+    extractpdf_drop_outline(outline);
+}
+
+static void test_empty_outline(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = NULL;
+    size_t count = 99;
+
+    CHECK(extractpdf_open(EMPTY_OUTLINE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+    extractpdf_close(document);
+
+    CHECK(extractpdf_outline_count(outline, &count) == EXTRACTPDF_OK);
+    CHECK(count == 0);
+    extractpdf_drop_outline(outline);
+}
+
+static void test_repairable_outline_is_rejected_without_repair(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = (extractpdf_outline *)&sentinel;
+
+    CHECK(extractpdf_open(OUTLINE_REPAIRABLE_BAD_PDF, NULL, &document) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(outline == NULL);
+
+    outline = (extractpdf_outline *)&sentinel;
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+}
+
+static void test_cycle_depth_and_pdf_only_boundaries(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = (extractpdf_outline *)&sentinel;
+
+    CHECK(extractpdf_open(OUTLINE_CYCLE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+
+    document = NULL;
+    outline = (extractpdf_outline *)&sentinel;
+    CHECK(extractpdf_open(OUTLINE_DEPTH_257_PDF, NULL, &document) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+
+    document = NULL;
+    outline = (extractpdf_outline *)&sentinel;
+    CHECK(extractpdf_open(COMPOSITION_NON_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, &outline) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(outline == NULL);
+    extractpdf_close(document);
+}
+
+static void test_argument_and_reset_contract(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_outline *outline = (extractpdf_outline *)&sentinel;
+    extractpdf_outline_info info = { 0 };
+    extractpdf_outline_info small = { 0 };
+    const char *text = (const char *)&sentinel;
+    size_t size = 99;
+    size_t count = 99;
+
+    CHECK(extractpdf_document_outline(NULL, &outline) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(outline == NULL);
+    CHECK(extractpdf_document_outline(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_open(OUTLINE_TREE_PDF, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_outline(document, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+
+    CHECK(extractpdf_outline_count(NULL, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_outline_count(outline, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    small.struct_size = offsetof(extractpdf_outline_info, is_open);
+    CHECK(extractpdf_outline_get_info(outline, 0, &small) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    info.struct_size = sizeof(info);
+    info.parent_index = 0;
+    info.first_child_index = 0;
+    info.next_sibling_index = 0;
+    info.destination_kind = EXTRACTPDF_OUTLINE_DESTINATION_URI;
+    info.target_page = 99;
+    info.target.x = 99.0f;
+    info.target.y = 99.0f;
+    info.is_open = 99;
+    CHECK(extractpdf_outline_get_info(outline, 99, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.parent_index == SIZE_MAX);
+    CHECK(info.first_child_index == SIZE_MAX);
+    CHECK(info.next_sibling_index == SIZE_MAX);
+    CHECK(info.destination_kind == EXTRACTPDF_OUTLINE_DESTINATION_NONE);
+    CHECK(info.target_page == -1);
+    CHECK(close_float(info.target.x, 0.0f));
+    CHECK(close_float(info.target.y, 0.0f));
+    CHECK(info.is_open == 0);
+
+    info.parent_index = 0;
+    CHECK(extractpdf_outline_get_info(NULL, 0, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.parent_index == SIZE_MAX);
+
+    CHECK(extractpdf_outline_get_info(NULL, 0, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_outline_title(NULL, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_outline_title(outline, 99, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_outline_uri(outline, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_outline_uri(NULL, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    CHECK(extractpdf_outline_uri(outline, 2, NULL, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    extractpdf_close(document);
+    extractpdf_drop_outline(outline);
+    extractpdf_drop_outline(NULL);
+}
+
+int main(void)
+{
+    test_valid_outline_and_independent_lifetime();
+    test_empty_outline();
+    test_repairable_outline_is_rejected_without_repair();
+    test_cycle_depth_and_pdf_only_boundaries();
+    test_argument_and_reset_contract();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 5 Outline / Bookmarks V1 for #33 / #2.

Design: `docs/superpowers/specs/2026-08-28-extractpdf-document-outline-design.md`
Plan: `docs/superpowers/plans/2026-08-28-extractpdf-document-outline.md`

## TDD evidence

- RED exact head: `91d845b23009c5ffdc33ef5630a795c103804542`
- RED workflow: #170 (`33166419688`)
- RED result: ExtractPDF library and every pre-existing target through `extractpdf_test_pdf_metadata` built successfully; only `extractpdf_test_pdf_outline` failed, exactly because the new opaque outline type, destination enum/constants, info struct, extraction/accessor/drop APIs were absent.
- GREEN exact head: `9d08109219a6de8477cbb65fa0e07387574119d1`
- Linux GREEN workflow: #171 (`33169569807`) — static build + all CTests ✅; ASan/UBSan build + all CTests ✅.
- Same-head full-ci workflow: #172 (`33169686797`) on the unchanged GREEN SHA — Linux static + sanitizers ✅; macOS configure/build/test ✅; Windows DLL configure/build/test ✅. Windows ran `extractpdf.pdf_outline` as test 17/17 and all 17 CTests passed.

## Locked architecture

- PDF-only immutable `extractpdf_outline` snapshot, preorder flat indices.
- `SIZE_MAX` parent / first-child / next-sibling sentinel.
- NONE / INTERNAL / URI destinations.
- INTERNAL = zero-based flat PDF page + Fitz page-space x/y.
- Titles and external URIs are snapshot-owned borrowed UTF-8; absent title remains distinct from present-empty.
- Empty outline = `OK` + non-NULL count-0 snapshot.
- Snapshot survives source document close and retains no MuPDF/document pointer.
- Iterative read-only PDF structural preflight rejects non-indirect items, bad Parent/Prev/Last relations, cycles/repeated nodes, and overflow without silently repairing the document.
- Structurally valid depth >256 returns `UNSUPPORTED` before MuPDF outline iterator construction; malformed structure remains `FORMAT`.
- Snapshot indices are never persistent bookmark IDs or mutation identities; editing remains a separate architecture.

## Final scope / review

Final diff from integrated base `cb0f50b0734bcae00fedd529e4f13701c0852866` contains exactly 11 paths: spec, plan, public header, `src/pdf_outline.c`, root/test CMake, one C test, and four deterministic fixtures. No changes to `src/document.c`, `src/internal.h`, `src/links.c`, `src/pdf_metadata.c`, or Phase 4 composition/output implementation.

Fresh exact-diff review after full-ci found no Critical/Important blocker and no review threads are open.

Keep this PR draft/open/unmerged pending explicit integration authorization.