### PR TITLE
feat: expose immutable PDF annotation snapshot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(extractpdf
   src/pdf_merge.c
   src/output_file.c
   src/pdf_metadata.c
-  src/pdf_outline.c)
+  src/pdf_outline.c
+  src/pdf_annotations.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC

--- a/docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md
+++ b/docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md
@@ -1,0 +1,347 @@
+# ExtractPDF PDF Page Annotation Enumeration V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a PDF-only immutable page annotation snapshot with tolerant `/Annots` collection semantics, strict surviving-item materialization, deterministic order, snapshot-local identity, independent lifetime, and atomic failure publication.
+
+**Architecture:** Down-cast the existing loaded `fz_page` to `pdf_page` and walk the page object's `/Annots` array read-only. Filter non-dictionaries and Link/Popup/Widget entries without invoking MuPDF annotation synchronization/resynthesis; strictly validate and copy the surviving annotation's Rect/F/Contents into an ExtractPDF-owned array/string arena, then publish only after the complete snapshot succeeds.
+
+**Tech Stack:** C11, MuPDF 1.28.2 pinned through existing vcpkg overlay, CMake/CTest, Linux ASan/UBSan, macOS CI, Windows DLL CI, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md`
+
+## Global Constraints
+
+- Base is integrated outline master exact SHA `a83639752e629225b34b052d537a5d2e61220711`, verified by push workflow #175 (`33176336925`).
+- Work on `feat/pdf-annotations`; child issue is #35; umbrella is #2.
+- PDF-only V1; non-PDF page -> `EXTRACTPDF_ERROR_UNSUPPORTED`.
+- Reuse existing `extractpdf_page`; no second public PDF page handle.
+- Immutable `extractpdf_annotation_page` snapshot owns all public item/string data and retains no MuPDF/PDF/page/document pointer.
+- Collection tolerance: missing/non-array `/Annots` -> empty; non-dictionary entries ignored; Link/Popup/Widget ignored; absent/non-name/unrecognized subtype -> UNKNOWN.
+- Surviving item strictness: Rect exactly four finite numbers; present F is uint32-representable integer; present Contents is string; malformed survivor -> FORMAT.
+- Preserve original `/Annots` relative order among survivors exactly.
+- Snapshot indices are local coordinates only, never persistent annotation identity or mutation selectors.
+- Empty result -> `OK + non-NULL count-0 snapshot`.
+- Extraction resets `*out_annotations = NULL` before validation/fallible work and publishes only after complete success.
+- Do not call `pdf_sync_annots`, `pdf_load_annots`, update/resynthesis, or mutation APIs for enumeration.
+- RED must contain no production annotation ABI or implementation.
+- Exact GREEN head requires Linux static/all CTests, Linux ASan/UBSan/all CTests, macOS build/test, and Windows DLL build/test.
+
+---
+
+## File Structure
+
+**Create during RED**
+- `tests/fixtures/annotations-mixed.pdf`
+- `tests/fixtures/annotations-nonarray.pdf`
+- `tests/fixtures/annotations-filtered-only.pdf`
+- `tests/fixtures/annotations-late-malformed.pdf`
+- `tests/test_pdf_annotations.c`
+
+**Modify during RED**
+- `tests/CMakeLists.txt`
+
+**Create during GREEN**
+- `src/pdf_annotations.c`
+
+**Modify during GREEN**
+- `include/extractpdf/extractpdf.h`
+- `CMakeLists.txt`
+
+**Reuse unchanged**
+- `src/internal.h`
+- `src/page.c`
+- existing valid no-annotation PDF fixture
+- `.github/workflows/ci.yml`
+
+---
+
+### Task 1: Strict RED for annotation snapshot contract
+
+**Files:**
+- Create four deterministic annotation fixtures listed above.
+- Create `tests/test_pdf_annotations.c`.
+- Modify `tests/CMakeLists.txt`.
+
+**Interfaces:**
+- Consumes existing `extractpdf_open`, `extractpdf_load_page`, `extractpdf_drop_page`, `extractpdf_close`, status enum, `extractpdf_rect`.
+- Produces compile-time references to the not-yet-existing `extractpdf_annotation_page`, `extractpdf_annotation_type`, `extractpdf_annotation_info`, `extractpdf_extract_annotations`, `extractpdf_annotation_count`, `extractpdf_annotation_get_info`, `extractpdf_annotation_contents`, `extractpdf_drop_annotation_page`.
+
+- [ ] **Step 1: Check in deterministic fixtures**
+
+Use a one-page `%PDF-1.4` direct-object fixture writer with explicit xref offsets. Keep annotation objects indirect except for the deliberate scalar entries. All pages use `/MediaBox [0 0 200 200]`.
+
+`annotations-mixed.pdf` page `/Annots`:
+
+```pdf
+[5 0 R 17 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R]
+```
+
+Objects:
+
+```pdf
+5 0 obj << /Type /Annot /Subtype /Text /Rect [10 20 30 40] /F 4 /Contents (alpha) >> endobj
+6 0 obj << /Type /Annot /Subtype /Link /Rect [1 1 2 2] /A << /S /URI /URI (https://example.com) >> >> endobj
+7 0 obj << /Type /Annot /Subtype /FutureThing /Rect [50 60 70 80] /F 64 /Contents (unknown) >> endobj
+8 0 obj << /Type /Annot /Subtype /Widget /Rect [2 2 3 3] /FT /Tx >> endobj
+9 0 obj << /Type /Annot /Subtype /Popup /Rect [3 3 4 4] >> endobj
+10 0 obj << /Type /Annot /Subtype /Highlight /Rect [90 100 120 130] /Contents (bravo) >> endobj
+```
+
+`annotations-nonarray.pdf`: page has `/Annots 17`.
+
+`annotations-filtered-only.pdf`: page `/Annots [17 5 0 R 6 0 R 7 0 R]`, where objects 5/6/7 are Link/Widget/Popup.
+
+`annotations-late-malformed.pdf`: page `/Annots [5 0 R 6 0 R]`; object 5 is valid Text with `/Contents (first)`, object 6 is Highlight with valid Rect but `/Contents 123`.
+
+- [ ] **Step 2: Write the failing C test**
+
+The test must assert:
+
+```c
+/* mixed tolerance + exact surviving order */
+CHECK(extractpdf_extract_annotations(page, &annotations) == EXTRACTPDF_OK);
+CHECK(extractpdf_annotation_count(annotations, &count) == EXTRACTPDF_OK);
+CHECK(count == 3);
+expect_info(annotations, 0, EXTRACTPDF_ANNOTATION_TEXT, 10, 160, 30, 180, 4);
+expect_contents(annotations, 0, "alpha");
+expect_info(annotations, 1, EXTRACTPDF_ANNOTATION_UNKNOWN, 50, 120, 70, 140, 64);
+expect_contents(annotations, 1, "unknown");
+expect_info(annotations, 2, EXTRACTPDF_ANNOTATION_HIGHLIGHT, 90, 70, 120, 100, 0);
+expect_contents(annotations, 2, "bravo");
+```
+
+The y values above prove PDF user-space -> Fitz page-space conversion for a 200-point unrotated page: `[x0 y0 x1 y1]` maps to `[x0 200-y1 x1 200-y0]`.
+
+Also assert:
+
+```c
+/* lifetime */
+extractpdf_drop_page(page);
+extractpdf_close(document);
+/* all count/info/contents accessors still work */
+
+/* empty variants */
+/* no /Annots, non-array /Annots, filtered-only -> OK + non-NULL + count 0 */
+
+/* atomicity */
+annotations = sentinel;
+CHECK(extractpdf_extract_annotations(late_malformed_page, &annotations) == EXTRACTPDF_ERROR_FORMAT);
+CHECK(annotations == NULL);
+annotations = sentinel;
+CHECK(extractpdf_extract_annotations(late_malformed_page, &annotations) == EXTRACTPDF_ERROR_FORMAT);
+CHECK(annotations == NULL);
+
+/* argument/reset */
+/* NULL extraction args; count reset; get_info neutral reset; contents NULL/0 reset; invalid index; drop(NULL) */
+```
+
+Create two independent snapshots of `annotations-mixed.pdf` and assert equal values/order only; do not expose or compare any public object identity.
+
+- [ ] **Step 3: Register only the new RED test target**
+
+Append to `tests/CMakeLists.txt` following the existing PDF test pattern:
+
+```cmake
+add_executable(extractpdf_test_pdf_annotations test_pdf_annotations.c)
+target_link_libraries(extractpdf_test_pdf_annotations PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_annotations PRIVATE
+  ANNOTATIONS_MIXED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-mixed.pdf"
+  ANNOTATIONS_NONARRAY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-nonarray.pdf"
+  ANNOTATIONS_FILTERED_ONLY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-filtered-only.pdf"
+  ANNOTATIONS_LATE_MALFORMED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-late-malformed.pdf")
+add_test(NAME extractpdf.pdf_annotations COMMAND extractpdf_test_pdf_annotations)
+```
+
+Reuse the exact existing no-annotation fixture macro/pattern already present in the test CMake file rather than introducing a duplicate PDF.
+
+- [ ] **Step 4: Verify RED**
+
+Run the repository's normal Linux configure/build path.
+
+Expected boundary:
+
+```text
+ExtractPDF library builds                             PASS
+all pre-existing test targets through pdf_outline    PASS build/link
+extractpdf_test_pdf_annotations                      FAIL compile
+```
+
+The new target must fail specifically on absent annotation type/struct/API declarations. If a fixture parse error, unrelated target, runtime test, crash, or timeout is reached, RED is invalid and must be fixed before continuing.
+
+- [ ] **Step 5: Commit RED**
+
+```bash
+git add tests/fixtures/annotations-*.pdf tests/test_pdf_annotations.c tests/CMakeLists.txt
+git commit -m "test: lock PDF annotation snapshot contract"
+```
+
+Record exact RED SHA and workflow/run evidence in issue #35 / later PR body.
+
+---
+
+### Task 2: Minimal public ABI and immutable implementation
+
+**Files:**
+- Modify `include/extractpdf/extractpdf.h`.
+- Create `src/pdf_annotations.c`.
+- Modify `CMakeLists.txt`.
+- Test unchanged: `tests/test_pdf_annotations.c`.
+
+**Interfaces:**
+- Produces exactly the public API in the design spec.
+- Uses `pdf_page_from_fz_page`, raw `pdf_page->obj`, `pdf_dict_get`, `pdf_array_len/get`, PDF object type predicates/converters, `pdf_page_obj_transform`, Fitz matrix inversion/rectangle transform, existing `extractpdf_status_from_mupdf`.
+
+- [ ] **Step 1: Add the public declarations only**
+
+Add the opaque handle, stable enum, info struct, extraction/count/info/contents/drop declarations from the spec. Do not expose MuPDF enums or PDF object identity.
+
+- [ ] **Step 2: Add private snapshot records**
+
+`src/pdf_annotations.c` owns:
+
+```c
+typedef struct extractpdf_annotation_internal {
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    size_t contents_offset;
+    size_t contents_size;
+    int has_contents;
+} extractpdf_annotation_internal;
+
+struct extractpdf_annotation_page {
+    extractpdf_annotation_internal *items;
+    char *strings;
+    size_t count;
+    size_t string_size;
+    size_t string_capacity;
+};
+```
+
+No pointer back to page/document/PDF/MuPDF is allowed.
+
+- [ ] **Step 3: Implement tolerant survivor classification**
+
+For each raw `/Annots` element in index order:
+
+```text
+not dictionary -> skip
+Subtype Link    -> skip
+Subtype Popup   -> skip
+Subtype Widget  -> skip
+otherwise       -> survivor
+```
+
+Map known subtype names explicitly to the stable ExtractPDF enum; missing/non-name/other name -> UNKNOWN.
+
+Do not call `pdf_sync_annots` or any annotation resynthesis/update function.
+
+- [ ] **Step 4: Implement strict survivor validation/materialization**
+
+For each survivor:
+
+1. Validate `/Rect` is an array of length 4 and every member is numeric + finite.
+2. Obtain the page transform; invert it to map PDF-user-space rectangle into Fitz page space; normalize rectangle endpoints.
+3. If `/F` absent use zero; if present require integer in `[0, UINT32_MAX]`.
+4. If `/Contents` absent mark `has_contents = 0`; if present require string, decode PDF text to UTF-8, deep-copy with trailing NUL into the snapshot string arena.
+5. Check every count/allocation/string-size multiplication/addition for `SIZE_MAX` overflow; return NOMEM on overflow/allocation failure.
+
+Any FORMAT/NOMEM/MuPDF failure disposes the whole private snapshot and returns without publication.
+
+- [ ] **Step 5: Implement accessors and atomic publication**
+
+Extraction begins:
+
+```c
+if (out_annotations == NULL)
+    return EXTRACTPDF_ERROR_ARGUMENT;
+*out_annotations = NULL;
+```
+
+Only after complete success:
+
+```c
+*out_annotations = snapshot;
+return EXTRACTPDF_OK;
+```
+
+`count` resets `*out_count = 0` when possible before validation.
+
+`get_info` validates `struct_size`, resets type/bounds/flags, then validates handle/index and copies known fields.
+
+`contents` resets pointer/size to NULL/0, returns `OK + NULL + 0` for absent contents, and borrowed snapshot-owned UTF-8 for present contents.
+
+`drop(NULL)` is a no-op.
+
+- [ ] **Step 6: Wire the implementation into the root library**
+
+Add only `src/pdf_annotations.c` to `add_library(extractpdf ...)`.
+
+- [ ] **Step 7: Verify GREEN locally/CI**
+
+Run Linux strict static + all CTests and Linux sanitizer build + all CTests. Expected: all tests including `extractpdf.pdf_annotations` pass with no sanitizer failures.
+
+- [ ] **Step 8: Commit GREEN**
+
+```bash
+git add include/extractpdf/extractpdf.h src/pdf_annotations.c CMakeLists.txt
+git commit -m "feat: expose immutable PDF annotation snapshot"
+```
+
+---
+
+### Task 3: Exact-head cross-platform proof and review
+
+**Files:** no intended production changes.
+
+- [ ] **Step 1: Confirm exact diff scope**
+
+Diff from integrated base must contain only:
+
+```text
+docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md
+docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md
+tests/fixtures/annotations-mixed.pdf
+tests/fixtures/annotations-nonarray.pdf
+tests/fixtures/annotations-filtered-only.pdf
+tests/fixtures/annotations-late-malformed.pdf
+tests/test_pdf_annotations.c
+tests/CMakeLists.txt
+include/extractpdf/extractpdf.h
+src/pdf_annotations.c
+CMakeLists.txt
+```
+
+No page/link/outline/metadata/composition/output implementation edits are expected.
+
+- [ ] **Step 2: Run same-SHA full-ci**
+
+Require on one unchanged GREEN SHA:
+
+```text
+Linux static + all CTests       PASS
+Linux ASan/UBSan + all CTests   PASS
+macOS configure/build/test      PASS
+Windows DLL configure/build/test PASS
+```
+
+Windows must execute `extractpdf.pdf_annotations`.
+
+- [ ] **Step 3: Fresh review against the five locked boundaries**
+
+Review explicitly for:
+
+```text
+malformed/tolerance
+empty snapshot
+order
+identity
+error atomicity
+```
+
+Reject any implementation that sorts survivors, exposes object identity, returns NULL on successful empty extraction, silently defaults malformed surviving public fields, retains page/document pointers, or publishes a partial snapshot.
+
+- [ ] **Step 4: Update issue #35 / PR evidence**
+
+Record RED SHA/run, GREEN SHA/run, full-ci run, exact scope, and review disposition. Keep mutation/forms explicitly deferred.

--- a/docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md
+++ b/docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md
@@ -1,204 +1,133 @@
 # ExtractPDF PDF Page Annotation Enumeration V1 Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> Use strict RED -> GREEN -> exact-head verification. Do not add production behavior before the RED failure is captured.
 
-**Goal:** Add a PDF-only immutable page annotation snapshot with tolerant `/Annots` collection semantics, strict surviving-item materialization, deterministic order, snapshot-local identity, independent lifetime, and atomic failure publication.
+**Goal:** Add a PDF-only immutable ordinary-annotation snapshot with tolerant `/Annots` collection handling, strict surviving-item materialization, stable relative order, snapshot-local indices, independent lifetime, and atomic failure publication.
 
-**Architecture:** Down-cast the existing loaded `fz_page` to `pdf_page` and walk the page object's `/Annots` array read-only. Filter non-dictionaries and Link/Popup/Widget entries without invoking MuPDF annotation synchronization/resynthesis; strictly validate and copy the surviving annotation's Rect/F/Contents into an ExtractPDF-owned array/string arena, then publish only after the complete snapshot succeeds.
-
-**Tech Stack:** C11, MuPDF 1.28.2 pinned through existing vcpkg overlay, CMake/CTest, Linux ASan/UBSan, macOS CI, Windows DLL CI, GitHub Actions.
+**Base:** integrated master `a83639752e629225b34b052d537a5d2e61220711`; branch `feat/pdf-annotations`; issue #35; roadmap #2.
 
 **Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md`
 
-## Global Constraints
+## Locked constraints
 
-- Base is integrated outline master exact SHA `a83639752e629225b34b052d537a5d2e61220711`, verified by push workflow #175 (`33176336925`).
-- Work on `feat/pdf-annotations`; child issue is #35; umbrella is #2.
-- PDF-only V1; non-PDF page -> `EXTRACTPDF_ERROR_UNSUPPORTED`.
-- Reuse existing `extractpdf_page`; no second public PDF page handle.
-- Immutable `extractpdf_annotation_page` snapshot owns all public item/string data and retains no MuPDF/PDF/page/document pointer.
-- Collection tolerance: missing/non-array `/Annots` -> empty; non-dictionary entries ignored; Link/Popup/Widget ignored; absent/non-name/unrecognized subtype -> UNKNOWN.
-- Surviving item strictness: Rect exactly four finite numbers; present F is uint32-representable integer; present Contents is string; malformed survivor -> FORMAT.
-- Preserve original `/Annots` relative order among survivors exactly.
-- Snapshot indices are local coordinates only, never persistent annotation identity or mutation selectors.
-- Empty result -> `OK + non-NULL count-0 snapshot`.
-- Extraction resets `*out_annotations = NULL` before validation/fallible work and publishes only after complete success.
-- Do not call `pdf_sync_annots`, `pdf_load_annots`, update/resynthesis, or mutation APIs for enumeration.
-- RED must contain no production annotation ABI or implementation.
-- Exact GREEN head requires Linux static/all CTests, Linux ASan/UBSan/all CTests, macOS build/test, and Windows DLL build/test.
+- Reuse `extractpdf_page`; no second PDF page handle.
+- PDF-only V1; non-PDF page -> `UNSUPPORTED`.
+- Missing/non-array `/Annots` -> successful empty snapshot.
+- Non-dictionary members ignored.
+- Link/Popup/Widget filtered out.
+- Missing/non-name/unrecognized subtype -> `UNKNOWN`.
+- Surviving `/Rect` must be exactly four finite numbers.
+- Missing `/F` -> 0; present `/F` must be uint32-representable integer.
+- Missing `/Contents` -> absent; present `/Contents` must be a PDF string.
+- Preserve original `/Annots` relative order among survivors.
+- Snapshot indices are never persistent identities or mutation handles.
+- Snapshot retains no MuPDF/PDF/page/document pointer.
+- `*out_annotations` is reset to NULL before later validation/work and published only after complete success.
+- Enumeration itself does not call annotation synchronization/resynthesis/update/mutation APIs.
+- Use `pdf_page_transform()` CTM **directly** to map PDF rectangle coordinates to Fitz page space; do not invert it.
 
----
+## File scope
 
-## File Structure
-
-**Create during RED**
-- `tests/fixtures/annotations-mixed.pdf`
-- `tests/fixtures/annotations-nonarray.pdf`
-- `tests/fixtures/annotations-filtered-only.pdf`
-- `tests/fixtures/annotations-late-malformed.pdf`
-- `tests/test_pdf_annotations.c`
-
-**Modify during RED**
-- `tests/CMakeLists.txt`
-
-**Create during GREEN**
-- `src/pdf_annotations.c`
-
-**Modify during GREEN**
-- `include/extractpdf/extractpdf.h`
-- `CMakeLists.txt`
-
-**Reuse unchanged**
-- `src/internal.h`
-- `src/page.c`
-- existing valid no-annotation PDF fixture
-- `.github/workflows/ci.yml`
-
----
-
-### Task 1: Strict RED for annotation snapshot contract
-
-**Files:**
-- Create four deterministic annotation fixtures listed above.
-- Create `tests/test_pdf_annotations.c`.
-- Modify `tests/CMakeLists.txt`.
-
-**Interfaces:**
-- Consumes existing `extractpdf_open`, `extractpdf_load_page`, `extractpdf_drop_page`, `extractpdf_close`, status enum, `extractpdf_rect`.
-- Produces compile-time references to the not-yet-existing `extractpdf_annotation_page`, `extractpdf_annotation_type`, `extractpdf_annotation_info`, `extractpdf_extract_annotations`, `extractpdf_annotation_count`, `extractpdf_annotation_get_info`, `extractpdf_annotation_contents`, `extractpdf_drop_annotation_page`.
-
-- [ ] **Step 1: Check in deterministic fixtures**
-
-Use a one-page `%PDF-1.4` direct-object fixture writer with explicit xref offsets. Keep annotation objects indirect except for the deliberate scalar entries. All pages use `/MediaBox [0 0 200 200]`.
-
-`annotations-mixed.pdf` page `/Annots`:
-
-```pdf
-[5 0 R 17 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R]
-```
-
-Objects:
-
-```pdf
-5 0 obj << /Type /Annot /Subtype /Text /Rect [10 20 30 40] /F 4 /Contents (alpha) >> endobj
-6 0 obj << /Type /Annot /Subtype /Link /Rect [1 1 2 2] /A << /S /URI /URI (https://example.com) >> >> endobj
-7 0 obj << /Type /Annot /Subtype /FutureThing /Rect [50 60 70 80] /F 64 /Contents (unknown) >> endobj
-8 0 obj << /Type /Annot /Subtype /Widget /Rect [2 2 3 3] /FT /Tx >> endobj
-9 0 obj << /Type /Annot /Subtype /Popup /Rect [3 3 4 4] >> endobj
-10 0 obj << /Type /Annot /Subtype /Highlight /Rect [90 100 120 130] /Contents (bravo) >> endobj
-```
-
-`annotations-nonarray.pdf`: page has `/Annots 17`.
-
-`annotations-filtered-only.pdf`: page `/Annots [17 5 0 R 6 0 R 7 0 R]`, where objects 5/6/7 are Link/Widget/Popup.
-
-`annotations-late-malformed.pdf`: page `/Annots [5 0 R 6 0 R]`; object 5 is valid Text with `/Contents (first)`, object 6 is Highlight with valid Rect but `/Contents 123`.
-
-- [ ] **Step 2: Write the failing C test**
-
-The test must assert:
-
-```c
-/* mixed tolerance + exact surviving order */
-CHECK(extractpdf_extract_annotations(page, &annotations) == EXTRACTPDF_OK);
-CHECK(extractpdf_annotation_count(annotations, &count) == EXTRACTPDF_OK);
-CHECK(count == 3);
-expect_info(annotations, 0, EXTRACTPDF_ANNOTATION_TEXT, 10, 160, 30, 180, 4);
-expect_contents(annotations, 0, "alpha");
-expect_info(annotations, 1, EXTRACTPDF_ANNOTATION_UNKNOWN, 50, 120, 70, 140, 64);
-expect_contents(annotations, 1, "unknown");
-expect_info(annotations, 2, EXTRACTPDF_ANNOTATION_HIGHLIGHT, 90, 70, 120, 100, 0);
-expect_contents(annotations, 2, "bravo");
-```
-
-The y values above prove PDF user-space -> Fitz page-space conversion for a 200-point unrotated page: `[x0 y0 x1 y1]` maps to `[x0 200-y1 x1 200-y0]`.
-
-Also assert:
-
-```c
-/* lifetime */
-extractpdf_drop_page(page);
-extractpdf_close(document);
-/* all count/info/contents accessors still work */
-
-/* empty variants */
-/* no /Annots, non-array /Annots, filtered-only -> OK + non-NULL + count 0 */
-
-/* atomicity */
-annotations = sentinel;
-CHECK(extractpdf_extract_annotations(late_malformed_page, &annotations) == EXTRACTPDF_ERROR_FORMAT);
-CHECK(annotations == NULL);
-annotations = sentinel;
-CHECK(extractpdf_extract_annotations(late_malformed_page, &annotations) == EXTRACTPDF_ERROR_FORMAT);
-CHECK(annotations == NULL);
-
-/* argument/reset */
-/* NULL extraction args; count reset; get_info neutral reset; contents NULL/0 reset; invalid index; drop(NULL) */
-```
-
-Create two independent snapshots of `annotations-mixed.pdf` and assert equal values/order only; do not expose or compare any public object identity.
-
-- [ ] **Step 3: Register only the new RED test target**
-
-Append to `tests/CMakeLists.txt` following the existing PDF test pattern:
-
-```cmake
-add_executable(extractpdf_test_pdf_annotations test_pdf_annotations.c)
-target_link_libraries(extractpdf_test_pdf_annotations PRIVATE ExtractPDF::ExtractPDF)
-target_compile_definitions(extractpdf_test_pdf_annotations PRIVATE
-  ANNOTATIONS_MIXED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-mixed.pdf"
-  ANNOTATIONS_NONARRAY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-nonarray.pdf"
-  ANNOTATIONS_FILTERED_ONLY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-filtered-only.pdf"
-  ANNOTATIONS_LATE_MALFORMED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-late-malformed.pdf")
-add_test(NAME extractpdf.pdf_annotations COMMAND extractpdf_test_pdf_annotations)
-```
-
-Reuse the exact existing no-annotation fixture macro/pattern already present in the test CMake file rather than introducing a duplicate PDF.
-
-- [ ] **Step 4: Verify RED**
-
-Run the repository's normal Linux configure/build path.
-
-Expected boundary:
+RED:
 
 ```text
-ExtractPDF library builds                             PASS
-all pre-existing test targets through pdf_outline    PASS build/link
-extractpdf_test_pdf_annotations                      FAIL compile
+tests/fixtures/annotations-mixed.pdf
+tests/fixtures/annotations-nonarray.pdf
+tests/fixtures/annotations-filtered-only.pdf
+tests/fixtures/annotations-late-malformed.pdf
+tests/test_pdf_annotations.c
+tests/CMakeLists.txt
 ```
 
-The new target must fail specifically on absent annotation type/struct/API declarations. If a fixture parse error, unrelated target, runtime test, crash, or timeout is reached, RED is invalid and must be fixed before continuing.
+GREEN production:
 
-- [ ] **Step 5: Commit RED**
-
-```bash
-git add tests/fixtures/annotations-*.pdf tests/test_pdf_annotations.c tests/CMakeLists.txt
-git commit -m "test: lock PDF annotation snapshot contract"
+```text
+include/extractpdf/extractpdf.h
+src/pdf_annotations.c
+CMakeLists.txt
 ```
 
-Record exact RED SHA and workflow/run evidence in issue #35 / later PR body.
+No changes are expected in page, links, outline, metadata, render, text, image, composition, or output implementation.
 
 ---
 
-### Task 2: Minimal public ABI and immutable implementation
+## Task 1 — Strict RED
 
-**Files:**
-- Modify `include/extractpdf/extractpdf.h`.
-- Create `src/pdf_annotations.c`.
-- Modify `CMakeLists.txt`.
-- Test unchanged: `tests/test_pdf_annotations.c`.
+- [x] Create deterministic fixtures.
+- [x] Add `tests/test_pdf_annotations.c` referencing the wished-for annotation ABI.
+- [x] Register `extractpdf.pdf_annotations` in CMake, including Windows DLL-copy target list.
+- [x] Verify exact RED failure before production code.
 
-**Interfaces:**
-- Produces exactly the public API in the design spec.
-- Uses `pdf_page_from_fz_page`, raw `pdf_page->obj`, `pdf_dict_get`, `pdf_array_len/get`, PDF object type predicates/converters, `pdf_page_obj_transform`, Fitz matrix inversion/rectangle transform, existing `extractpdf_status_from_mupdf`.
+### Required RED fixture behavior
 
-- [ ] **Step 1: Add the public declarations only**
+`annotations-mixed.pdf` logical order:
 
-Add the opaque handle, stable enum, info struct, extraction/count/info/contents/drop declarations from the spec. Do not expose MuPDF enums or PDF object identity.
+```text
+Text-A
+scalar 17
+Link
+FutureThing
+Widget
+Popup
+Highlight-B
+```
 
-- [ ] **Step 2: Add private snapshot records**
+Expected survivors after GREEN:
 
-`src/pdf_annotations.c` owns:
+```text
+0 TEXT       Rect [10 20 30 40]       -> Fitz [10 160 30 180], flags=4,  contents="alpha"
+1 UNKNOWN    Rect [50 60 70 80]       -> Fitz [50 120 70 140], flags=64, contents="unknown"
+2 HIGHLIGHT  Rect [90 100 120 130]    -> Fitz [90 70 120 100], flags=0,  contents="bravo"
+```
+
+`annotations-nonarray.pdf`: `/Annots 17` -> `OK + non-NULL count 0`.
+
+`annotations-filtered-only.pdf`: scalar + Link + Widget + Popup -> `OK + non-NULL count 0`.
+
+`annotations-late-malformed.pdf`: valid Text followed by Highlight `/Contents 123` -> whole extraction `FORMAT + NULL`, repeatably.
+
+Reuse existing `one-page.pdf` for missing `/Annots` empty case.
+
+### RED acceptance
+
+The library and every pre-existing target must build. Only the new annotation test target may fail, and it must fail because `extractpdf_annotation_page`, enum/info types, constants, and annotation APIs do not yet exist. Runtime/fixture errors are not valid RED.
+
+Record exact RED SHA/run in PR #36 and issue #35.
+
+---
+
+## Task 2 — Minimal GREEN
+
+### Public ABI
+
+Add exactly:
+
+```c
+typedef struct extractpdf_annotation_page extractpdf_annotation_page;
+typedef enum extractpdf_annotation_type { ... } extractpdf_annotation_type;
+typedef struct extractpdf_annotation_info {
+    size_t struct_size;
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+} extractpdf_annotation_info;
+
+extractpdf_status extractpdf_extract_annotations(
+    extractpdf_page *, extractpdf_annotation_page **);
+extractpdf_status extractpdf_annotation_count(
+    const extractpdf_annotation_page *, size_t *);
+extractpdf_status extractpdf_annotation_get_info(
+    const extractpdf_annotation_page *, size_t, extractpdf_annotation_info *);
+extractpdf_status extractpdf_annotation_contents(
+    const extractpdf_annotation_page *, size_t, const char **, size_t *);
+void extractpdf_drop_annotation_page(extractpdf_annotation_page *);
+```
+
+Do not expose MuPDF enum values, PDF object numbers, `/NM`, or mutation identity.
+
+### Private snapshot
+
+`src/pdf_annotations.c` owns records equivalent to:
 
 ```c
 typedef struct extractpdf_annotation_internal {
@@ -219,39 +148,41 @@ struct extractpdf_annotation_page {
 };
 ```
 
-No pointer back to page/document/PDF/MuPDF is allowed.
+No back-pointer to source page/document is allowed.
 
-- [ ] **Step 3: Implement tolerant survivor classification**
+### Pass 1: tolerant survivor count
 
-For each raw `/Annots` element in index order:
+From the existing `fz_page`, use `pdf_page_from_fz_page()`. NULL -> `UNSUPPORTED`.
+
+Read `pdf_page->obj` `/Annots` raw. `pdf_array_len()` naturally gives zero for missing/non-array. For each element in array order:
 
 ```text
 not dictionary -> skip
 Subtype Link    -> skip
 Subtype Popup   -> skip
 Subtype Widget  -> skip
-otherwise       -> survivor
+otherwise       -> survivor; known subtype maps explicitly, else UNKNOWN
 ```
 
-Map known subtype names explicitly to the stable ExtractPDF enum; missing/non-name/other name -> UNKNOWN.
+Count survivors with size/allocation overflow guards.
 
-Do not call `pdf_sync_annots` or any annotation resynthesis/update function.
+### Pass 2: strict materialization
 
-- [ ] **Step 4: Implement strict survivor validation/materialization**
+Obtain `pdf_page_transform(ctx, pdf_page, NULL, &page_ctm)` once. The returned CTM maps PDF page user space to Fitz page space and is applied directly.
 
 For each survivor:
 
-1. Validate `/Rect` is an array of length 4 and every member is numeric + finite.
-2. Obtain the page transform; invert it to map PDF-user-space rectangle into Fitz page space; normalize rectangle endpoints.
-3. If `/F` absent use zero; if present require integer in `[0, UINT32_MAX]`.
-4. If `/Contents` absent mark `has_contents = 0`; if present require string, decode PDF text to UTF-8, deep-copy with trailing NUL into the snapshot string arena.
-5. Check every count/allocation/string-size multiplication/addition for `SIZE_MAX` overflow; return NOMEM on overflow/allocation failure.
+1. Locate `/Rect`; require array length 4 and numeric finite members.
+2. Normalize PDF endpoints, apply `fz_transform_rect(raw_rect, page_ctm)`, verify finite result, normalize output endpoints.
+3. `/F`: missing -> 0; present -> require integer in `[0, UINT32_MAX]`.
+4. `/Contents`: missing -> absent; present -> require string, decode with `pdf_to_text_string()`, deep-copy into snapshot string arena with terminating NUL.
+5. Any malformed survivor fails the whole extraction.
 
-Any FORMAT/NOMEM/MuPDF failure disposes the whole private snapshot and returns without publication.
+Use existing `extractpdf_status_from_mupdf()` for MuPDF exceptions. Allocation/size overflow -> `NOMEM`.
 
-- [ ] **Step 5: Implement accessors and atomic publication**
+### Atomic publication and accessors
 
-Extraction begins:
+Extraction starts:
 
 ```c
 if (out_annotations == NULL)
@@ -259,89 +190,55 @@ if (out_annotations == NULL)
 *out_annotations = NULL;
 ```
 
-Only after complete success:
+Publish only after pass 2 completes and the materialized count equals the allocated survivor count.
 
-```c
-*out_annotations = snapshot;
-return EXTRACTPDF_OK;
+`annotation_count`: reset output count to zero when possible before validation.
+
+`annotation_get_info`: validate `struct_size` through `flags`; then neutral-reset type/bounds/flags before handle/index validation; accept larger structs.
+
+`annotation_contents`: reset pointer/size to NULL/0 before validation; absent contents -> `OK + NULL + 0`; present contents -> borrowed snapshot-owned UTF-8.
+
+`drop(NULL)` is safe.
+
+### GREEN acceptance
+
+On the exact GREEN SHA:
+
+```text
+Linux static build                PASS
+all static CTests                 PASS
+Linux ASan/UBSan build            PASS
+all sanitizer CTests              PASS
 ```
 
-`count` resets `*out_count = 0` when possible before validation.
-
-`get_info` validates `struct_size`, resets type/bounds/flags, then validates handle/index and copies known fields.
-
-`contents` resets pointer/size to NULL/0, returns `OK + NULL + 0` for absent contents, and borrowed snapshot-owned UTF-8 for present contents.
-
-`drop(NULL)` is a no-op.
-
-- [ ] **Step 6: Wire the implementation into the root library**
-
-Add only `src/pdf_annotations.c` to `add_library(extractpdf ...)`.
-
-- [ ] **Step 7: Verify GREEN locally/CI**
-
-Run Linux strict static + all CTests and Linux sanitizer build + all CTests. Expected: all tests including `extractpdf.pdf_annotations` pass with no sanitizer failures.
-
-- [ ] **Step 8: Commit GREEN**
-
-```bash
-git add include/extractpdf/extractpdf.h src/pdf_annotations.c CMakeLists.txt
-git commit -m "feat: expose immutable PDF annotation snapshot"
-```
+Do not weaken tests to get GREEN.
 
 ---
 
-### Task 3: Exact-head cross-platform proof and review
+## Task 3 — Final exact-head proof
 
-**Files:** no intended production changes.
+Before final full CI:
 
-- [ ] **Step 1: Confirm exact diff scope**
+- [ ] Correct any documentation/API implementation mismatch without changing locked semantics.
+- [ ] Confirm diff scope contains only spec, plan, four fixtures, one annotation test, test/root CMake, public header, and `src/pdf_annotations.c`.
+- [ ] Review explicitly against: malformed/tolerance, empty snapshot, order, identity, error atomicity.
 
-Diff from integrated base must contain only:
-
-```text
-docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md
-docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md
-tests/fixtures/annotations-mixed.pdf
-tests/fixtures/annotations-nonarray.pdf
-tests/fixtures/annotations-filtered-only.pdf
-tests/fixtures/annotations-late-malformed.pdf
-tests/test_pdf_annotations.c
-tests/CMakeLists.txt
-include/extractpdf/extractpdf.h
-src/pdf_annotations.c
-CMakeLists.txt
-```
-
-No page/link/outline/metadata/composition/output implementation edits are expected.
-
-- [ ] **Step 2: Run same-SHA full-ci**
-
-Require on one unchanged GREEN SHA:
+Trigger the repository's `full-ci` PR label on the **final unchanged head**. Require:
 
 ```text
-Linux static + all CTests       PASS
-Linux ASan/UBSan + all CTests   PASS
-macOS configure/build/test      PASS
-Windows DLL configure/build/test PASS
+Linux static + ASan/UBSan  PASS
+macOS build/test            PASS
+Windows DLL build/test      PASS
 ```
 
-Windows must execute `extractpdf.pdf_annotations`.
+Windows must execute `extractpdf.pdf_annotations`, proving export/link/runtime behavior through the shared-library build.
 
-- [ ] **Step 3: Fresh review against the five locked boundaries**
+After all jobs pass, update PR #36 and issue #35 with:
 
-Review explicitly for:
+- RED exact SHA + workflow/run and expected failure;
+- GREEN/final exact SHA + Linux workflow/run;
+- same-head full-ci workflow/run;
+- exact diff scope;
+- fresh review result for the five locked boundaries.
 
-```text
-malformed/tolerance
-empty snapshot
-order
-identity
-error atomicity
-```
-
-Reject any implementation that sorts survivors, exposes object identity, returns NULL on successful empty extraction, silently defaults malformed surviving public fields, retains page/document pointers, or publishes a partial snapshot.
-
-- [ ] **Step 4: Update issue #35 / PR evidence**
-
-Record RED SHA/run, GREEN SHA/run, full-ci run, exact scope, and review disposition. Keep mutation/forms explicitly deferred.
+Keep annotation mutation and forms/widgets deferred to separate architecture work.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md
@@ -1,0 +1,390 @@
+# ExtractPDF PDF Page Annotation Enumeration V1 Design
+
+## Status
+
+Approved Phase 5 Interactive PDF design for issue #35 under roadmap #2.
+
+Base: integrated outline master exact SHA `a83639752e629225b34b052d537a5d2e61220711`, verified by push workflow #175 (`33176336925`) across Linux static + ASan/UBSan, macOS, and Windows DLL.
+
+This slice is read-only annotation enumeration only. Annotation mutation and forms/widgets remain separate architectures.
+
+## Goals
+
+- Reuse the existing opaque `extractpdf_page`.
+- Expose an ExtractPDF-owned immutable page annotation snapshot with no MuPDF pointer or PDF object crossing the C ABI.
+- Preserve page annotation array order after deterministic filtering.
+- Use the existing Fitz page-space geometry contract for annotation bounds.
+- Keep snapshot data valid after the source page is dropped and the source document is closed.
+- Define tolerant collection semantics separately from strict per-item materialization semantics.
+- Make error publication atomic: success publishes one complete snapshot; failure publishes nothing.
+- Keep enumeration indices snapshot-local and explicitly non-persistent.
+
+## Non-goals
+
+V1 does not mutate annotations, expose PDF object numbers/generations, provide persistent annotation IDs, enumerate links, enumerate popup objects, enumerate widgets/forms, render annotation appearance streams, expose annotation-specific vertex/quad/ink geometry, model reply threads, flatten annotations, save mutations, execute JavaScript, or define cross-snapshot identity.
+
+## PDF-only Boundary
+
+```text
+PDF page      -> annotation snapshot API
+non-PDF page  -> EXTRACTPDF_ERROR_UNSUPPORTED
+```
+
+The public surface remains rooted in the existing `extractpdf_page`; no second public PDF page handle is introduced.
+
+## Public ABI
+
+```c
+typedef struct extractpdf_annotation_page extractpdf_annotation_page;
+
+typedef enum extractpdf_annotation_type {
+    EXTRACTPDF_ANNOTATION_UNKNOWN = 0,
+    EXTRACTPDF_ANNOTATION_TEXT = 1,
+    EXTRACTPDF_ANNOTATION_FREE_TEXT = 2,
+    EXTRACTPDF_ANNOTATION_LINE = 3,
+    EXTRACTPDF_ANNOTATION_SQUARE = 4,
+    EXTRACTPDF_ANNOTATION_CIRCLE = 5,
+    EXTRACTPDF_ANNOTATION_POLYGON = 6,
+    EXTRACTPDF_ANNOTATION_POLY_LINE = 7,
+    EXTRACTPDF_ANNOTATION_HIGHLIGHT = 8,
+    EXTRACTPDF_ANNOTATION_UNDERLINE = 9,
+    EXTRACTPDF_ANNOTATION_SQUIGGLY = 10,
+    EXTRACTPDF_ANNOTATION_STRIKE_OUT = 11,
+    EXTRACTPDF_ANNOTATION_REDACT = 12,
+    EXTRACTPDF_ANNOTATION_STAMP = 13,
+    EXTRACTPDF_ANNOTATION_CARET = 14,
+    EXTRACTPDF_ANNOTATION_INK = 15,
+    EXTRACTPDF_ANNOTATION_FILE_ATTACHMENT = 16,
+    EXTRACTPDF_ANNOTATION_SOUND = 17,
+    EXTRACTPDF_ANNOTATION_MOVIE = 18,
+    EXTRACTPDF_ANNOTATION_RICH_MEDIA = 19,
+    EXTRACTPDF_ANNOTATION_SCREEN = 20,
+    EXTRACTPDF_ANNOTATION_PRINTER_MARK = 21,
+    EXTRACTPDF_ANNOTATION_TRAP_NET = 22,
+    EXTRACTPDF_ANNOTATION_WATERMARK = 23,
+    EXTRACTPDF_ANNOTATION_3D = 24,
+    EXTRACTPDF_ANNOTATION_PROJECTION = 25
+} extractpdf_annotation_type;
+
+typedef struct extractpdf_annotation_info {
+    size_t struct_size;
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+} extractpdf_annotation_info;
+
+EXTRACTPDF_API extractpdf_status extractpdf_extract_annotations(
+    extractpdf_page *page,
+    extractpdf_annotation_page **out_annotations);
+
+EXTRACTPDF_API extractpdf_status extractpdf_annotation_count(
+    const extractpdf_annotation_page *annotations,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_annotation_get_info(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    extractpdf_annotation_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_annotation_contents(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API void extractpdf_drop_annotation_page(
+    extractpdf_annotation_page *annotations);
+```
+
+`extractpdf_annotation_type` is an ExtractPDF enum, not a cast of MuPDF's `pdf_annot_type`. Public numeric values are stable even if MuPDF changes its enum.
+
+## Minimal V1 Data Model
+
+Each surviving ordinary annotation contributes:
+
+```text
+type      stable ExtractPDF annotation type, UNKNOWN when absent/unrecognized
+bounds    annotation /Rect mapped into Fitz page space
+flags     raw PDF annotation /F bitmask as uint32_t
+contents  optional decoded PDF text string copied into snapshot storage
+```
+
+V1 intentionally stops here. Author, name, modification date, color, opacity, intent, reply/thread relations, appearance state, and subtype-specific geometry are deferred until there is a concrete consumer.
+
+## `struct_size` Compatibility
+
+Callers initialize:
+
+```c
+extractpdf_annotation_info info = {0};
+info.struct_size = sizeof(info);
+```
+
+V1 requires the supplied struct to cover through `flags`. Larger structs are accepted; V1 writes only known fields.
+
+After `struct_size` validation and before later handle/index validation, known output fields reset to:
+
+```text
+type   = UNKNOWN
+bounds = {0,0,0,0}
+flags  = 0
+```
+
+## Collection Tolerance Contract
+
+Annotation enumeration deliberately does **not** copy the outline slice's strict structural preflight model.
+
+Pinned MuPDF 1.28.2 semantics establish the compatibility direction: `pdf_array_len()` returns zero for a non-array, and `pdf_sync_annots()` scans `/Annots` in array order, ignores non-dictionary members, excludes `Link` and `Popup`, and routes `Widget` separately. ExtractPDF locks the same collection behavior while implementing it through a read-only raw `/Annots` walk so enumeration itself does not invoke annotation synchronization, appearance resynthesis, or document mutation.
+
+Collection rules:
+
+- no `/Annots` -> empty;
+- non-array `/Annots` -> empty;
+- empty array -> empty;
+- non-dictionary array entry -> ignore;
+- `/Subtype /Link` -> ignore; links remain in the Phase 3 link API;
+- `/Subtype /Popup` -> ignore;
+- `/Subtype /Widget` -> ignore; widgets/forms remain a separate Phase 5 slice;
+- every other dictionary entry survives in its original relative array order;
+- missing, non-name, or unrecognized `/Subtype` -> public `UNKNOWN`, not a collection error.
+
+This is a tolerant enumerator, not a general PDF validator.
+
+## Strict Surviving-item Materialization
+
+Tolerance of the collection container does not mean silently inventing required public item data.
+
+For each surviving ordinary annotation:
+
+- `/Rect` must be an array of exactly four numeric values; otherwise extraction returns `EXTRACTPDF_ERROR_FORMAT`;
+- all four rectangle values must be finite; otherwise `FORMAT`;
+- rectangle endpoints are normalized after mapping to Fitz page space so `x0 <= x1` and `y0 <= y1`;
+- missing `/F` means flags `0`;
+- present `/F` must be an integer representable as `uint32_t`; otherwise `FORMAT`;
+- missing `/Contents` means absent contents (`OK + NULL + 0` from the accessor);
+- present `/Contents` must be a PDF string; otherwise `FORMAT`;
+- present empty contents remains distinct from absent contents;
+- PDF text strings are decoded through MuPDF's PDF text-string decoding, then copied into snapshot-owned UTF-8 storage.
+
+A malformed surviving item fails the **whole extraction**. ExtractPDF never returns a snapshot containing a guessed/defaulted rectangle or a partial prefix of earlier valid items.
+
+## Geometry
+
+The PDF annotation `/Rect` is defined in PDF page user space. ExtractPDF converts it to the same Fitz page-space coordinate model already used by page bounds, text/search, images, and links.
+
+Implementation uses the loaded `pdf_page`'s page object plus MuPDF's page transform and inverse transform. No raw PDF coordinate system appears in the public ABI.
+
+## Empty Snapshot
+
+All valid zero-result cases return:
+
+```text
+extractpdf_extract_annotations() -> EXTRACTPDF_OK
+*out_annotations                 -> non-NULL snapshot
+extractpdf_annotation_count()    -> 0
+```
+
+This includes:
+
+- no `/Annots`;
+- non-array `/Annots`;
+- empty array;
+- array containing only non-dictionaries, Link, Popup, and Widget entries.
+
+Success always returns a valid snapshot handle, including count zero.
+
+## Order
+
+Public indices preserve original `/Annots` array order among surviving ordinary annotations.
+
+```text
+/Annots = [ Text-A, 17, Link, Unknown-X, Widget, Popup, Highlight-B ]
+public   = [ Text-A, Unknown-X, Highlight-B ]
+index    = [   0,        1,           2     ]
+```
+
+No sorting by type, bounds, object number, appearance, or any other property is permitted.
+
+## Identity
+
+Annotation indices are snapshot-local coordinates only.
+
+They are not:
+
+- PDF object numbers;
+- PDF object-number/generation pairs;
+- NM/name values;
+- persistent annotation IDs;
+- cross-snapshot identities;
+- mutation selectors;
+- future update/delete handles.
+
+V1 exposes no PDF object identity in the public ABI. Two snapshots of the same unchanged page may happen to contain the same values in the same order, but the API makes no identity promise across those snapshots.
+
+Future create/update/delete gets a separate design covering stable selectors, transactions/rollback, mutation ordering, save/rewrite integration, and interaction with pre-existing snapshots.
+
+## Snapshot Lifetime and Ownership
+
+Conceptually:
+
+```text
+extractpdf_annotation_page
+  ├── items[]
+  └── strings[]
+```
+
+The published snapshot retains no `pdf_annot *`, `pdf_obj *`, `pdf_page *`, `fz_page *`, `fz_document *`, `extractpdf_page *`, or `extractpdf_document *`.
+
+After successful extraction, callers may immediately drop the source page and close the source document; annotation info and contents remain valid until `extractpdf_drop_annotation_page()`.
+
+`extractpdf_drop_annotation_page(NULL)` is a safe no-op.
+
+## Error Atomicity
+
+`extractpdf_extract_annotations()` follows an atomic publication contract:
+
+```text
+out_annotations == NULL -> ARGUMENT
+otherwise first action  -> *out_annotations = NULL
+```
+
+All PDF traversal, filtering, validation, geometry conversion, allocation, and text copying occur into private temporary state. `*out_annotations` is assigned only after the complete snapshot succeeds.
+
+On any failure:
+
+- `*out_annotations == NULL`;
+- all temporary item/string storage is released;
+- no partial count or item prefix is observable;
+- no MuPDF/PDF pointer escapes;
+- allocation or size overflow -> `EXTRACTPDF_ERROR_NOMEM`;
+- malformed surviving item -> `EXTRACTPDF_ERROR_FORMAT`;
+- non-PDF page -> `EXTRACTPDF_ERROR_UNSUPPORTED`;
+- MuPDF exceptions -> existing `extractpdf_status_from_mupdf()` mapping.
+
+Accessors reset caller-visible outputs to neutral values before later handle/index/type validation wherever an output pointer is available.
+
+## Read-only MuPDF Integration Boundary
+
+The implementation must not call `pdf_sync_annots()`, `pdf_load_annots()`, annotation update/resynthesis APIs, or mutation APIs merely to enumerate annotations.
+
+Preferred internal flow:
+
+```text
+extractpdf_page
+    ↓
+pdf_page_from_fz_page()
+    ↓
+loaded pdf_page->obj
+    ↓
+read-only /Annots array walk
+    ↓
+filter non-dict / Link / Popup / Widget
+    ↓
+strictly materialize survivor Rect/F/Contents
+    ↓
+PDF-space Rect -> Fitz page-space bounds
+    ↓
+copy immutable item/string snapshot
+    ↓
+publish atomically
+```
+
+## Deterministic Test Fixtures
+
+### `annotations-mixed.pdf`
+
+One page with this logical `/Annots` order:
+
+```text
+Text-A
+integer scalar 17
+Link
+Unknown-X
+Widget
+Popup
+Highlight-B
+```
+
+Expected public snapshot:
+
+```text
+0 TEXT       contents="alpha"
+1 UNKNOWN    contents="unknown"
+2 HIGHLIGHT  contents="bravo"
+```
+
+The fixture uses intentionally distinct rectangles/flags/contents so exact order can be asserted without object identity.
+
+### `annotations-nonarray.pdf`
+
+`/Annots 17`. Expected: `OK + non-NULL count-0 snapshot`.
+
+### `annotations-filtered-only.pdf`
+
+Contains only a scalar, Link, Popup, and Widget. Expected: `OK + non-NULL count-0 snapshot`.
+
+### Existing no-annotation PDF
+
+Reuse an existing valid PDF with no `/Annots` to prove the missing-key empty case.
+
+### `annotations-late-malformed.pdf`
+
+First survivor is valid. Second survivor has present non-string `/Contents 123`.
+
+Expected: `EXTRACTPDF_ERROR_FORMAT`, output snapshot NULL. Repeat the call on the same page to prove deterministic failure and no hidden partial publication.
+
+## Strict TDD Boundary
+
+Branch starts from integrated master exact SHA:
+
+```text
+a83639752e629225b34b052d537a5d2e61220711
+  ↓
+feat/pdf-annotations
+```
+
+RED contains only deterministic fixtures, `tests/test_pdf_annotations.c`, and `tests/CMakeLists.txt` changes. No production annotation type/function declaration or implementation may exist in the RED commit.
+
+Acceptable RED: existing library and all pre-existing targets build; only the new annotation test target fails to compile because the new opaque snapshot/type/info/API are absent. Fixture parse errors, unrelated regressions, crashes, timeouts, or a RED that reaches runtime are invalid.
+
+GREEN production scope:
+
+```text
+Modify: include/extractpdf/extractpdf.h
+Create: src/pdf_annotations.c
+Modify: CMakeLists.txt
+```
+
+Avoid unrelated changes to existing page, links, outline, metadata, composition, rendering, text, image, or output implementation.
+
+Exact GREEN head must pass:
+
+```text
+Linux strict static + all CTests       ✅
+Linux ASan/UBSan + all CTests          ✅
+same-head macOS configure/build/test   ✅
+same-head Windows DLL build/test       ✅
+```
+
+Windows must run the new annotation CTest through the shared-library build so the new ABI is proven exported, linkable, and runnable.
+
+## Architecture Summary
+
+```text
+PDF-only page annotation enumeration
++ existing extractpdf_page
++ immutable page snapshot
++ tolerant /Annots collection filtering
++ strict surviving-item materialization
++ original relative order
++ UNKNOWN for absent/unrecognized subtype
++ Link/Popup/Widget excluded
++ Fitz page-space bounds
++ uint32 flags
++ snapshot-owned optional UTF-8 contents
++ valid empty snapshot
++ document-independent lifetime
++ snapshot-local indices only
++ atomic publication on success
++ mutation/forms kept separate
+```

--- a/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md
@@ -6,31 +6,22 @@ Approved Phase 5 Interactive PDF design for issue #35 under roadmap #2.
 
 Base: integrated outline master exact SHA `a83639752e629225b34b052d537a5d2e61220711`, verified by push workflow #175 (`33176336925`) across Linux static + ASan/UBSan, macOS, and Windows DLL.
 
-This slice is read-only annotation enumeration only. Annotation mutation and forms/widgets remain separate architectures.
+This slice is read-only ordinary-annotation enumeration. Annotation mutation and forms/widgets remain separate architectures.
 
 ## Goals
 
 - Reuse the existing opaque `extractpdf_page`.
-- Expose an ExtractPDF-owned immutable page annotation snapshot with no MuPDF pointer or PDF object crossing the C ABI.
-- Preserve page annotation array order after deterministic filtering.
-- Use the existing Fitz page-space geometry contract for annotation bounds.
-- Keep snapshot data valid after the source page is dropped and the source document is closed.
-- Define tolerant collection semantics separately from strict per-item materialization semantics.
-- Make error publication atomic: success publishes one complete snapshot; failure publishes nothing.
-- Keep enumeration indices snapshot-local and explicitly non-persistent.
+- Return an ExtractPDF-owned immutable annotation snapshot with no MuPDF/PDF pointer in the public ABI.
+- Preserve `/Annots` relative order after deterministic filtering.
+- Expose annotation bounds in the existing Fitz page-space coordinate model.
+- Keep snapshot data valid after the source page is dropped and document is closed.
+- Separate tolerant collection handling from strict materialization of annotations that survive filtering.
+- Publish atomically: complete snapshot on success, no snapshot on failure.
+- Keep public indices snapshot-local and non-persistent.
 
 ## Non-goals
 
-V1 does not mutate annotations, expose PDF object numbers/generations, provide persistent annotation IDs, enumerate links, enumerate popup objects, enumerate widgets/forms, render annotation appearance streams, expose annotation-specific vertex/quad/ink geometry, model reply threads, flatten annotations, save mutations, execute JavaScript, or define cross-snapshot identity.
-
-## PDF-only Boundary
-
-```text
-PDF page      -> annotation snapshot API
-non-PDF page  -> EXTRACTPDF_ERROR_UNSUPPORTED
-```
-
-The public surface remains rooted in the existing `extractpdf_page`; no second public PDF page handle is introduced.
+V1 does not mutate annotations, expose PDF object numbers/generations or persistent IDs, enumerate links/popups/widgets as ordinary annotations, render appearance streams, expose subtype-specific geometry, model replies, flatten annotations, save mutations, or define cross-snapshot identity.
 
 ## Public ABI
 
@@ -96,87 +87,59 @@ EXTRACTPDF_API void extractpdf_drop_annotation_page(
     extractpdf_annotation_page *annotations);
 ```
 
-`extractpdf_annotation_type` is an ExtractPDF enum, not a cast of MuPDF's `pdf_annot_type`. Public numeric values are stable even if MuPDF changes its enum.
+`extractpdf_annotation_type` is an ExtractPDF enum, not a cast of MuPDF's enum. Its numeric values belong to the public ABI.
 
-## Minimal V1 Data Model
+## Minimal V1 Item
 
-Each surviving ordinary annotation contributes:
-
-```text
-type      stable ExtractPDF annotation type, UNKNOWN when absent/unrecognized
-bounds    annotation /Rect mapped into Fitz page space
-flags     raw PDF annotation /F bitmask as uint32_t
-contents  optional decoded PDF text string copied into snapshot storage
-```
-
-V1 intentionally stops here. Author, name, modification date, color, opacity, intent, reply/thread relations, appearance state, and subtype-specific geometry are deferred until there is a concrete consumer.
-
-## `struct_size` Compatibility
-
-Callers initialize:
-
-```c
-extractpdf_annotation_info info = {0};
-info.struct_size = sizeof(info);
-```
-
-V1 requires the supplied struct to cover through `flags`. Larger structs are accepted; V1 writes only known fields.
-
-After `struct_size` validation and before later handle/index validation, known output fields reset to:
+Each surviving annotation exposes only:
 
 ```text
-type   = UNKNOWN
-bounds = {0,0,0,0}
-flags  = 0
+type      stable ExtractPDF type; UNKNOWN for missing/non-name/unrecognized subtype
+bounds    /Rect converted into Fitz page space
+flags     raw PDF /F bitmask as uint32_t
+contents  optional decoded PDF text copied into snapshot-owned UTF-8 storage
 ```
 
-## Collection Tolerance Contract
+Author/name/date/color/opacity/intent/reply relations/appearance state and subtype-specific geometry remain deferred.
 
-Annotation enumeration deliberately does **not** copy the outline slice's strict structural preflight model.
+## Malformed vs Tolerance
 
-Pinned MuPDF 1.28.2 semantics establish the compatibility direction: `pdf_array_len()` returns zero for a non-array, and `pdf_sync_annots()` scans `/Annots` in array order, ignores non-dictionary members, excludes `Link` and `Popup`, and routes `Widget` separately. ExtractPDF locks the same collection behavior while implementing it through a read-only raw `/Annots` walk so enumeration itself does not invoke annotation synchronization, appearance resynthesis, or document mutation.
+The `/Annots` collection is intentionally tolerant, following the compatibility direction of pinned MuPDF 1.28.2:
 
-Collection rules:
-
-- no `/Annots` -> empty;
+- missing `/Annots` -> empty;
 - non-array `/Annots` -> empty;
 - empty array -> empty;
-- non-dictionary array entry -> ignore;
-- `/Subtype /Link` -> ignore; links remain in the Phase 3 link API;
+- non-dictionary member -> ignore;
+- `/Subtype /Link` -> ignore; links already have the Phase 3 link API;
 - `/Subtype /Popup` -> ignore;
-- `/Subtype /Widget` -> ignore; widgets/forms remain a separate Phase 5 slice;
-- every other dictionary entry survives in its original relative array order;
-- missing, non-name, or unrecognized `/Subtype` -> public `UNKNOWN`, not a collection error.
+- `/Subtype /Widget` -> ignore; forms/widgets are a later Phase 5 slice;
+- any other dictionary survives in original relative order;
+- missing, non-name, or unrecognized `/Subtype` -> `UNKNOWN`.
 
-This is a tolerant enumerator, not a general PDF validator.
+There is no outline-style structural preflight. This is an enumerator, not a general PDF validator.
 
-## Strict Surviving-item Materialization
+Once a dictionary survives filtering, materialization is strict:
 
-Tolerance of the collection container does not mean silently inventing required public item data.
+- `/Rect` must exist and be an array of exactly four finite numeric values;
+- missing `/F` -> `0`; present `/F` must be an integer in `[0, UINT32_MAX]`;
+- missing `/Contents` -> absent contents;
+- present `/Contents` must be a PDF string;
+- present-empty contents remains distinct from absent contents;
+- malformed surviving data -> `EXTRACTPDF_ERROR_FORMAT` for the whole extraction.
 
-For each surviving ordinary annotation:
-
-- `/Rect` must be an array of exactly four numeric values; otherwise extraction returns `EXTRACTPDF_ERROR_FORMAT`;
-- all four rectangle values must be finite; otherwise `FORMAT`;
-- rectangle endpoints are normalized after mapping to Fitz page space so `x0 <= x1` and `y0 <= y1`;
-- missing `/F` means flags `0`;
-- present `/F` must be an integer representable as `uint32_t`; otherwise `FORMAT`;
-- missing `/Contents` means absent contents (`OK + NULL + 0` from the accessor);
-- present `/Contents` must be a PDF string; otherwise `FORMAT`;
-- present empty contents remains distinct from absent contents;
-- PDF text strings are decoded through MuPDF's PDF text-string decoding, then copied into snapshot-owned UTF-8 storage.
-
-A malformed surviving item fails the **whole extraction**. ExtractPDF never returns a snapshot containing a guessed/defaulted rectangle or a partial prefix of earlier valid items.
+The implementation must never publish a guessed rectangle/default for malformed surviving data or a prefix containing only earlier valid annotations.
 
 ## Geometry
 
-The PDF annotation `/Rect` is defined in PDF page user space. ExtractPDF converts it to the same Fitz page-space coordinate model already used by page bounds, text/search, images, and links.
+PDF annotation `/Rect` is in PDF page user space. ExtractPDF maps it to the same Fitz page-space model used by links/text/images/page bounds.
 
-Implementation uses the loaded `pdf_page`'s page object plus MuPDF's page transform and inverse transform. No raw PDF coordinate system appears in the public ABI.
+Use MuPDF's `pdf_page_transform()` CTM **directly** on the normalized PDF rectangle. This matches MuPDF 1.28.2's own `pdf_bound_annot()` and link-loading paths: the returned page CTM maps PDF page user-space coordinates to Fitz page space. Do not invert that CTM.
+
+After transformation, normalize the output endpoints so `x0 <= x1` and `y0 <= y1`.
 
 ## Empty Snapshot
 
-All valid zero-result cases return:
+Every valid zero-result case is successful:
 
 ```text
 extractpdf_extract_annotations() -> EXTRACTPDF_OK
@@ -184,18 +147,11 @@ extractpdf_extract_annotations() -> EXTRACTPDF_OK
 extractpdf_annotation_count()    -> 0
 ```
 
-This includes:
-
-- no `/Annots`;
-- non-array `/Annots`;
-- empty array;
-- array containing only non-dictionaries, Link, Popup, and Widget entries.
-
-Success always returns a valid snapshot handle, including count zero.
+This includes no `/Annots`, non-array `/Annots`, an empty array, or an array containing only filtered entries.
 
 ## Order
 
-Public indices preserve original `/Annots` array order among surviving ordinary annotations.
+Public indices are exactly the original `/Annots` relative order among surviving ordinary annotations.
 
 ```text
 /Annots = [ Text-A, 17, Link, Unknown-X, Widget, Popup, Highlight-B ]
@@ -203,188 +159,87 @@ public   = [ Text-A, Unknown-X, Highlight-B ]
 index    = [   0,        1,           2     ]
 ```
 
-No sorting by type, bounds, object number, appearance, or any other property is permitted.
+No sorting by subtype, rectangle, PDF object number, appearance, or any other property is allowed.
 
 ## Identity
 
-Annotation indices are snapshot-local coordinates only.
+Annotation indices are snapshot-local coordinates only. They are not PDF object identities, object-number/generation pairs, `/NM` values, persistent IDs, cross-snapshot identities, mutation selectors, or future update/delete handles.
 
-They are not:
+Two snapshots of the same unchanged page may contain equal values/order, but callers get no identity guarantee between them. Mutation requires a separate design for stable selectors, transactions/rollback, save/rewrite behavior, and interaction with pre-existing snapshots.
 
-- PDF object numbers;
-- PDF object-number/generation pairs;
-- NM/name values;
-- persistent annotation IDs;
-- cross-snapshot identities;
-- mutation selectors;
-- future update/delete handles.
+## Lifetime and Ownership
 
-V1 exposes no PDF object identity in the public ABI. Two snapshots of the same unchanged page may happen to contain the same values in the same order, but the API makes no identity promise across those snapshots.
+The published snapshot contains only ExtractPDF-owned item records and copied strings. It retains no `pdf_annot *`, `pdf_obj *`, `pdf_page *`, `fz_page *`, `fz_document *`, `extractpdf_page *`, or `extractpdf_document *`.
 
-Future create/update/delete gets a separate design covering stable selectors, transactions/rollback, mutation ordering, save/rewrite integration, and interaction with pre-existing snapshots.
-
-## Snapshot Lifetime and Ownership
-
-Conceptually:
-
-```text
-extractpdf_annotation_page
-  ├── items[]
-  └── strings[]
-```
-
-The published snapshot retains no `pdf_annot *`, `pdf_obj *`, `pdf_page *`, `fz_page *`, `fz_document *`, `extractpdf_page *`, or `extractpdf_document *`.
-
-After successful extraction, callers may immediately drop the source page and close the source document; annotation info and contents remain valid until `extractpdf_drop_annotation_page()`.
-
-`extractpdf_drop_annotation_page(NULL)` is a safe no-op.
+After successful extraction callers may immediately drop the source page and close the document. Snapshot accessors remain valid until `extractpdf_drop_annotation_page()`; dropping NULL is a no-op.
 
 ## Error Atomicity
 
-`extractpdf_extract_annotations()` follows an atomic publication contract:
+Extraction begins with:
 
 ```text
 out_annotations == NULL -> ARGUMENT
-otherwise first action  -> *out_annotations = NULL
+otherwise                -> *out_annotations = NULL before later validation/work
 ```
 
-All PDF traversal, filtering, validation, geometry conversion, allocation, and text copying occur into private temporary state. `*out_annotations` is assigned only after the complete snapshot succeeds.
+Traversal, filtering, validation, geometry conversion, allocation, and string copies are private until all survivors are materialized. Only then is the snapshot published.
 
-On any failure:
+On failure:
 
-- `*out_annotations == NULL`;
-- all temporary item/string storage is released;
-- no partial count or item prefix is observable;
-- no MuPDF/PDF pointer escapes;
-- allocation or size overflow -> `EXTRACTPDF_ERROR_NOMEM`;
-- malformed surviving item -> `EXTRACTPDF_ERROR_FORMAT`;
-- non-PDF page -> `EXTRACTPDF_ERROR_UNSUPPORTED`;
-- MuPDF exceptions -> existing `extractpdf_status_from_mupdf()` mapping.
+- output remains NULL;
+- all temporary item/string storage is freed;
+- no partial count/item prefix is observable;
+- allocation/size overflow -> `NOMEM`;
+- malformed surviving item -> `FORMAT`;
+- non-PDF page -> `UNSUPPORTED`;
+- MuPDF exceptions -> existing status mapper.
 
-Accessors reset caller-visible outputs to neutral values before later handle/index/type validation wherever an output pointer is available.
+Accessors reset caller-visible outputs to neutral values before later handle/index validation wherever possible. `extractpdf_annotation_get_info()` validates `struct_size` first, then resets known fields before handle/index validation.
 
-## Read-only MuPDF Integration Boundary
+## Read-only Integration Boundary
 
-The implementation must not call `pdf_sync_annots()`, `pdf_load_annots()`, annotation update/resynthesis APIs, or mutation APIs merely to enumerate annotations.
-
-Preferred internal flow:
+Enumeration uses the already-loaded page and performs a raw read-only `/Annots` walk. It does not itself call `pdf_sync_annots()`, `pdf_load_annots()`, annotation update/resynthesis APIs, or mutation APIs. The existing page-loading behavior is unchanged by this slice.
 
 ```text
 extractpdf_page
-    ↓
-pdf_page_from_fz_page()
-    ↓
-loaded pdf_page->obj
-    ↓
-read-only /Annots array walk
-    ↓
-filter non-dict / Link / Popup / Widget
-    ↓
-strictly materialize survivor Rect/F/Contents
-    ↓
-PDF-space Rect -> Fitz page-space bounds
-    ↓
-copy immutable item/string snapshot
-    ↓
-publish atomically
+    -> pdf_page_from_fz_page()
+    -> raw page /Annots array
+    -> tolerant filter
+    -> strict survivor Rect/F/Contents materialization
+    -> pdf_page_transform() CTM -> Fitz bounds
+    -> deep-copy snapshot
+    -> atomic publication
 ```
 
-## Deterministic Test Fixtures
+## Deterministic Fixtures
 
-### `annotations-mixed.pdf`
+`annotations-mixed.pdf` interleaves Text, scalar `17`, Link, unknown subtype, Widget, Popup, Highlight. Expected public order is Text / UNKNOWN / Highlight with distinct bounds, flags, and contents.
 
-One page with this logical `/Annots` order:
+`annotations-nonarray.pdf` uses `/Annots 17` and must return a non-NULL count-0 snapshot.
 
-```text
-Text-A
-integer scalar 17
-Link
-Unknown-X
-Widget
-Popup
-Highlight-B
-```
+`annotations-filtered-only.pdf` contains only scalar/Link/Widget/Popup and must return a non-NULL count-0 snapshot.
 
-Expected public snapshot:
+`annotations-late-malformed.pdf` has one valid survivor followed by a survivor with `/Contents 123`; extraction must return `FORMAT + NULL` on every call, proving late failure atomicity.
 
-```text
-0 TEXT       contents="alpha"
-1 UNKNOWN    contents="unknown"
-2 HIGHLIGHT  contents="bravo"
-```
+An existing PDF with no annotations proves the missing-key empty case.
 
-The fixture uses intentionally distinct rectangles/flags/contents so exact order can be asserted without object identity.
+## TDD / Acceptance Boundary
 
-### `annotations-nonarray.pdf`
-
-`/Annots 17`. Expected: `OK + non-NULL count-0 snapshot`.
-
-### `annotations-filtered-only.pdf`
-
-Contains only a scalar, Link, Popup, and Widget. Expected: `OK + non-NULL count-0 snapshot`.
-
-### Existing no-annotation PDF
-
-Reuse an existing valid PDF with no `/Annots` to prove the missing-key empty case.
-
-### `annotations-late-malformed.pdf`
-
-First survivor is valid. Second survivor has present non-string `/Contents 123`.
-
-Expected: `EXTRACTPDF_ERROR_FORMAT`, output snapshot NULL. Repeat the call on the same page to prove deterministic failure and no hidden partial publication.
-
-## Strict TDD Boundary
-
-Branch starts from integrated master exact SHA:
+Branch base:
 
 ```text
 a83639752e629225b34b052d537a5d2e61220711
-  ↓
-feat/pdf-annotations
+  -> feat/pdf-annotations
 ```
 
-RED contains only deterministic fixtures, `tests/test_pdf_annotations.c`, and `tests/CMakeLists.txt` changes. No production annotation type/function declaration or implementation may exist in the RED commit.
+RED contains deterministic fixtures/test/CMake registration and no annotation production declarations or implementation. Valid RED means all old targets build and only the new annotation target fails on absent ABI.
 
-Acceptable RED: existing library and all pre-existing targets build; only the new annotation test target fails to compile because the new opaque snapshot/type/info/API are absent. Fixture parse errors, unrelated regressions, crashes, timeouts, or a RED that reaches runtime are invalid.
-
-GREEN production scope:
+GREEN production scope is limited to:
 
 ```text
-Modify: include/extractpdf/extractpdf.h
-Create: src/pdf_annotations.c
-Modify: CMakeLists.txt
+include/extractpdf/extractpdf.h
+src/pdf_annotations.c
+CMakeLists.txt
 ```
 
-Avoid unrelated changes to existing page, links, outline, metadata, composition, rendering, text, image, or output implementation.
-
-Exact GREEN head must pass:
-
-```text
-Linux strict static + all CTests       ✅
-Linux ASan/UBSan + all CTests          ✅
-same-head macOS configure/build/test   ✅
-same-head Windows DLL build/test       ✅
-```
-
-Windows must run the new annotation CTest through the shared-library build so the new ABI is proven exported, linkable, and runnable.
-
-## Architecture Summary
-
-```text
-PDF-only page annotation enumeration
-+ existing extractpdf_page
-+ immutable page snapshot
-+ tolerant /Annots collection filtering
-+ strict surviving-item materialization
-+ original relative order
-+ UNKNOWN for absent/unrecognized subtype
-+ Link/Popup/Widget excluded
-+ Fitz page-space bounds
-+ uint32 flags
-+ snapshot-owned optional UTF-8 contents
-+ valid empty snapshot
-+ document-independent lifetime
-+ snapshot-local indices only
-+ atomic publication on success
-+ mutation/forms kept separate
-```
+Final exact head must pass Linux strict static/all CTests, Linux ASan/UBSan/all CTests, macOS configure/build/test, and Windows DLL configure/build/test with `extractpdf.pdf_annotations` executed on Windows.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -26,6 +26,7 @@ typedef struct extractpdf_image_page extractpdf_image_page;
 typedef struct extractpdf_link_page extractpdf_link_page;
 typedef struct extractpdf_output extractpdf_output;
 typedef struct extractpdf_outline extractpdf_outline;
+typedef struct extractpdf_annotation_page extractpdf_annotation_page;
 
 typedef struct extractpdf_point {
     float x;
@@ -125,6 +126,42 @@ typedef struct extractpdf_outline_info {
     extractpdf_point target;
     int is_open;
 } extractpdf_outline_info;
+
+typedef enum extractpdf_annotation_type {
+    EXTRACTPDF_ANNOTATION_UNKNOWN = 0,
+    EXTRACTPDF_ANNOTATION_TEXT = 1,
+    EXTRACTPDF_ANNOTATION_FREE_TEXT = 2,
+    EXTRACTPDF_ANNOTATION_LINE = 3,
+    EXTRACTPDF_ANNOTATION_SQUARE = 4,
+    EXTRACTPDF_ANNOTATION_CIRCLE = 5,
+    EXTRACTPDF_ANNOTATION_POLYGON = 6,
+    EXTRACTPDF_ANNOTATION_POLY_LINE = 7,
+    EXTRACTPDF_ANNOTATION_HIGHLIGHT = 8,
+    EXTRACTPDF_ANNOTATION_UNDERLINE = 9,
+    EXTRACTPDF_ANNOTATION_SQUIGGLY = 10,
+    EXTRACTPDF_ANNOTATION_STRIKE_OUT = 11,
+    EXTRACTPDF_ANNOTATION_REDACT = 12,
+    EXTRACTPDF_ANNOTATION_STAMP = 13,
+    EXTRACTPDF_ANNOTATION_CARET = 14,
+    EXTRACTPDF_ANNOTATION_INK = 15,
+    EXTRACTPDF_ANNOTATION_FILE_ATTACHMENT = 16,
+    EXTRACTPDF_ANNOTATION_SOUND = 17,
+    EXTRACTPDF_ANNOTATION_MOVIE = 18,
+    EXTRACTPDF_ANNOTATION_RICH_MEDIA = 19,
+    EXTRACTPDF_ANNOTATION_SCREEN = 20,
+    EXTRACTPDF_ANNOTATION_PRINTER_MARK = 21,
+    EXTRACTPDF_ANNOTATION_TRAP_NET = 22,
+    EXTRACTPDF_ANNOTATION_WATERMARK = 23,
+    EXTRACTPDF_ANNOTATION_3D = 24,
+    EXTRACTPDF_ANNOTATION_PROJECTION = 25
+} extractpdf_annotation_type;
+
+typedef struct extractpdf_annotation_info {
+    size_t struct_size;
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+} extractpdf_annotation_info;
 
 typedef enum extractpdf_metadata_field {
     EXTRACTPDF_METADATA_TITLE = 1,
@@ -349,6 +386,25 @@ EXTRACTPDF_API extractpdf_status extractpdf_link_uri(
     const char **out_utf8,
     size_t *out_size);
 
+EXTRACTPDF_API extractpdf_status extractpdf_extract_annotations(
+    extractpdf_page *page,
+    extractpdf_annotation_page **out_annotations);
+
+EXTRACTPDF_API extractpdf_status extractpdf_annotation_count(
+    const extractpdf_annotation_page *annotations,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_annotation_get_info(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    extractpdf_annotation_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_annotation_contents(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size);
+
 EXTRACTPDF_API const char *extractpdf_status_string(
     extractpdf_status status);
 
@@ -369,6 +425,9 @@ EXTRACTPDF_API void extractpdf_drop_link_page(
 
 EXTRACTPDF_API void extractpdf_drop_outline(
     extractpdf_outline *outline);
+
+EXTRACTPDF_API void extractpdf_drop_annotation_page(
+    extractpdf_annotation_page *annotations);
 
 EXTRACTPDF_API void extractpdf_drop_bitmap(
     extractpdf_bitmap *bitmap);

--- a/src/pdf_annotations.c
+++ b/src/pdf_annotations.c
@@ -1,0 +1,556 @@
+#include "pdf_internal.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct extractpdf_annotation_internal {
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    size_t contents_offset;
+    size_t contents_size;
+    int has_contents;
+} extractpdf_annotation_internal;
+
+struct extractpdf_annotation_page {
+    extractpdf_annotation_internal *items;
+    char *strings;
+    size_t count;
+    size_t string_size;
+    size_t string_capacity;
+};
+
+static void extractpdf_zero_annotation_rect(extractpdf_rect *rect)
+{
+    rect->x0 = 0.0f;
+    rect->y0 = 0.0f;
+    rect->x1 = 0.0f;
+    rect->y1 = 0.0f;
+}
+
+static void extractpdf_dispose_annotation_page(
+    extractpdf_annotation_page *annotations)
+{
+    if (annotations == NULL)
+        return;
+
+    free(annotations->items);
+    free(annotations->strings);
+    free(annotations);
+}
+
+static extractpdf_annotation_page *extractpdf_allocate_annotation_page(
+    size_t count)
+{
+    extractpdf_annotation_page *annotations;
+
+    annotations = (extractpdf_annotation_page *)calloc(1, sizeof(*annotations));
+    if (annotations == NULL)
+        return NULL;
+
+    if (count != 0) {
+        if (count > SIZE_MAX / sizeof(*annotations->items)) {
+            free(annotations);
+            return NULL;
+        }
+        annotations->items = (extractpdf_annotation_internal *)calloc(
+            count, sizeof(*annotations->items));
+        if (annotations->items == NULL) {
+            free(annotations);
+            return NULL;
+        }
+    }
+
+    annotations->count = count;
+    return annotations;
+}
+
+static extractpdf_status extractpdf_annotation_append_string(
+    extractpdf_annotation_page *annotations,
+    const char *text,
+    size_t *out_offset,
+    size_t *out_size)
+{
+    size_t size;
+    size_t required;
+    size_t capacity;
+    char *grown;
+
+    size = strlen(text);
+    if (size == SIZE_MAX || annotations->string_size > SIZE_MAX - size - 1)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    required = annotations->string_size + size + 1;
+    if (required > annotations->string_capacity) {
+        capacity = annotations->string_capacity != 0 ?
+            annotations->string_capacity : 64;
+        while (capacity < required) {
+            if (capacity > SIZE_MAX / 2) {
+                capacity = required;
+                break;
+            }
+            capacity *= 2;
+        }
+        if (capacity < required)
+            return EXTRACTPDF_ERROR_NOMEM;
+
+        grown = (char *)realloc(annotations->strings, capacity);
+        if (grown == NULL)
+            return EXTRACTPDF_ERROR_NOMEM;
+        annotations->strings = grown;
+        annotations->string_capacity = capacity;
+    }
+
+    *out_offset = annotations->string_size;
+    *out_size = size;
+    memcpy(annotations->strings + annotations->string_size, text, size + 1);
+    annotations->string_size = required;
+    return EXTRACTPDF_OK;
+}
+
+static int extractpdf_annotation_dict_find(
+    fz_context *ctx,
+    pdf_obj *dictionary,
+    pdf_obj *key,
+    pdf_obj **out_value)
+{
+    int count;
+    int index;
+
+    *out_value = NULL;
+    count = pdf_dict_len(ctx, dictionary);
+    for (index = 0; index < count; ++index) {
+        pdf_obj *candidate = pdf_dict_get_key(ctx, dictionary, index);
+        if (pdf_name_eq(ctx, candidate, key)) {
+            *out_value = pdf_dict_get_val(ctx, dictionary, index);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static extractpdf_annotation_type extractpdf_annotation_type_from_name(
+    const char *name)
+{
+    if (strcmp(name, "Text") == 0)
+        return EXTRACTPDF_ANNOTATION_TEXT;
+    if (strcmp(name, "FreeText") == 0)
+        return EXTRACTPDF_ANNOTATION_FREE_TEXT;
+    if (strcmp(name, "Line") == 0)
+        return EXTRACTPDF_ANNOTATION_LINE;
+    if (strcmp(name, "Square") == 0)
+        return EXTRACTPDF_ANNOTATION_SQUARE;
+    if (strcmp(name, "Circle") == 0)
+        return EXTRACTPDF_ANNOTATION_CIRCLE;
+    if (strcmp(name, "Polygon") == 0)
+        return EXTRACTPDF_ANNOTATION_POLYGON;
+    if (strcmp(name, "PolyLine") == 0)
+        return EXTRACTPDF_ANNOTATION_POLY_LINE;
+    if (strcmp(name, "Highlight") == 0)
+        return EXTRACTPDF_ANNOTATION_HIGHLIGHT;
+    if (strcmp(name, "Underline") == 0)
+        return EXTRACTPDF_ANNOTATION_UNDERLINE;
+    if (strcmp(name, "Squiggly") == 0)
+        return EXTRACTPDF_ANNOTATION_SQUIGGLY;
+    if (strcmp(name, "StrikeOut") == 0)
+        return EXTRACTPDF_ANNOTATION_STRIKE_OUT;
+    if (strcmp(name, "Redact") == 0)
+        return EXTRACTPDF_ANNOTATION_REDACT;
+    if (strcmp(name, "Stamp") == 0)
+        return EXTRACTPDF_ANNOTATION_STAMP;
+    if (strcmp(name, "Caret") == 0)
+        return EXTRACTPDF_ANNOTATION_CARET;
+    if (strcmp(name, "Ink") == 0)
+        return EXTRACTPDF_ANNOTATION_INK;
+    if (strcmp(name, "FileAttachment") == 0)
+        return EXTRACTPDF_ANNOTATION_FILE_ATTACHMENT;
+    if (strcmp(name, "Sound") == 0)
+        return EXTRACTPDF_ANNOTATION_SOUND;
+    if (strcmp(name, "Movie") == 0)
+        return EXTRACTPDF_ANNOTATION_MOVIE;
+    if (strcmp(name, "RichMedia") == 0)
+        return EXTRACTPDF_ANNOTATION_RICH_MEDIA;
+    if (strcmp(name, "Screen") == 0)
+        return EXTRACTPDF_ANNOTATION_SCREEN;
+    if (strcmp(name, "PrinterMark") == 0)
+        return EXTRACTPDF_ANNOTATION_PRINTER_MARK;
+    if (strcmp(name, "TrapNet") == 0)
+        return EXTRACTPDF_ANNOTATION_TRAP_NET;
+    if (strcmp(name, "Watermark") == 0)
+        return EXTRACTPDF_ANNOTATION_WATERMARK;
+    if (strcmp(name, "3D") == 0)
+        return EXTRACTPDF_ANNOTATION_3D;
+    if (strcmp(name, "Projection") == 0)
+        return EXTRACTPDF_ANNOTATION_PROJECTION;
+    return EXTRACTPDF_ANNOTATION_UNKNOWN;
+}
+
+static int extractpdf_annotation_classify(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_type *out_type)
+{
+    pdf_obj *subtype = NULL;
+    const char *name;
+    int present;
+
+    *out_type = EXTRACTPDF_ANNOTATION_UNKNOWN;
+    present = extractpdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(Subtype), &subtype);
+    if (!present || !pdf_is_name(ctx, subtype))
+        return 1;
+
+    name = pdf_to_name(ctx, subtype);
+    if (strcmp(name, "Link") == 0 ||
+        strcmp(name, "Popup") == 0 ||
+        strcmp(name, "Widget") == 0)
+        return 0;
+
+    *out_type = extractpdf_annotation_type_from_name(name);
+    return 1;
+}
+
+static extractpdf_status extractpdf_annotation_read_bounds(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    fz_matrix page_ctm,
+    extractpdf_rect *out_bounds)
+{
+    pdf_obj *rect_obj = NULL;
+    float values[4];
+    fz_rect raw;
+    fz_rect transformed;
+    int present;
+    int index;
+
+    present = extractpdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(Rect), &rect_obj);
+    if (!present || !pdf_is_array(ctx, rect_obj) ||
+        pdf_array_len(ctx, rect_obj) != 4)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    for (index = 0; index < 4; ++index) {
+        pdf_obj *value = pdf_array_get(ctx, rect_obj, index);
+        if (!pdf_is_number(ctx, value))
+            return EXTRACTPDF_ERROR_FORMAT;
+        values[index] = pdf_to_real(ctx, value);
+        if (!isfinite(values[index]))
+            return EXTRACTPDF_ERROR_FORMAT;
+    }
+
+    raw.x0 = values[0] < values[2] ? values[0] : values[2];
+    raw.x1 = values[0] < values[2] ? values[2] : values[0];
+    raw.y0 = values[1] < values[3] ? values[1] : values[3];
+    raw.y1 = values[1] < values[3] ? values[3] : values[1];
+    transformed = fz_transform_rect(raw, page_ctm);
+
+    if (!isfinite(transformed.x0) || !isfinite(transformed.y0) ||
+        !isfinite(transformed.x1) || !isfinite(transformed.y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    out_bounds->x0 = transformed.x0 < transformed.x1 ?
+        transformed.x0 : transformed.x1;
+    out_bounds->x1 = transformed.x0 < transformed.x1 ?
+        transformed.x1 : transformed.x0;
+    out_bounds->y0 = transformed.y0 < transformed.y1 ?
+        transformed.y0 : transformed.y1;
+    out_bounds->y1 = transformed.y0 < transformed.y1 ?
+        transformed.y1 : transformed.y0;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_annotation_read_flags(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    uint32_t *out_flags)
+{
+    pdf_obj *flags_obj = NULL;
+    int64_t value;
+    int present;
+
+    *out_flags = 0;
+    present = extractpdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(F), &flags_obj);
+    if (!present)
+        return EXTRACTPDF_OK;
+    if (!pdf_is_int(ctx, flags_obj))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    value = pdf_to_int64(ctx, flags_obj);
+    if (value < 0 || (uint64_t)value > UINT32_MAX)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    *out_flags = (uint32_t)value;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_annotation_read_contents(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_page *annotations,
+    extractpdf_annotation_internal *item)
+{
+    pdf_obj *contents_obj = NULL;
+    const char *text;
+    int present;
+
+    present = extractpdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(Contents), &contents_obj);
+    if (!present)
+        return EXTRACTPDF_OK;
+    if (!pdf_is_string(ctx, contents_obj))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    text = pdf_to_text_string(ctx, contents_obj);
+    if (text == NULL)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    item->has_contents = 1;
+    return extractpdf_annotation_append_string(
+        annotations,
+        text,
+        &item->contents_offset,
+        &item->contents_size);
+}
+
+static extractpdf_status extractpdf_annotation_materialize(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    fz_matrix page_ctm,
+    extractpdf_annotation_page *annotations,
+    size_t index,
+    extractpdf_annotation_type type)
+{
+    extractpdf_annotation_internal *item = &annotations->items[index];
+    extractpdf_status status;
+
+    item->type = type;
+
+    status = extractpdf_annotation_read_bounds(
+        ctx, annotation, page_ctm, &item->bounds);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    status = extractpdf_annotation_read_flags(
+        ctx, annotation, &item->flags);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    return extractpdf_annotation_read_contents(
+        ctx, annotation, annotations, item);
+}
+
+extractpdf_status extractpdf_extract_annotations(
+    extractpdf_page *page,
+    extractpdf_annotation_page **out_annotations)
+{
+    extractpdf_annotation_page *annotations;
+    fz_context *ctx;
+    pdf_page *pdf_page = NULL;
+    pdf_obj *annots = NULL;
+    size_t count = 0;
+    size_t output_index = 0;
+    int annotation_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+    extractpdf_status status = EXTRACTPDF_OK;
+
+    if (out_annotations == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_annotations = NULL;
+
+    if (page == NULL || page->page == NULL || page->document == NULL ||
+        page->document->ctx == NULL || page->document->doc == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    ctx = page->document->ctx;
+
+    fz_var(pdf_page);
+    fz_var(annots);
+    fz_var(count);
+    fz_var(annotation_count);
+    fz_var(caught_code);
+
+    fz_try(ctx)
+    {
+        int index;
+
+        pdf_page = pdf_page_from_fz_page(ctx, page->page);
+        if (pdf_page != NULL) {
+            annots = pdf_dict_get(ctx, pdf_page->obj, PDF_NAME(Annots));
+            annotation_count = pdf_array_len(ctx, annots);
+            for (index = 0; index < annotation_count; ++index) {
+                pdf_obj *annotation = pdf_array_get(ctx, annots, index);
+                extractpdf_annotation_type type;
+
+                if (!pdf_is_dict(ctx, annotation))
+                    continue;
+                if (!extractpdf_annotation_classify(ctx, annotation, &type))
+                    continue;
+                if (count == SIZE_MAX) {
+                    status = EXTRACTPDF_ERROR_NOMEM;
+                    break;
+                }
+                ++count;
+            }
+        }
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (pdf_page == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    annotations = extractpdf_allocate_annotation_page(count);
+    if (annotations == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    if (count == 0) {
+        *out_annotations = annotations;
+        return EXTRACTPDF_OK;
+    }
+
+    caught_code = FZ_ERROR_NONE;
+    status = EXTRACTPDF_OK;
+    fz_var(output_index);
+    fz_var(caught_code);
+    fz_var(status);
+
+    fz_try(ctx)
+    {
+        fz_matrix page_ctm;
+        int index;
+
+        pdf_page_transform(ctx, pdf_page, NULL, &page_ctm);
+        for (index = 0; index < annotation_count; ++index) {
+            pdf_obj *annotation = pdf_array_get(ctx, annots, index);
+            extractpdf_annotation_type type;
+
+            if (!pdf_is_dict(ctx, annotation))
+                continue;
+            if (!extractpdf_annotation_classify(ctx, annotation, &type))
+                continue;
+            if (output_index >= annotations->count) {
+                status = EXTRACTPDF_ERROR_FORMAT;
+                break;
+            }
+
+            status = extractpdf_annotation_materialize(
+                ctx,
+                annotation,
+                page_ctm,
+                annotations,
+                output_index,
+                type);
+            if (status != EXTRACTPDF_OK)
+                break;
+            ++output_index;
+        }
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        extractpdf_status caught_status =
+            extractpdf_status_from_mupdf(caught_code);
+        extractpdf_dispose_annotation_page(annotations);
+        return caught_status;
+    }
+    if (status != EXTRACTPDF_OK || output_index != annotations->count) {
+        if (status == EXTRACTPDF_OK)
+            status = EXTRACTPDF_ERROR_FORMAT;
+        extractpdf_dispose_annotation_page(annotations);
+        return status;
+    }
+
+    *out_annotations = annotations;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_annotation_count(
+    const extractpdf_annotation_page *annotations,
+    size_t *out_count)
+{
+    if (out_count != NULL)
+        *out_count = 0;
+
+    if (annotations == NULL || out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    *out_count = annotations->count;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_annotation_get_info(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    extractpdf_annotation_info *out_info)
+{
+    const extractpdf_annotation_internal *item;
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_annotation_info, flags) +
+        sizeof(out_info->flags);
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->type = EXTRACTPDF_ANNOTATION_UNKNOWN;
+    extractpdf_zero_annotation_rect(&out_info->bounds);
+    out_info->flags = 0;
+
+    if (annotations == NULL || index >= annotations->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    item = &annotations->items[index];
+    out_info->type = item->type;
+    out_info->bounds = item->bounds;
+    out_info->flags = item->flags;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_annotation_contents(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    const char **out_utf8,
+    size_t *out_size)
+{
+    const extractpdf_annotation_internal *item;
+
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
+
+    if (annotations == NULL || out_utf8 == NULL || out_size == NULL ||
+        index >= annotations->count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    item = &annotations->items[index];
+    if (!item->has_contents)
+        return EXTRACTPDF_OK;
+
+    *out_utf8 = annotations->strings + item->contents_offset;
+    *out_size = item->contents_size;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_annotation_page(
+    extractpdf_annotation_page *annotations)
+{
+    extractpdf_dispose_annotation_page(annotations);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,6 +163,17 @@ target_compile_definitions(extractpdf_test_pdf_outline PRIVATE
 add_test(NAME extractpdf.pdf_outline COMMAND extractpdf_test_pdf_outline)
 set_tests_properties(extractpdf.pdf_outline PROPERTIES TIMEOUT 30)
 
+add_executable(extractpdf_test_pdf_annotations test_pdf_annotations.c)
+target_link_libraries(extractpdf_test_pdf_annotations PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_annotations PRIVATE
+  ANNOTATIONS_MIXED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-mixed.pdf"
+  ANNOTATIONS_NONARRAY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-nonarray.pdf"
+  ANNOTATIONS_FILTERED_ONLY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-filtered-only.pdf"
+  ANNOTATIONS_LATE_MALFORMED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-late-malformed.pdf"
+  EMPTY_ANNOTATIONS_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf")
+add_test(NAME extractpdf.pdf_annotations COMMAND extractpdf_test_pdf_annotations)
+set_tests_properties(extractpdf.pdf_annotations PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -181,7 +192,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_pdf_merge
       extractpdf_test_output_file
       extractpdf_test_pdf_metadata
-      extractpdf_test_pdf_outline)
+      extractpdf_test_pdf_outline
+      extractpdf_test_pdf_annotations)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/annotations-filtered-only.pdf
+++ b/tests/fixtures/annotations-filtered-only.pdf
@@ -1,0 +1,38 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Annots [17 5 0 R 6 0 R 7 0 R] >>
+endobj
+4 0 obj
+<< >>
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Link /Rect [1 1 2 2] /A << /S /URI /URI (https://example.com) >> >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Widget /Rect [2 2 3 3] /FT /Tx >>
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /Popup /Rect [3 3 4 4] >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000223 00000 n 
+0000000244 00000 n 
+0000000353 00000 n 
+0000000428 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+494
+%%EOF

--- a/tests/fixtures/annotations-late-malformed.pdf
+++ b/tests/fixtures/annotations-late-malformed.pdf
@@ -1,0 +1,34 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Annots [5 0 R 6 0 R] >>
+endobj
+4 0 obj
+<< >>
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (first) >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Highlight /Rect [50 60 70 80] /Contents 123 >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000214 00000 n 
+0000000235 00000 n 
+0000000322 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+410
+%%EOF

--- a/tests/fixtures/annotations-mixed.pdf
+++ b/tests/fixtures/annotations-mixed.pdf
@@ -1,0 +1,50 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Annots [5 0 R 17 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R] >>
+endobj
+4 0 obj
+<< >>
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /F 4 /Contents (alpha) >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Link /Rect [1 1 2 2] /A << /S /URI /URI (https://example.com) >> >>
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /FutureThing /Rect [50 60 70 80] /F 64 /Contents (unknown) >>
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /Widget /Rect [2 2 3 3] /FT /Tx >>
+endobj
+9 0 obj
+<< /Type /Annot /Subtype /Popup /Rect [3 3 4 4] >>
+endobj
+10 0 obj
+<< /Type /Annot /Subtype /Highlight /Rect [90 100 120 130] /Contents (bravo) >>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000242 00000 n 
+0000000263 00000 n 
+0000000355 00000 n 
+0000000464 00000 n 
+0000000566 00000 n 
+0000000641 00000 n 
+0000000707 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R >>
+startxref
+803
+%%EOF

--- a/tests/fixtures/annotations-nonarray.pdf
+++ b/tests/fixtures/annotations-nonarray.pdf
@@ -1,0 +1,22 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Annots 17 >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+203
+%%EOF

--- a/tests/test_pdf_annotations.c
+++ b/tests/test_pdf_annotations.c
@@ -1,0 +1,267 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    if (d < 0.0f)
+        d = -d;
+    return d < 0.01f;
+}
+
+static void expect_info(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    extractpdf_annotation_type type,
+    float x0,
+    float y0,
+    float x1,
+    float y1,
+    uint32_t flags)
+{
+    extractpdf_annotation_info info = { 0 };
+    info.struct_size = sizeof(info);
+
+    CHECK(extractpdf_annotation_get_info(annotations, index, &info) ==
+          EXTRACTPDF_OK);
+    CHECK(info.struct_size == sizeof(info));
+    CHECK(info.type == type);
+    CHECK(close_float(info.bounds.x0, x0));
+    CHECK(close_float(info.bounds.y0, y0));
+    CHECK(close_float(info.bounds.x1, x1));
+    CHECK(close_float(info.bounds.y1, y1));
+    CHECK(info.flags == flags);
+}
+
+static void expect_contents(
+    const extractpdf_annotation_page *annotations,
+    size_t index,
+    const char *expected)
+{
+    const char *text = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_annotation_contents(
+              annotations, index, &text, &size) == EXTRACTPDF_OK);
+    if (expected == NULL) {
+        CHECK(text == NULL);
+        CHECK(size == 0);
+        return;
+    }
+
+    CHECK(text != NULL);
+    CHECK(size == strlen(expected));
+    CHECK(memcmp(text, expected, size) == 0);
+    CHECK(text[size] == '\0');
+}
+
+static void open_page(
+    const char *path,
+    extractpdf_document **out_document,
+    extractpdf_page **out_page)
+{
+    *out_document = NULL;
+    *out_page = NULL;
+    CHECK(extractpdf_open(path, NULL, out_document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(*out_document, 0, out_page) == EXTRACTPDF_OK);
+    CHECK(*out_page != NULL);
+}
+
+static void test_mixed_order_identity_and_lifetime(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_annotation_page *first = NULL;
+    extractpdf_annotation_page *second = NULL;
+    size_t count = 0;
+
+    open_page(ANNOTATIONS_MIXED_PDF, &document, &page);
+
+    CHECK(extractpdf_extract_annotations(page, &first) == EXTRACTPDF_OK);
+    CHECK(first != NULL);
+    CHECK(extractpdf_extract_annotations(page, &second) == EXTRACTPDF_OK);
+    CHECK(second != NULL);
+    CHECK(first != second);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+
+    CHECK(extractpdf_annotation_count(first, &count) == EXTRACTPDF_OK);
+    CHECK(count == 3);
+
+    expect_info(first, 0, EXTRACTPDF_ANNOTATION_TEXT,
+                10.0f, 160.0f, 30.0f, 180.0f, 4u);
+    expect_contents(first, 0, "alpha");
+
+    expect_info(first, 1, EXTRACTPDF_ANNOTATION_UNKNOWN,
+                50.0f, 120.0f, 70.0f, 140.0f, 64u);
+    expect_contents(first, 1, "unknown");
+
+    expect_info(first, 2, EXTRACTPDF_ANNOTATION_HIGHLIGHT,
+                90.0f, 70.0f, 120.0f, 100.0f, 0u);
+    expect_contents(first, 2, "bravo");
+
+    CHECK(extractpdf_annotation_count(second, &count) == EXTRACTPDF_OK);
+    CHECK(count == 3);
+    expect_info(second, 0, EXTRACTPDF_ANNOTATION_TEXT,
+                10.0f, 160.0f, 30.0f, 180.0f, 4u);
+    expect_info(second, 1, EXTRACTPDF_ANNOTATION_UNKNOWN,
+                50.0f, 120.0f, 70.0f, 140.0f, 64u);
+    expect_info(second, 2, EXTRACTPDF_ANNOTATION_HIGHLIGHT,
+                90.0f, 70.0f, 120.0f, 100.0f, 0u);
+
+    extractpdf_drop_annotation_page(first);
+    extractpdf_drop_annotation_page(second);
+}
+
+static void expect_empty_snapshot(const char *path)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_annotation_page *annotations = NULL;
+    size_t count = 99;
+
+    open_page(path, &document, &page);
+    CHECK(extractpdf_extract_annotations(page, &annotations) == EXTRACTPDF_OK);
+    CHECK(annotations != NULL);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+
+    CHECK(extractpdf_annotation_count(annotations, &count) == EXTRACTPDF_OK);
+    CHECK(count == 0);
+    extractpdf_drop_annotation_page(annotations);
+}
+
+static void test_empty_snapshot_tolerance(void)
+{
+    expect_empty_snapshot(EMPTY_ANNOTATIONS_PDF);
+    expect_empty_snapshot(ANNOTATIONS_NONARRAY_PDF);
+    expect_empty_snapshot(ANNOTATIONS_FILTERED_ONLY_PDF);
+}
+
+static void test_late_failure_is_atomic_and_repeatable(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_annotation_page *annotations =
+        (extractpdf_annotation_page *)&sentinel;
+
+    open_page(ANNOTATIONS_LATE_MALFORMED_PDF, &document, &page);
+
+    CHECK(extractpdf_extract_annotations(page, &annotations) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(annotations == NULL);
+
+    annotations = (extractpdf_annotation_page *)&sentinel;
+    CHECK(extractpdf_extract_annotations(page, &annotations) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(annotations == NULL);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+}
+
+static void test_argument_and_reset_contract(void)
+{
+    int sentinel = 0;
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_annotation_page *annotations =
+        (extractpdf_annotation_page *)&sentinel;
+    extractpdf_annotation_info info = { 0 };
+    extractpdf_annotation_info small = { 0 };
+    const char *text = (const char *)&sentinel;
+    size_t size = 99;
+    size_t count = 99;
+
+    CHECK(extractpdf_extract_annotations(NULL, &annotations) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(annotations == NULL);
+    CHECK(extractpdf_extract_annotations(NULL, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    open_page(ANNOTATIONS_MIXED_PDF, &document, &page);
+    CHECK(extractpdf_extract_annotations(page, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(extractpdf_extract_annotations(page, &annotations) ==
+          EXTRACTPDF_OK);
+    CHECK(annotations != NULL);
+
+    CHECK(extractpdf_annotation_count(NULL, &count) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_annotation_count(annotations, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    small.struct_size = offsetof(extractpdf_annotation_info, flags);
+    CHECK(extractpdf_annotation_get_info(annotations, 0, &small) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    info.struct_size = sizeof(info);
+    info.type = EXTRACTPDF_ANNOTATION_HIGHLIGHT;
+    info.bounds.x0 = 99.0f;
+    info.bounds.y0 = 99.0f;
+    info.bounds.x1 = 99.0f;
+    info.bounds.y1 = 99.0f;
+    info.flags = UINT32_MAX;
+    CHECK(extractpdf_annotation_get_info(annotations, 99, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.type == EXTRACTPDF_ANNOTATION_UNKNOWN);
+    CHECK(close_float(info.bounds.x0, 0.0f));
+    CHECK(close_float(info.bounds.y0, 0.0f));
+    CHECK(close_float(info.bounds.x1, 0.0f));
+    CHECK(close_float(info.bounds.y1, 0.0f));
+    CHECK(info.flags == 0);
+
+    info.type = EXTRACTPDF_ANNOTATION_TEXT;
+    CHECK(extractpdf_annotation_get_info(NULL, 0, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.type == EXTRACTPDF_ANNOTATION_UNKNOWN);
+    CHECK(extractpdf_annotation_get_info(NULL, 0, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_annotation_contents(NULL, 0, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (const char *)&sentinel;
+    size = 99;
+    CHECK(extractpdf_annotation_contents(annotations, 99, &text, &size) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    CHECK(extractpdf_annotation_contents(annotations, 0, NULL, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+    extractpdf_drop_annotation_page(annotations);
+    extractpdf_drop_annotation_page(NULL);
+}
+
+int main(void)
+{
+    test_mixed_order_identity_and_lifetime();
+    test_empty_snapshot_tolerance();
+    test_late_failure_is_atomic_and_repeatable();
+    test_argument_and_reset_contract();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 5 Annotation Enumeration V1 for #35 / #2.

Design: `docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotations-design.md`
Plan: `docs/superpowers/plans/2026-08-28-extractpdf-pdf-annotations.md`

## TDD evidence

- Integrated base: `a83639752e629225b34b052d537a5d2e61220711` (outline integrated master; push workflow #175 passed Linux static + ASan/UBSan, macOS, Windows DLL).
- RED exact head: `7810edf15e73a1b82fbdf9274a708c8ed1326310`.
- RED workflow: #176 (`33177453322`).
- RED result: ExtractPDF and every pre-existing target through `extractpdf_test_pdf_outline` built successfully; only `extractpdf_test_pdf_annotations` failed to compile, exactly because the new annotation snapshot type/enum/info/constants and extraction/accessor/drop APIs were absent. No fixture/runtime/unrelated regression was reached.
- Production GREEN commit: `2ed491439f7d4f1be4404c6872f50ac3327d2a72`.
- Linux GREEN workflow: #177 (`33177980883`) — strict static build + all CTests ✅; ASan/UBSan build + all CTests ✅.
- Final feature head: `1734a0a9563c86fbad3a3528231b420ed11dc56f`; the only post-GREEN change corrected the design/plan to document MuPDF's `pdf_page_transform()` CTM direction. Production code and tests were unchanged.
- Same-head full-ci workflow: #179 (`33178285133`) — Linux static + sanitizers ✅; macOS configure/build/test ✅; Windows DLL configure/build/test ✅.
- Windows feature-head DLL job built `pdf_annotations.c`, linked/exported `extractpdf.dll`, built `extractpdf_test_pdf_annotations.exe`, and ran `extractpdf.pdf_annotations` as test 18/18; all 18 CTests passed.

## Locked contract

- **Malformed / tolerance:** missing or non-array `/Annots` is empty; non-dictionary entries are ignored; Link/Popup/Widget are filtered; missing/non-name/unrecognized subtype is `UNKNOWN`. Surviving annotations are strict: malformed Rect/F/Contents fails the whole extraction with `FORMAT`.
- **Empty snapshot:** every valid zero-result case returns `OK + non-NULL count-0 snapshot`; the snapshot remains valid after dropping the source page and closing the document.
- **Order:** public indices preserve original `/Annots` relative order among surviving ordinary annotations; no sorting by subtype, geometry, object number, or appearance.
- **Identity:** indices are snapshot-local only; the public ABI exposes no object number, generation, `/NM`, persistent ID, cross-snapshot identity, or future mutation handle.
- **Error atomicity:** `*out_annotations` is reset to NULL before fallible work; traversal/materialization is private; only a complete snapshot is published. A deterministic fixture proves a valid first item followed by a malformed second item still returns `FORMAT + NULL`, repeatably.

## Implementation boundary

- Enumeration uses a raw read-only `/Annots` walk from the existing loaded PDF page.
- It does not itself call `pdf_sync_annots()`, `pdf_load_annots()`, annotation update/resynthesis APIs, or mutation APIs.
- PDF annotation Rects are converted to Fitz page space by applying MuPDF 1.28.2's `pdf_page_transform()` CTM directly, matching MuPDF's annotation/link geometry path.
- Published snapshots retain no MuPDF/PDF/page/document pointer.
- Annotation mutation and forms/widgets remain separate future architectures.

## Final scope / review

Final diff from integrated base contains exactly 11 paths: spec, plan, public header, `src/pdf_annotations.c`, root/test CMake, one C test, and four deterministic fixtures. No edits to existing page, links, outline, metadata, render, text, image, composition, or output implementation.

Fresh exact-head review against malformed/tolerance, empty snapshot, order, identity, and error atomicity found no Critical/Important blocker. No implementation change was made after the successful same-head full-ci proof.

## Integration evidence

- PR #36 merged with expected head `1734a0a9563c86fbad3a3528231b420ed11dc56f`.
- Integrated master merge commit: `58525ce1b4b691ef53dfafc7c4e4d82753c966ba`.
- Integrated push workflow #180 (`33181186725`) completed successfully on that exact merge SHA: Linux static + all CTests ✅, Linux ASan/UBSan + all CTests ✅, macOS configure/build/test ✅, Windows DLL configure/build/test ✅.
- Windows master ran `extractpdf.pdf_annotations` as test 18/18 and all 18 CTests passed.
- Issue #35 is closed completed; roadmap #2 records Annotation Enumeration V1 as integrated.