### PR TITLE
integrate: PDF annotation mutation editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,9 @@ add_library(extractpdf
   src/pdf_metadata.c
   src/pdf_outline.c
   src/pdf_annotation_common.c
-  src/pdf_annotations.c)
+  src/pdf_annotations.c
+  src/pdf_edit.c
+  src/pdf_edit_annotations.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)
 target_include_directories(extractpdf PUBLIC
@@ -48,6 +50,9 @@ else()
 endif()
 
 if(EXTRACTPDF_BUILD_TESTS)
+  target_sources(extractpdf PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/pdf_edit_fault_hook.c")
+  target_compile_definitions(extractpdf PRIVATE EXTRACTPDF_TESTING=1)
   include(CTest)
   add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(extractpdf
   src/output_file.c
   src/pdf_metadata.c
   src/pdf_outline.c
+  src/pdf_annotation_common.c
   src/pdf_annotations.c)
 add_library(ExtractPDF::ExtractPDF ALIAS extractpdf)
 target_compile_features(extractpdf PUBLIC c_std_11)

--- a/docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
+++ b/docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
@@ -34,6 +34,23 @@
 - Keep the current single-thread handle contract. Add no mutable process-global/TLS state.
 - Strict RED precedes all new production declarations/behavior. Final feature head requires Linux static + all CTests, Linux ASan/UBSan + all CTests, macOS, and Windows DLL proof.
 
+## Completion Definition
+
+Implementation is complete only when all of these are true on one exact feature SHA:
+
+```text
+strict compile RED was captured before production ABI
+old Annotation Enumeration behavior still passes unchanged
+all Mutation V1 public contracts pass deterministic CTest
+19/19 Linux static CTests pass
+19/19 Linux ASan/UBSan CTests pass
+19/19 macOS CTests pass
+19/19 Windows DLL CTests pass
+fresh exact-head review has no Critical/Important blocker
+```
+
+Integration is a separate explicit gate after that proof.
+
 ---
 
 ## File Structure
@@ -55,30 +72,30 @@
   - private `extractpdf_pdf_annotation_view`;
   - survivor classification and strict common-materialization declarations.
 - Create `src/pdf_annotation_common.c`
-  - move the current subtype/filter/Rect/F/Contents logic out of `src/pdf_annotations.c` without changing its behavior.
+  - move current subtype/filter/Rect/F/Contents logic from `src/pdf_annotations.c` without changing behavior.
 - Modify `src/pdf_annotations.c`
-  - consume the shared helpers and retain immutable snapshot allocation/copy/public accessors.
+  - consume shared helpers and retain immutable snapshot allocation/copy/public accessors.
 
 ### Editor implementation
 
 - Create `src/pdf_edit_internal.h`
-  - private editor struct, ref registry, token helpers, page/object resolution helpers, and test-fault numeric constants under `EXTRACTPDF_TESTING`.
+  - private editor struct, ref registry, token helpers, page/object resolution helpers, test-fault constants under `EXTRACTPDF_TESTING`.
 - Create `src/pdf_edit.c`
   - begin policy checks, source-to-private clone/context lifecycle, signed-field scan, JavaScript disable, journal enable, non-consuming snapshot, drop.
 - Create `src/pdf_edit_annotations.c`
   - editor discovery, canonical ref registry, live getters, counted UTF-8 validation/copy, create/update/delete, full-uint32 flags write, appearance update, journal rollback.
 - Modify `CMakeLists.txt`
-  - compile the new production modules.
+  - compile new production modules.
 
 ### Deterministic tests
 
 - Create `tests/test_pdf_annotation_mutation.c`
   - one executable with named groups `arguments`, `begin`, `discovery`, `create`, `update-delete`, `contents-flags`, `snapshot`, `javascript` and no third-party framework.
 - Create `tests/pdf_edit_test_api.h`
-  - test-only fault enum/hook declaration; not installed and not included by the public header.
+  - test-only fault enum/hook declaration; not installed and not included by public header.
 - Create `tests/pdf_edit_fault_hook.c`
-  - test-only exported hook compiled into `extractpdf` only when tests are built; state remains per editor, never global.
-- Create checked-in deterministic fixtures:
+  - test-only hook compiled into `extractpdf` only when tests are built; state remains per editor, never global.
+- Create:
   - `tests/fixtures/annotation-mutation.pdf`
   - `tests/fixtures/annotation-mutation-signed.pdf`
   - `tests/fixtures/annotation-mutation-unsigned-signature.pdf`
@@ -88,7 +105,7 @@
   - `tests/fixtures/encrypted-one-page.pdf` with password `user-pass`
   - `tests/fixtures/composition-non-pdf.txt`
 - Modify `tests/CMakeLists.txt`
-  - register the mutation target/CTest, fixture/output paths, fault-hook compilation, and Windows DLL-copy target.
+  - register mutation target/CTest, fixture/output paths, fault-hook compilation, and Windows DLL-copy target.
 
 No page/render/text/image/link/outline/metadata/composition behavior is refactored as part of this feature.
 
@@ -107,11 +124,11 @@ No page/render/text/image/link/outline/metadata/composition behavior is refactor
 
 **Interfaces:**
 - Consumes: current public document, immutable annotation, metadata, and output APIs.
-- Produces: the complete wished-for Mutation V1 contract as a compile RED. No new production declaration appears in this task.
+- Produces: complete wished-for Mutation V1 contract as a compile RED. No new production declaration appears in this task.
 
 - [ ] **Step 1: Generate deterministic checked-in PDFs**
 
-Run this one-shot authoring script from repository root. Do not commit the script; commit only its outputs.
+Run this one-shot authoring script from repository root. Do not commit the script; commit only outputs.
 
 ```bash
 python3 - <<'PY'
@@ -192,7 +209,7 @@ PY
 sha256sum tests/fixtures/annotation-mutation*.pdf
 ```
 
-Run the generator a second time and repeat `sha256sum`. The four hashes must be unchanged.
+Run generator a second time and repeat `sha256sum`; all four hashes must remain unchanged.
 
 Fixture contract:
 
@@ -205,10 +222,10 @@ annotation-mutation.pdf page 0 survivors:
 4 Ink        flags 0           contents ink-e
 
 filtered page-0 entries: scalar 17, Link, Popup, Widget
-page 1: FreeText then Circle
+page 1 survivors: FreeText, Circle
 ```
 
-- [ ] **Step 2: Add the test-only fault declaration, with no implementation yet**
+- [ ] **Step 2: Add test-only fault declaration, no implementation**
 
 Create `tests/pdf_edit_test_api.h`:
 
@@ -234,9 +251,9 @@ EXTRACTPDF_API void extractpdf_test_pdf_edit_set_fault(
 
 The unknown `extractpdf_pdf_edit` type is intentionally part of RED.
 
-- [ ] **Step 3: Add the mutation test executable and common helpers**
+- [ ] **Step 3: Add test executable/common helpers**
 
-Create `tests/test_pdf_annotation_mutation.c` using the existing `CHECK` style:
+Create `tests/test_pdf_annotation_mutation.c` with existing `CHECK` style:
 
 ```c
 #include <extractpdf/extractpdf.h>
@@ -275,29 +292,17 @@ static int ref_is_zero(const extractpdf_annotation_ref *ref)
 }
 ```
 
-Add helpers that:
+Implement helpers to open source, save output, read live editor data, and reparse outputs exclusively through public immutable APIs. `expect_snapshot_annotation()` verifies type, bounds, flags, and missing/present-empty/non-empty Contents; it never inspects raw PDF objects.
 
-```text
-open source document
-save extractpdf_output with extractpdf_output_save_file
-read live edit info/Contents
-reparse saved output through extractpdf_open -> load_page -> extract_annotations
-verify missing/present-empty/non-empty Contents distinctly
-```
+- [ ] **Step 4: Lock output reset, struct-size, and argument contracts**
 
-`expect_snapshot_annotation()` must verify type, bounds, flags, and Contents through public immutable APIs; it must not inspect raw PDF objects.
-
-- [ ] **Step 4: Lock output reset, struct-size, and basic argument contracts**
-
-`test_arguments()` must include these exact checks:
+`test_arguments()` includes null/reset checks before any real editor is needed:
 
 ```c
 int sentinel = 0;
 extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
 extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
 extractpdf_annotation_info info = {0};
-extractpdf_annotation_create_options create = {0};
-extractpdf_annotation_update update = {0};
 extractpdf_output *output = (extractpdf_output *)&sentinel;
 char *text = (char *)(uintptr_t)1;
 size_t size = 99;
@@ -322,14 +327,6 @@ size = 99;
 CHECK(extractpdf_pdf_edit_annotation_contents(NULL, &ref, &text, &size) == EXTRACTPDF_ERROR_ARGUMENT);
 CHECK(text == NULL && size == 0);
 
-create.struct_size = offsetof(extractpdf_annotation_create_options, contents_size);
-zero_ref(&ref);
-CHECK(extractpdf_pdf_edit_annotation_create(NULL, 0, &create, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
-CHECK(ref_is_zero(&ref));
-
-update.struct_size = offsetof(extractpdf_annotation_update, contents_size);
-CHECK(extractpdf_pdf_edit_annotation_update(NULL, &ref, &update) == EXTRACTPDF_ERROR_ARGUMENT);
-
 output = (extractpdf_output *)&sentinel;
 CHECK(extractpdf_pdf_edit_snapshot(NULL, &output) == EXTRACTPDF_ERROR_ARGUMENT);
 CHECK(output == NULL);
@@ -339,9 +336,50 @@ extractpdf_drop_pdf_edit(NULL);
 CHECK(strcmp(extractpdf_status_string(EXTRACTPDF_ERROR_STATE), "invalid state") == 0);
 ```
 
-After a real editor is available later, this same group must also verify too-small create/update `struct_size`, unknown update bits, bad page indices, and reset values. Larger-than-V1 structs must be accepted by providing a wrapper struct whose first member is the V1 struct plus trailing bytes.
+The same RED test function also opens `MUTATION_PDF`, begins a real editor once the implementation exists, then locks forward-compatible struct behavior explicitly:
 
-- [ ] **Step 5: Lock begin lifetime and fail-closed policies**
+```c
+struct create_larger {
+    extractpdf_annotation_create_options v1;
+    uint64_t future;
+};
+struct update_larger {
+    extractpdf_annotation_update v1;
+    uint64_t future;
+};
+extractpdf_annotation_create_options create_small = {0};
+extractpdf_annotation_update update_small = {0};
+struct create_larger create_big = {0};
+struct update_larger update_big = {0};
+
+create_small.struct_size =
+    offsetof(extractpdf_annotation_create_options, contents_size);
+zero_ref(&ref);
+CHECK(extractpdf_pdf_edit_annotation_create(
+          edit, 0, &create_small, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(ref_is_zero(&ref));
+
+update_small.struct_size =
+    offsetof(extractpdf_annotation_update, contents_size);
+CHECK(extractpdf_pdf_edit_annotation_update(
+          edit, &live_ref, &update_small) == EXTRACTPDF_ERROR_ARGUMENT);
+
+create_big.v1.struct_size = sizeof(create_big);
+create_big.v1.type = EXTRACTPDF_ANNOTATION_TEXT;
+create_big.v1.bounds = (extractpdf_rect){150,150,170,170};
+zero_ref(&ref);
+CHECK(extractpdf_pdf_edit_annotation_create(
+          edit, 0, &create_big.v1, &ref) == EXTRACTPDF_OK);
+
+update_big.v1.struct_size = sizeof(update_big);
+update_big.v1.fields = 0;
+CHECK(extractpdf_pdf_edit_annotation_update(
+          edit, &live_ref, &update_big.v1) == EXTRACTPDF_OK);
+```
+
+Also require unknown update bits -> `ARGUMENT`, page `-1`/page_count -> `ARGUMENT`, and every supplied count/ref/string/output is reset before later validation failure.
+
+- [ ] **Step 5: Lock begin lifetime/fail-closed policies**
 
 `test_begin_lifetime_and_fail_closed()`:
 
@@ -384,9 +422,9 @@ CHECK(edit == NULL);
 extractpdf_close(source);
 ```
 
-- [ ] **Step 6: Lock discovery/ref identity and malformed atomicity**
+- [ ] **Step 6: Lock discovery/ref identity/malformed atomicity**
 
-`test_discovery_and_refs()` must assert exactly five page-0 survivors and canonical repeated ref acquisition:
+`test_discovery_and_refs()`:
 
 ```c
 CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) == EXTRACTPDF_OK);
@@ -397,7 +435,7 @@ CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_again) == EXTRACTPD
 CHECK(memcmp(&square_ref, &square_again, sizeof(square_ref)) == 0);
 ```
 
-Open the same source into editor B and verify `square_ref` used with B returns `ARGUMENT`. Verify page `-1`, page `2`, and index `99` are `ARGUMENT` with reset outputs.
+Open editor B from same source; using `square_ref` with B must be `ARGUMENT`. Page `-1`, page `2`, and index `99` must be `ARGUMENT` with reset outputs.
 
 For `annotations-late-malformed.pdf`:
 
@@ -411,9 +449,9 @@ CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 0, &ref) == EXTRACTPDF_ERRO
 CHECK(ref_is_zero(&ref));
 ```
 
-No prefix ref may be registered by the failed scan.
+No prefix ref may be registered by failed scan.
 
-- [ ] **Step 7: Lock create/update/delete/rollback/type-matrix behavior**
+- [ ] **Step 7: Lock create/update/delete/rollback/type matrix**
 
 Create helper:
 
@@ -442,7 +480,7 @@ static extractpdf_annotation_ref create_rect_annot(
 }
 ```
 
-`test_create()` creates these four exact cases and verifies each through live getters:
+`test_create()` creates and live-verifies:
 
 ```text
 page 0 TEXT      [20,20,35,35]   flags 1   Contents "new-text"
@@ -451,25 +489,25 @@ page 1 SQUARE    [100,20,150,70] flags 8   Contents absent
 page 1 CIRCLE    [20,90,70,140]  flags 16  Contents present-empty
 ```
 
-Then set the same valid options to HIGHLIGHT and UNKNOWN and require `UNSUPPORTED + zero ref`.
+Using otherwise valid options with HIGHLIGHT and UNKNOWN must return `UNSUPPORTED + zero ref`.
 
 `test_update_delete()` must:
 
 ```text
-1. acquire Text ref and Square ref from page 0;
+1. acquire Text and Square refs from page 0;
 2. delete Text;
 3. require Text get_info/contents/update/delete => STATE;
-4. reacquire page-0 index 0 and require byte-equal token to original Square ref;
-5. update Square bounds + flags + Contents using original Square ref;
-6. verify all three changed;
-7. acquire Highlight ref; BOUNDS update => UNSUPPORTED;
-8. Highlight FLAGS|CONTENTS update => OK;
+4. reacquire page-0 index 0 and require token byte-equal to original Square ref;
+5. update Square bounds+flags+Contents through original ref;
+6. verify all requested fields changed;
+7. acquire Highlight; BOUNDS update => UNSUPPORTED;
+8. Highlight FLAGS|CONTENTS => OK;
 9. live UNKNOWN zero-field update => OK;
 10. tombstone zero-field update => STATE;
 11. wrong-session zero-field update => ARGUMENT.
 ```
 
-Atomic update fault must save pre-call values explicitly:
+Atomic update fault saves and compares explicit pre/post values:
 
 ```c
 extractpdf_annotation_info before = {0};
@@ -488,7 +526,7 @@ CHECK(extractpdf_pdf_edit_annotation_contents(
 change.struct_size = sizeof(change);
 change.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
                 EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
-change.bounds = (extractpdf_rect){20, 20, 90, 90};
+change.bounds = (extractpdf_rect){20,20,90,90};
 change.contents_utf8 = "rollback-new";
 change.contents_size = sizeof("rollback-new") - 1;
 extractpdf_test_pdf_edit_set_fault(
@@ -503,6 +541,7 @@ CHECK(close_float(before.bounds.x0, after.bounds.x0));
 CHECK(close_float(before.bounds.y0, after.bounds.y0));
 CHECK(close_float(before.bounds.x1, after.bounds.x1));
 CHECK(close_float(before.bounds.y1, after.bounds.y1));
+CHECK(before.flags == after.flags);
 CHECK(before_size == after_size);
 CHECK(before_size == 0 || memcmp(before_text, after_text, before_size) == 0);
 extractpdf_free(before_text);
@@ -522,9 +561,9 @@ CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &after_count) == EXTRACTPDF_
 CHECK(after_count == before_count);
 ```
 
-- [ ] **Step 8: Lock full-u32 flags and counted Contents semantics**
+- [ ] **Step 8: Lock full-u32 flags/counted Contents**
 
-`test_contents_flags()` begins with the existing Text:
+`test_contents_flags()` starts from existing Text:
 
 ```c
 info.struct_size = sizeof(info);
@@ -539,7 +578,7 @@ CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text_ref, &info) == EXTRACT
 CHECK(info.flags == UINT32_MAX);
 ```
 
-Also use:
+Use:
 
 ```c
 static const char counted[3] = {'c','a','t'};
@@ -550,23 +589,23 @@ static const char embedded_nul[3] = {'a','\0','b'};
 Required sequence:
 
 ```text
-CONTENTS=counted/3 -> OK, getter returns allocated "cat" + NUL
-mutate to "dog" -> previously returned allocated copy still equals "cat"
-CONTENTS=NULL/0 -> remove; getter returns NULL/0
-CONTENTS=nonNULL/0 -> present empty; getter returns nonNULL/0
-bad_utf8/2 -> ARGUMENT, state unchanged
-embedded_nul/3 -> ARGUMENT, state unchanged
-NULL/1 -> ARGUMENT
+CONTENTS=counted/3 -> OK, getter allocated "cat" + NUL
+mutate to "dog" -> prior allocated copy still equals "cat"
+CONTENTS=NULL/0 -> remove; getter NULL/0
+CONTENTS=nonNULL/0 -> present empty; getter nonNULL/0
+bad_utf8/2 -> ARGUMENT and state unchanged
+embedded_nul/3 -> ARGUMENT and state unchanged
+NULL/1 -> ARGUMENT and state unchanged
 ```
 
-- [ ] **Step 9: Lock source/snapshot/output isolation and JavaScript non-execution**
+- [ ] **Step 9: Lock source/snapshot/output isolation and JS non-execution**
 
-Before beginning an editor, obtain an immutable source annotation snapshot and retain it. After begin succeeds, close source, mutate editor, then prove the retained source snapshot still reads:
+Before editor begin, retain immutable source annotation snapshot. After begin succeeds, close source, mutate editor, then retained source snapshot must still expose:
 
 ```text
 Text bounds [10,160,30,180]
 flags 2147483649
-Contents "text-a"
+Contents text-a
 ```
 
 Snapshot test:
@@ -588,16 +627,15 @@ update.contents_utf8 = "snapshot-b";
 update.contents_size = sizeof("snapshot-b") - 1;
 CHECK(extractpdf_pdf_edit_annotation_update(edit, &text_ref, &update) == EXTRACTPDF_OK);
 CHECK(extractpdf_pdf_edit_snapshot(edit, &b) == EXTRACTPDF_OK);
-
 CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
 CHECK(memcmp(a_data, a_copy, a_size) == 0);
 ```
 
-Save A/B, reparse both through immutable annotation enumeration, and require A=`text-a`, B=`snapshot-b`. Drop the editor and re-read A/B output bytes again to prove output lifetime independence.
+Save A/B, reparse through immutable annotation enumeration, require A=`text-a`, B=`snapshot-b`. Drop editor and read A/B bytes again to prove output lifetime independence.
 
-Arm `SNAPSHOT_BEFORE_PUBLISH`, require failure + NULL output, then perform a real Contents update through the same ref and require success; a mere getter is not sufficient proof that the editor remains usable after failed snapshot.
+Arm `SNAPSHOT_BEFORE_PUBLISH`, require non-OK + NULL output, then perform a real update to `after-failed-snapshot`, read it through same ref, snapshot again, reparse, and require new value.
 
-JavaScript fixture starts with `/Info /Title (SAFE)` and `/OpenAction` JavaScript `this.title = "EXECUTED"`. `test_javascript_disabled()` must begin an editor, update the Text annotation so `pdf_update_annot()` executes, snapshot, reparse, and require public metadata Title remains exactly `SAFE`.
+JS fixture starts with `/Info /Title (SAFE)` and `/OpenAction` JS `this.title = "EXECUTED"`. `test_javascript_disabled()` must begin editor, update Text so `pdf_update_annot()` executes, snapshot, reparse, and require public metadata Title exactly `SAFE`.
 
 - [ ] **Step 10: Add named test-group dispatch**
 
@@ -625,7 +663,7 @@ int main(int argc, char **argv)
 }
 ```
 
-- [ ] **Step 11: Register the RED target**
+- [ ] **Step 11: Register RED target**
 
 Append to `tests/CMakeLists.txt`:
 
@@ -653,9 +691,9 @@ add_test(NAME extractpdf.pdf_annotation_mutation
 set_tests_properties(extractpdf.pdf_annotation_mutation PROPERTIES TIMEOUT 60)
 ```
 
-Add `extractpdf_test_pdf_annotation_mutation` to the existing Windows DLL-copy list. Do **not** add `pdf_edit_fault_hook.c` in RED.
+Add target to Windows DLL-copy list. Do not add `pdf_edit_fault_hook.c` in RED.
 
-- [ ] **Step 12: Run and capture strict RED**
+- [ ] **Step 12: Run/capture strict RED**
 
 ```bash
 rm -rf build
@@ -676,7 +714,7 @@ only extractpdf_test_pdf_annotation_mutation fails to compile
 failure is absent approved ABI: editor/ref/types/status/constants/functions
 ```
 
-A fixture/runtime error, missing header/path, or old target regression is not valid RED.
+Fixture/runtime error, missing header/path, or old-target regression is invalid RED.
 
 Commit:
 
@@ -691,7 +729,7 @@ git add tests/fixtures/annotation-mutation.pdf \
 git commit -m "test: define PDF annotation mutation red"
 ```
 
-Open a draft PR to `master`, link #37/#2, push, and record exact RED SHA + workflow in PR #body and #37 before any production ABI is added.
+Open draft PR to `master`, link #37/#2, push, and record exact RED SHA + workflow in PR body and #37 before production ABI.
 
 ---
 
@@ -730,9 +768,9 @@ extractpdf_status extractpdf_pdf_annotation_read_view(
     extractpdf_pdf_annotation_view *out_view);
 ```
 
-- [ ] **Step 1: Prove the existing annotation target is green before refactor**
+- [ ] **Step 1: Prove current annotation target green before refactor**
 
-The RED build already produced every old executable before failing the new target. Run:
+The RED build already produced old executables before failing new target:
 
 ```bash
 ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
@@ -740,29 +778,25 @@ ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
 
 Expected: pass.
 
-- [ ] **Step 2: Move classification/materialization helpers without behavior changes**
+- [ ] **Step 2: Move classification/materialization helpers without behavior change**
 
-Create `src/pdf_annotation_common.h/.c`. Move the existing private logic for:
+Create shared module and move:
 
 ```text
-dictionary key presence lookup
-Subtype explicit mapping
+dictionary key-presence lookup
+Subtype mapping
 Link/Popup/Widget filtering
 UNKNOWN mapping
 strict four-finite-number Rect validation
 strict uint32 /F validation
-strict optional PDF-string /Contents validation + pdf_to_text_string decoding
+strict optional PDF-string /Contents validation and pdf_to_text_string decode
 ```
 
-`read_view()` receives a caller-computed `page_ctm`; it must not recompute page transform for each annotation. It zero-initializes all output fields and maps normalized PDF Rect to normalized Fitz bounds with `fz_transform_rect(raw, page_ctm)`.
+`read_view()` receives caller-computed `page_ctm`, zero-initializes output, and maps normalized PDF Rect to normalized Fitz bounds with `fz_transform_rect(raw, page_ctm)`. Borrowed Contents is copied immediately by callers.
 
-The returned Contents pointer is private/borrowed and must be copied before leaving the current MuPDF access scope.
+- [ ] **Step 3: Rewrite immutable enumeration to consume shared helpers**
 
-- [ ] **Step 3: Rewrite immutable enumeration to use shared helpers**
-
-First pass continues raw `/Annots` traversal and calls only `classify()`.
-
-Second pass computes `pdf_page_transform()` once, then:
+First pass remains raw `/Annots` + classify. Second pass computes page transform once:
 
 ```c
 extractpdf_pdf_annotation_view view;
@@ -784,9 +818,9 @@ if (view.has_contents) {
 }
 ```
 
-Delete the duplicate static classifier/Rect/F/Contents code from `src/pdf_annotations.c`.
+Delete duplicate private classifier/Rect/F/Contents code from `src/pdf_annotations.c`.
 
-- [ ] **Step 4: Build every old target explicitly while mutation stays compile-RED**
+- [ ] **Step 4: Build old targets explicitly while mutation remains compile-RED**
 
 ```bash
 cmake --build build --parallel 2 --target \
@@ -811,7 +845,7 @@ cmake --build build --parallel 2 --target \
 ctest --test-dir build -E '^extractpdf\.pdf_annotation_mutation$' --output-on-failure
 ```
 
-Expected: 18/18 old CTests pass. Do not run a full default build and misclassify the still-intentional mutation compile RED as a refactor regression.
+Expected: 18/18 old CTests pass. Do not misclassify intentional mutation compile RED as refactor failure.
 
 - [ ] **Step 5: Commit**
 
@@ -821,11 +855,11 @@ git add src/pdf_annotation_common.h src/pdf_annotation_common.c \
 git commit -m "refactor: share PDF annotation semantics"
 ```
 
-Reviewer rejects this task if any old annotation behavior changes or editor-specific state enters the common module.
+Reviewer rejects if old annotation behavior changes or editor state enters common module.
 
 ---
 
-### Task 3: Add the ABI shell and isolated editor lifecycle
+### Task 3: Add ABI shell and isolated editor lifecycle
 
 **Files:**
 - Modify: `include/extractpdf/extractpdf.h`
@@ -838,12 +872,12 @@ Reviewer rejects this task if any old annotation behavior changes or editor-spec
 - Modify: `CMakeLists.txt`
 
 **Interfaces:**
-- Consumes: `extractpdf_serialize_pdf()`, private `extractpdf_output` bytes, MuPDF PDF document/stream/javascript/journal/signature APIs.
-- Produces: complete linkable public Mutation V1 ABI; real begin/snapshot/drop; annotation calls initially provide exact reset/validation shells and otherwise `UNSUPPORTED` until Tasks 4-6.
+- Consumes: `extractpdf_serialize_pdf()`, private output bytes, MuPDF PDF stream/JS/journal/signature APIs.
+- Produces: complete linkable Mutation V1 ABI; real begin/snapshot/drop; annotation functions exact reset/validation shells until Tasks 4-6.
 
 - [ ] **Step 1: Add exact public ABI**
 
-Add to `include/extractpdf/extractpdf.h`:
+Add:
 
 ```c
 typedef struct extractpdf_pdf_edit extractpdf_pdf_edit;
@@ -877,13 +911,13 @@ typedef struct extractpdf_annotation_update {
 } extractpdf_annotation_update;
 ```
 
-Append status value without renumbering old values:
+Append:
 
 ```c
 EXTRACTPDF_ERROR_STATE = 8
 ```
 
-Add exactly these public functions:
+Add exactly:
 
 ```c
 EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_begin(
@@ -908,8 +942,6 @@ EXTRACTPDF_API void extractpdf_drop_pdf_edit(extractpdf_pdf_edit *);
 ```
 
 - [ ] **Step 2: Add stable STATE string**
-
-In `src/status.c`:
 
 ```c
 case EXTRACTPDF_ERROR_STATE:
@@ -958,23 +990,23 @@ struct extractpdf_pdf_edit {
 #endif
 ```
 
-The test header and private enum intentionally share numeric values but not a header dependency from `src/` to `tests/`.
+Test header and private enum share numeric values but no source-to-tests include dependency.
 
 - [ ] **Step 4: Implement signed-field scan without widget/event execution**
 
-In `src/pdf_edit.c`, walk `Root/AcroForm/Fields` using `pdf_walk_tree()` and inherited `/FT`. For a `/Sig` field call `pdf_signature_is_signed(ctx, document, field)`. A found signed field is enough to reject the source. Do not load widgets, enable JS, or dispatch events for this scan.
+Walk `Root/AcroForm/Fields` via `pdf_walk_tree()` with inherited `/FT`. For `/Sig`, call `pdf_signature_is_signed(ctx, document, field)`. A signed field rejects source. Do not load widgets, enable JS, or dispatch events.
 
-- [ ] **Step 5: Implement atomic `extractpdf_pdf_edit_begin()`**
+- [ ] **Step 5: Implement atomic begin**
 
-Required order:
+Order:
 
 ```text
 reset *out_edit
 validate source internals
 pdf_document_from_fz_document -> NULL => UNSUPPORTED
 raw trailer /Encrypt present => UNSUPPORTED
-signed-field scan => signed => UNSUPPORTED
-extractpdf_serialize_pdf(source ctx/pdf) -> seed_output
+signed-field scan -> signed => UNSUPPORTED
+extractpdf_serialize_pdf(source ctx/pdf) -> deterministic seed_output
 allocate edit
 new independent fz_context + discard callbacks
 fz_open_memory(seed_output bytes)
@@ -985,9 +1017,9 @@ create nonzero session_cookie
 publish edit
 ```
 
-Keep `seed_output` alive for the whole editor lifetime because the private document's input stream may reference its memory.
+Keep `seed_output` alive for editor lifetime because private document input stream may reference its memory.
 
-Use a private 64-bit mixer:
+Use:
 
 ```c
 static uint64_t mix64(uint64_t x)
@@ -1001,15 +1033,17 @@ static uint64_t mix64(uint64_t x)
 }
 ```
 
-Build the nonzero session discriminator from editor/context addresses, `time(NULL)`, `clock()`, and eight bytes from editor-local `fz_memrnd()`. This is an opaque session discriminator, not a cryptographic authentication boundary; no mutable global counter/state is introduced.
+Build nonzero session discriminator from edit/context addresses, `time(NULL)`, `clock()`, and eight bytes from editor-local `fz_memrnd()`. It is an opaque session discriminator, not a cryptographic authentication boundary; no mutable global counter/state.
 
-Any exception tears down all partial state and maps through `extractpdf_status_from_mupdf()`.
+Any exception tears down partial state and maps through `extractpdf_status_from_mupdf()`.
 
-- [ ] **Step 6: Implement non-consuming snapshot with MuPDF's snapshot writer**
+- [ ] **Step 6: Implement non-consuming snapshot with `pdf_write_snapshot()`**
 
-Do **not** call the existing full-finalizing `extractpdf_serialize_pdf()` on the live edit document. MuPDF 1.28.2 provides `pdf_write_snapshot()`, specifically documented to avoid finalizing the in-memory incremental xref.
+Do not call full-finalizing `extractpdf_serialize_pdf()` on live editor. MuPDF 1.28.2 `pdf_write_snapshot()` is specifically the non-finalizing writer for the in-memory incremental xref.
 
-In `src/pdf_edit.c`, implement a private buffer materializer:
+In `src/pdf_edit.c`, create a private buffer/output, call `pdf_write_snapshot()`, close output, retrieve buffer storage, allocate `extractpdf_output`, deep-copy bytes, then publish only after complete success. The helper must drop buffer/output on every exception path and map MuPDF errors.
+
+Required skeleton:
 
 ```c
 static extractpdf_status snapshot_pdf(
@@ -1074,17 +1108,15 @@ static extractpdf_status snapshot_pdf(
 }
 ```
 
-`extractpdf_pdf_edit_snapshot()` resets output, validates edit, calls this helper, then under `EXTRACTPDF_TESTING` consumes `SNAPSHOT_BEFORE_PUBLISH` by dropping the just-created result and returning `EXTRACTPDF_ERROR_MUPDF`. Otherwise publish result.
+`extractpdf_pdf_edit_snapshot()` resets output, validates editor, calls helper, then under test build consumes `SNAPSHOT_BEFORE_PUBLISH` by dropping result and returning `EXTRACTPDF_ERROR_MUPDF`. Same-state byte identity RED is mandatory acceptance proof; never weaken it.
 
-The same-state byte-identity RED test is the acceptance proof that the pinned snapshot writer is deterministic for this editor model; do not weaken that assertion.
+- [ ] **Step 7: Implement drop and annotation API validation shells**
 
-- [ ] **Step 7: Implement drop and exact annotation API shells**
+`extractpdf_drop_pdf_edit()` drops kept registry objects, registry, private PDF document, context, then seed output; NULL no-op. Document must be dropped before context/seed bytes.
 
-`extractpdf_drop_pdf_edit()` drops every kept registry object, registry allocation, private PDF document, private context, and finally `seed_output`; NULL is no-op. Drop document before context and seed bytes only after document no longer references its input stream.
+Define annotation functions in `src/pdf_edit_annotations.c` so test binary links. At this task they implement exact reset/pointer/minimum-`struct_size` validation and otherwise return `UNSUPPORTED` for a valid editor until later task.
 
-Define all annotation functions in `src/pdf_edit_annotations.c` so the test executable links. At this task they must implement exact output reset/pointer/`struct_size` validation and otherwise return `UNSUPPORTED` for a valid editor until the corresponding later task.
-
-- [ ] **Step 8: Add per-editor test fault hook**
+- [ ] **Step 8: Add per-editor test hook**
 
 In `tests/CMakeLists.txt`:
 
@@ -1114,11 +1146,11 @@ void extractpdf_test_pdf_edit_set_fault(
 }
 ```
 
-Production sources compare `edit->test_fault` only against the private `EXTRACTPDF_PDF_EDIT_TEST_FAULT_*` constants, never identifiers from `tests/pdf_edit_test_api.h`.
+Production source compares only private `EXTRACTPDF_PDF_EDIT_TEST_FAULT_*` constants.
 
-- [ ] **Step 9: Register production sources and run lifecycle groups**
+- [ ] **Step 9: Register sources/run lifecycle groups**
 
-Add to root `add_library(extractpdf ...)`:
+Add root sources:
 
 ```cmake
 src/pdf_annotation_common.c
@@ -1140,7 +1172,7 @@ cmake --build build --parallel 2
 ./build/tests/extractpdf_test_pdf_annotation_mutation begin
 ```
 
-Expected: `arguments` and `begin` pass. Discovery/CRUD groups remain behavioral RED because their shells return `UNSUPPORTED`.
+Expected: arguments and begin pass. Discovery/CRUD groups remain behavioral RED.
 
 - [ ] **Step 10: Commit**
 
@@ -1153,7 +1185,7 @@ git commit -m "feat: add isolated PDF editor lifecycle"
 
 ---
 
-### Task 4: Implement discovery, canonical refs, and live getters
+### Task 4: Implement discovery, canonical refs, live getters
 
 **Files:**
 - Modify: `src/pdf_edit_internal.h`
@@ -1161,10 +1193,10 @@ git commit -m "feat: add isolated PDF editor lifecycle"
 - Test: `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: shared annotation classifier/view and private editor PDF.
-- Produces: real count/ref_at/get_info/contents plus canonical refs that survive index shifts.
+- Consumes: shared classifier/view + private editor PDF.
+- Produces: real count/ref_at/get_info/contents and canonical refs surviving index shifts.
 
-- [ ] **Step 1: Run focused failing discovery group**
+- [ ] **Step 1: Run focused failing discovery**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation discovery
@@ -1172,9 +1204,7 @@ git commit -m "feat: add isolated PDF editor lifecycle"
 
 Expected: fail on current `UNSUPPORTED` shells.
 
-- [ ] **Step 2: Add private identity and registry-capacity helpers**
-
-Compare private annotation identity exactly:
+- [ ] **Step 2: Add private identity/registry-capacity helpers**
 
 ```c
 static int same_pdf_identity(fz_context *ctx, pdf_obj *a, pdf_obj *b)
@@ -1189,35 +1219,31 @@ static int same_pdf_identity(fz_context *ctx, pdf_obj *a, pdf_obj *b)
 }
 ```
 
-Never compare dictionary contents. `reserve_entries()` overflow-checks allocation and runs before an operation that cannot tolerate a later allocation failure.
+Never compare dictionary contents. `reserve_entries()` overflow-checks and allocates before operations that cannot tolerate later allocation failure.
 
-- [ ] **Step 3: Define canonical token encoding and validation**
+- [ ] **Step 3: Define canonical token encoding/validation**
 
-Never recycle a tombstoned slot. Repeated acquisition of a live object returns its existing slot/token.
-
-Concrete token layout:
+Never recycle tombstone slot. Repeated acquisition of live object returns existing token.
 
 ```text
-opaque[0] = edit->session_cookie
-opaque[1] = (uint64_t(entry->tag) << 32) | uint64_t(slot + 1)
+opaque[0] = session_cookie
+opaque[1] = (uint64_t(tag) << 32) | uint64_t(slot + 1)
 ```
 
-Maximum slots: `UINT32_MAX - 1`; exceeding it is `NOMEM`.
+Maximum slots `UINT32_MAX - 1`; beyond -> `NOMEM`. Derive nonzero `tag` from `mix64(session_cookie ^ (slot + 1))`.
 
-Derive `entry->tag` deterministically from `mix64(edit->session_cookie ^ (slot + 1))`, force zero to `1`; no second random/global state is required.
-
-Resolution order:
+Resolution:
 
 ```text
-NULL edit/ref                        ARGUMENT
-opaque[0] != session_cookie          ARGUMENT
-encoded slot 0/out of range          ARGUMENT
-tag mismatch                         ARGUMENT
-matching slot with live==0           STATE
-matching live entry                  OK
+NULL edit/ref -> ARGUMENT
+wrong cookie -> ARGUMENT
+zero/out-of-range slot -> ARGUMENT
+tag mismatch -> ARGUMENT
+matching tombstone -> STATE
+matching live -> OK
 ```
 
-- [ ] **Step 4: Scan and validate the entire requested page before publication**
+- [ ] **Step 4: Scan/validate whole page before publication**
 
 Implement:
 
@@ -1234,31 +1260,29 @@ static extractpdf_status scan_page(
 Sequence:
 
 ```text
-validate page index with pdf_count_pages
+validate page against pdf_count_pages
 pdf_load_page
 pdf_page_transform once
-raw page->obj /Annots walk
-non-dict skip
-shared classify: Link/Popup/Widget skip; other dict survives
-shared read_view for EVERY survivor
+raw page->obj /Annots
+skip non-dict
+shared classify filters Link/Popup/Widget
+shared read_view validates EVERY survivor
 only after whole scan succeeds keep wanted object
 release page
 publish count/object
 ```
 
-A malformed late survivor returns `FORMAT`; it publishes no new object/ref from the prefix.
+Malformed later survivor -> `FORMAT`, no prefix object/ref publication.
 
 - [ ] **Step 5: Implement count/ref_at**
 
-`count()` resets output and publishes the scanned count only on complete success.
+`count()` resets/publishes only complete scan count.
 
-`ref_at()` zeros output, scans/validates the complete page, checks `index < count`, then either finds the existing canonical registry entry or appends one kept private `pdf_obj *` and publishes its token.
+`ref_at()` zeros output, scans full page, validates `index < count`, canonical-registers kept object, publishes token.
 
-- [ ] **Step 6: Resolve a ref to a live `pdf_page` + borrowed `pdf_annot`**
+- [ ] **Step 6: Resolve ref while page stays alive**
 
-Do not return a `pdf_annot *` after its page is dropped because the annotation borrows its page pointer.
-
-Private resolver shape:
+Do not retain `pdf_annot *` after its page is dropped.
 
 ```c
 static extractpdf_status resolve_live_annot(
@@ -1268,13 +1292,13 @@ static extractpdf_status resolve_live_annot(
     pdf_annot **out_annot);
 ```
 
-It loads `entry->page_index`, iterates `pdf_first_annot()/pdf_next_annot()`, compares `pdf_annot_obj()` to the kept registry object, and returns a borrowed annot while `*out_page` remains alive. Caller drops the page after all work. If the registry says live but object is no longer present, return `STATE`.
+Load entry page, iterate `pdf_first_annot()/pdf_next_annot()`, compare `pdf_annot_obj()` to kept registry object, return borrowed annot while output page remains live. Missing live object -> `STATE`.
 
 - [ ] **Step 7: Implement live getters**
 
-`get_info()` validates minimum existing `extractpdf_annotation_info` size, preserves `struct_size`, resets known fields, resolves page/annot, computes one page CTM, calls shared `read_view()`, and copies type/bounds/flags.
+`get_info()` validates minimum existing info size, preserves `struct_size`, resets known fields, resolves page/annot, computes page CTM, calls shared view, copies type/bounds/flags.
 
-`contents()` independently resets non-NULL outputs, requires both outputs, resolves/read_view, and returns an allocated copy:
+`contents()` independently resets outputs, requires both, resolves/view, and copies:
 
 ```c
 if (!view.has_contents)
@@ -1289,7 +1313,7 @@ memcpy(copy, view.contents_utf8, view.contents_size + 1);
 *out_size = view.contents_size;
 ```
 
-- [ ] **Step 8: Run discovery + immutable regression gates**
+- [ ] **Step 8: Run discovery + old annotation regression**
 
 ```bash
 cmake --build build --parallel 2
@@ -1297,7 +1321,7 @@ cmake --build build --parallel 2
 ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
 ```
 
-Expected: both pass.
+Expected both pass.
 
 - [ ] **Step 9: Commit**
 
@@ -1308,43 +1332,43 @@ git commit -m "feat: add annotation edit refs and discovery"
 
 ---
 
-### Task 5: Implement safe Rect-based annotation creation
+### Task 5: Implement safe Rect-based create
 
 **Files:**
 - Modify: `src/pdf_edit_annotations.c`
 - Test: `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: editor page loading, registry reserve/publish, MuPDF journal/create/setter APIs.
-- Produces: atomic TEXT/FREE_TEXT/SQUARE/CIRCLE create with immediate canonical live ref.
+- Consumes: page loading, registry reserve/publish, MuPDF journal/create/setters.
+- Produces: atomic TEXT/FREE_TEXT/SQUARE/CIRCLE create + canonical live ref.
 
-- [ ] **Step 1: Run focused failing create group**
+- [ ] **Step 1: Run focused failing create**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation create
 ```
 
-Expected: fail on create `UNSUPPORTED` shell.
+Expected fail on create shell.
 
 - [ ] **Step 2: Implement counted UTF-8 validation/copy**
 
-Canonical accepted byte forms:
+Accepted byte forms:
 
 ```text
-ASCII: 01..7F
-2-byte: C2..DF 80..BF
-3-byte: E0 A0..BF 80..BF
-        E1..EC 80..BF 80..BF
-        ED 80..9F 80..BF
-        EE..EF 80..BF 80..BF
-4-byte: F0 90..BF 80..BF 80..BF
-        F1..F3 80..BF 80..BF 80..BF
-        F4 80..8F 80..BF 80..BF
+ASCII 01..7F
+2-byte C2..DF 80..BF
+3-byte E0 A0..BF 80..BF
+       E1..EC 80..BF 80..BF
+       ED 80..9F 80..BF
+       EE..EF 80..BF 80..BF
+4-byte F0 90..BF 80..BF 80..BF
+       F1..F3 80..BF 80..BF 80..BF
+       F4 80..8F 80..BF 80..BF
 ```
 
-Reject byte 00 anywhere in a present counted range, overlong sequences, surrogates, >U+10FFFF, and truncated/invalid continuations. For present data, overflow-check `size + 1`, allocate, copy exactly `size`, append NUL. NULL/0 is the absent marker and allocates nothing.
+Reject byte 00 in present range, overlong, surrogate, >U+10FFFF, truncated/invalid continuation. Present data: overflow-check `size+1`, allocate, exact copy, append NUL. NULL/0 is absent marker.
 
-- [ ] **Step 3: Validate create request before journal mutation**
+- [ ] **Step 3: Validate create before journal mutation**
 
 Minimum size:
 
@@ -1353,9 +1377,9 @@ offsetof(extractpdf_annotation_create_options, contents_size) +
     sizeof(options->contents_size)
 ```
 
-Validate page index, supported type, finite ordered bounds, and Contents tuple. Allow zero-width/zero-height rectangles.
+Validate page, supported type, finite ordered bounds, Contents tuple. Zero-width/height allowed.
 
-Map only:
+Only map:
 
 ```c
 TEXT      -> PDF_ANNOT_TEXT
@@ -1364,9 +1388,9 @@ SQUARE    -> PDF_ANNOT_SQUARE
 CIRCLE    -> PDF_ANNOT_CIRCLE
 ```
 
-All other types are `UNSUPPORTED`.
+Everything else -> `UNSUPPORTED`.
 
-- [ ] **Step 4: Implement full-uint32 flag writer**
+- [ ] **Step 4: Implement full-u32 flags**
 
 ```c
 static void set_annot_flags_u32(
@@ -1384,9 +1408,9 @@ static void set_annot_flags_u32(
 }
 ```
 
-This mirrors the low-range setter's dictionary result without signed narrowing. The enclosing public operation and later `pdf_update_annot()` provide the same mutation/appearance boundary.
+No signed narrowing. Enclosing journal operation + later `pdf_update_annot()` define the public atomic/appearance boundary.
 
-- [ ] **Step 5: Implement create inside one outer journal operation**
+- [ ] **Step 5: Implement create in one outer journal operation**
 
 Reserve registry capacity before `pdf_begin_operation()`.
 
@@ -1394,27 +1418,25 @@ Reserve registry capacity before `pdf_begin_operation()`.
 begin outer operation
 pdf_create_annot
 set Rect
-set full-u32 flags
+set u32 flags
 set Contents only when present
 pdf_update_annot
-optional deterministic test fault before outer end
-pdf_end_operation
-fill pre-reserved registry slot from pdf_annot_obj
+optional test fault
+end outer operation
+fill pre-reserved registry entry
 publish token
 ```
 
-Under `EXTRACTPDF_TESTING`, `AFTER_CREATE_MUTATION` clears itself and throws `FZ_ERROR_GENERIC` before `pdf_end_operation()`.
+`AFTER_CREATE_MUTATION` clears itself and throws before outer end. Exception -> abandon, drop temporary resources, no registry count increment, output ref stays zero.
 
-On exception: `pdf_abandon_operation()`, drop owned annot/page/temp Contents, leave output ref zero, and do not increment registry count.
-
-- [ ] **Step 6: Run create group and create-rollback assertions**
+- [ ] **Step 6: Run create + create rollback**
 
 ```bash
 cmake --build build --parallel 2
 ./build/tests/extractpdf_test_pdf_annotation_mutation create
 ```
 
-Expected: all four create types pass, Highlight/UNKNOWN create are `UNSUPPORTED`, injected create failure leaves count unchanged and output ref zero.
+Expected four supported types pass; Highlight/UNKNOWN unsupported; injected create failure preserves count + zero ref.
 
 - [ ] **Step 7: Commit**
 
@@ -1425,15 +1447,15 @@ git commit -m "feat: create Rect-based PDF annotations"
 
 ---
 
-### Task 6: Implement partial update, delete, Contents ownership, and rollback
+### Task 6: Implement partial update/delete/Contents ownership/rollback
 
 **Files:**
 - Modify: `src/pdf_edit_annotations.c`
 - Test: `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: canonical refs, UTF-8 helper, full-u32 flags helper, journal/setter/delete APIs, per-editor fault.
-- Produces: atomic partial update/delete, tombstones, exact Contents presence semantics, full-u32 round-trip.
+- Consumes: canonical refs, UTF-8 helper, u32 flags, journal/setter/delete, per-editor fault.
+- Produces: atomic update/delete, tombstones, exact Contents presence, full-u32 round-trip.
 
 - [ ] **Step 1: Run focused failing groups**
 
@@ -1442,62 +1464,52 @@ git commit -m "feat: create Rect-based PDF annotations"
 ./build/tests/extractpdf_test_pdf_annotation_mutation contents-flags
 ```
 
-Expected: fail on current update/delete shells.
+- [ ] **Step 2: Validate whole update before mutation**
 
-- [ ] **Step 2: Validate entire update request before mutation**
-
-Minimum size is through `contents_size`. Resolve ref **before** zero-field no-op handling.
+Minimum size through `contents_size`. Resolve ref before zero-mask no-op.
 
 ```c
 const uint32_t known =
     EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
     EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
     EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
-
 if (update->fields & ~known)
     return EXTRACTPDF_ERROR_ARGUMENT;
 if (update->fields == 0)
     return EXTRACTPDF_OK;
 ```
 
-Then:
+Then nonzero UNKNOWN -> unsupported; unsupported BOUNDS type -> unsupported; prevalidate requested bounds/Contents and allocate temp text before operation.
 
-```text
-UNKNOWN + nonzero fields -> UNSUPPORTED
-BOUNDS on non Text/FreeText/Square/Circle -> UNSUPPORTED
-requested bounds -> validate finite/ordered
-requested Contents -> validate tuple/UTF-8 and allocate temp C string before operation
-```
+- [ ] **Step 3: Preserve absent vs empty Contents**
 
-- [ ] **Step 3: Preserve absent versus present-empty Contents**
+Present string -> `pdf_set_annot_contents()`.
 
-Present string uses `pdf_set_annot_contents()`.
-
-Removal uses:
+Removal:
 
 ```c
 pdf_dict_del(ctx, pdf_annot_obj(ctx, annot), PDF_NAME(Contents));
 pdf_annot_request_resynthesis(ctx, annot);
 ```
 
-Do not turn removal into `pdf_set_annot_contents(annot, "")`.
+Do not encode removal as empty string.
 
-- [ ] **Step 4: Apply fixed-order update atomically**
+- [ ] **Step 4: Apply fixed-order atomic update**
 
-Order: BOUNDS -> FLAGS -> CONTENTS. After each requested field increments `applied_fields`; when `AFTER_FIRST_UPDATE_FIELD` is armed and `applied_fields == 1`, clear it and throw before the next field.
+Order BOUNDS -> FLAGS -> CONTENTS. Increment `applied_fields` after each requested field. Test fault after first field clears/throws before second.
 
-After all fields:
+After fields:
 
 ```c
 pdf_update_annot(ctx, annot);
 pdf_end_operation(ctx, edit->document);
 ```
 
-Any exception abandons the outer operation and leaves registry state untouched.
+Exception -> abandon; registry unchanged.
 
-- [ ] **Step 5: Implement delete and tombstone only after successful PDF delete**
+- [ ] **Step 5: Implement delete/tombstone after success only**
 
-Resolve the live ref to page/annot. UNKNOWN is `UNSUPPORTED`; any recognized ordinary annotation is deletable.
+Resolve live ref. UNKNOWN -> unsupported; recognized ordinary type deletable.
 
 ```c
 pdf_begin_operation(ctx, edit->document, "ExtractPDF delete annotation");
@@ -1506,9 +1518,9 @@ pdf_end_operation(ctx, edit->document);
 entry->live = 0;
 ```
 
-On exception abandon and keep `entry->live == 1`. Never recycle that slot. Associated Popup removal performed by MuPDF is accepted internal consistency behavior.
+Exception -> abandon + keep live. Never recycle slot.
 
-- [ ] **Step 6: Run update/delete/Contents/full-u32 tests**
+- [ ] **Step 6: Run update/delete/Contents/u32 tests**
 
 ```bash
 cmake --build build --parallel 2
@@ -1519,18 +1531,18 @@ cmake --build build --parallel 2
 Expected:
 
 ```text
-failed multi-field update restores all fields
-Text tombstone returns STATE from get/info/contents/update/delete
-Square ref remains stable after Text deletion shifts index
-Highlight bounds UNSUPPORTED, generic flags/Contents OK
+multi-field fault restores every field
+Text tombstone STATE for get/info/contents/update/delete
+Square ref stable after earlier delete shifts index
+Highlight bounds unsupported; flags/Contents OK
 live UNKNOWN zero-mask OK
 wrong-session zero-mask ARGUMENT
 tombstone zero-mask STATE
-raw 2147483649 and UINT32_MAX round-trip exactly
-counted non-NUL-terminated input works
-owned getter string survives later edit mutation
-absent vs present-empty preserved
-invalid UTF-8 / embedded NUL / NULL+nonzero rejected before mutation
+2147483649 and UINT32_MAX exact round-trip
+counted non-NUL input works
+owned getter survives later mutation
+absent/present-empty distinct
+invalid UTF-8/NUL/NULL+nonzero rejected before mutation
 ```
 
 - [ ] **Step 7: Commit**
@@ -1542,14 +1554,14 @@ git commit -m "feat: atomically update and delete annotations"
 
 ---
 
-### Task 7: Prove snapshot/source isolation and JavaScript non-execution through public outputs
+### Task 7: Prove source/snapshot/JS isolation through public outputs
 
 **Files:**
 - Modify only if a real defect is exposed: `src/pdf_edit.c`, `src/pdf_edit_annotations.c`, `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: completed lifecycle/discovery/CRUD implementation.
-- Produces: final semantic proof before all-suite GREEN.
+- Consumes completed editor/discovery/CRUD.
+- Produces final semantic proof before all-suite GREEN.
 
 - [ ] **Step 1: Run snapshot group unchanged**
 
@@ -1557,80 +1569,78 @@ git commit -m "feat: atomically update and delete annotations"
 ./build/tests/extractpdf_test_pdf_annotation_mutation snapshot
 ```
 
-Expected: pass. Failure is a product defect; do not weaken same-state byte identity, source isolation, output independence, or non-consuming assertions.
+Failure is product defect; do not weaken same-state byte identity, source isolation, output independence, or non-consuming assertions.
 
-- [ ] **Step 2: Require retained source snapshot to stay original after source close + editor mutation**
+- [ ] **Step 2: Verify retained source snapshot after source close + editor mutation**
 
-Verify through retained immutable snapshot:
+Require:
 
 ```text
-Text type
-Fitz bounds 10,160,30,180
+Text bounds 10,160,30,180
 flags 2147483649
 Contents text-a
 ```
 
-No source handle remains open solely for this assertion.
+No source handle remains open solely for test.
 
-- [ ] **Step 3: Reparse snapshots A and B only through public immutable APIs**
+- [ ] **Step 3: Reparse snapshots A/B only through public APIs**
 
-Required:
+Require:
 
 ```text
-A bytes == repeat bytes with no mutation
-A bytes remain unchanged after mutation
+A bytes == repeat with no mutation
+A unchanged after later mutation
 B contains later mutation
 A reparse -> text-a
 B reparse -> snapshot-b
-existing Text ref stays valid after snapshots
-outputs remain valid after editor drop
+Text ref valid after snapshots
+outputs valid after editor drop
 ```
 
-- [ ] **Step 4: Prove failed snapshot does not consume/corrupt editor**
+- [ ] **Step 4: Prove failed snapshot leaves editor fully usable**
 
-Arm `SNAPSHOT_BEFORE_PUBLISH`, require non-OK + NULL output, then update Contents to `after-failed-snapshot`, read it through the same ref, snapshot again, reparse, and require the new value. This proves post-failure mutation and publication both remain usable.
+Arm fault, require failure+NULL, then update Contents to `after-failed-snapshot`, read through same ref, snapshot again, reparse and require new value.
 
-- [ ] **Step 5: Run JavaScript group after real appearance path exists**
+- [ ] **Step 5: Run JS group after real appearance update exists**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation javascript
 ```
 
-The group performs a Text Contents update, snapshots, reparses metadata, and requires Title `SAFE`. Any `EXECUTED` result is a blocker.
+Group updates Text, snapshots, reparses metadata, requires Title `SAFE`. `EXECUTED` is blocker.
 
-- [ ] **Step 6: Run full mutation executable**
+- [ ] **Step 6: Run entire mutation executable**
 
 ```bash
 cmake --build build --parallel 2
 ./build/tests/extractpdf_test_pdf_annotation_mutation
 ```
 
-Expected: all groups pass.
+Expected all groups pass.
 
 - [ ] **Step 7: Commit only real corrections**
 
-If Step 1-6 required changes:
+If files changed:
 
 ```bash
 git add src/pdf_edit.c src/pdf_edit_annotations.c tests/test_pdf_annotation_mutation.c
 git commit -m "test: lock PDF annotation editor isolation"
 ```
 
-If no files changed, create no empty commit.
+No empty commit if no changes.
 
 ---
 
-### Task 8: Reach full GREEN and exact-head cross-platform proof
+### Task 8: Reach full GREEN/exact-head cross-platform proof
 
 **Files:**
-- No planned feature expansion.
-- Modify only approved-scope files if a real compiler/portability defect is found.
+- No planned expansion; modify only approved scope for real portability/compiler defect.
 
 **Interfaces:**
-- Consumes: Tasks 1-7.
-- Produces: merge-ready exact-head evidence; does not merge.
+- Consumes Tasks 1-7.
+- Produces merge-ready exact-head evidence; does not merge.
 
-- [ ] **Step 1: Fresh Linux static build + all CTests**
+- [ ] **Step 1: Fresh Linux static + all CTests**
 
 ```bash
 rm -rf build
@@ -1643,7 +1653,7 @@ cmake --build build --parallel 2
 ctest --test-dir build --output-on-failure
 ```
 
-Expected: **19/19 CTests pass**.
+Expected **19/19**.
 
 - [ ] **Step 2: Fresh Linux ASan/UBSan + all CTests**
 
@@ -1660,11 +1670,11 @@ cmake --build build-asan --parallel 2
 ctest --test-dir build-asan --output-on-failure
 ```
 
-Expected: 19/19, no sanitizer issue in editor/ref/string/registry code.
+Expected 19/19, no sanitizer issue.
 
 - [ ] **Step 3: Exact-head scope review**
 
-Allowed production paths:
+Allowed production:
 
 ```text
 include/extractpdf/extractpdf.h
@@ -1678,7 +1688,7 @@ src/pdf_edit_annotations.c
 CMakeLists.txt
 ```
 
-Allowed test/docs paths:
+Allowed tests/docs:
 
 ```text
 docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md
@@ -1693,73 +1703,66 @@ tests/fixtures/annotation-mutation-unsigned-signature.pdf
 tests/fixtures/annotation-mutation-js.pdf
 ```
 
-No unrelated page/render/text/image/link/outline/metadata/composition/output-file change is acceptable.
+No unrelated page/render/text/image/link/outline/metadata/composition/output-file change.
 
-- [ ] **Step 4: Push final GREEN and capture exact-head Linux PR CI**
+- [ ] **Step 4: Push final GREEN/capture Linux PR CI**
 
-Normal PR synchronize on the final exact SHA must pass:
-
-```text
-Linux strict static build + 19/19 CTests
-Linux ASan/UBSan + 19/19 CTests
-```
-
-Update draft PR and #37 with RED SHA/workflow, first production GREEN SHA/workflow, and final exact SHA.
+Normal synchronize on final exact SHA must pass Linux static 19/19 + ASan/UBSan 19/19. Update PR/#37 with RED SHA/run, first production GREEN SHA/run, final exact SHA.
 
 - [ ] **Step 5: Trigger same-head `full-ci`**
 
-Add `full-ci` only after final SHA is fixed. Verify labeled workflow `head_sha` equals that SHA.
+Add `full-ci` only after exact SHA fixed; verify labeled run head matches exact SHA.
 
 Acceptance:
 
 ```text
-Linux static + 19/19                 success
-Linux ASan/UBSan + 19/19            success
-macOS configure/build/19/19         success
-Windows DLL configure/build/19/19   success
+Linux static 19/19 success
+Linux ASan/UBSan 19/19 success
+macOS 19/19 success
+Windows DLL 19/19 success
 ```
 
-Windows logs must show editor source compilation, `extractpdf_test_pdf_annotation_mutation.exe`, and `extractpdf.pdf_annotation_mutation` passing through the DLL build.
+Windows logs must show editor sources, mutation test executable, and mutation CTest through DLL build.
 
-- [ ] **Step 6: Final exact-head review against every locked boundary**
+- [ ] **Step 6: Final exact-head review**
 
 Review:
 
 ```text
 source immutability
-begin source-lifetime independence
+begin lifetime independence
 encrypted/signed fail-closed
 JavaScript disabled
 discovery semantic reuse + malformed atomicity
-canonical refs + wrong-session + tombstone + no slot reuse
+canonical refs + wrong-session + tombstone + no reuse
 full uint32 flags
 Contents absent/empty/counting/UTF-8/ownership
 create type matrix
 zero-field validation ordering
 update/create rollback
-appearance update before operation completion
+appearance before operation completion
 snapshot determinism/non-consumption/output independence
 no MuPDF/PDF identity in public ABI
 ```
 
-Any Critical/Important fix creates a new exact SHA and requires Linux + same-head full-ci proof again.
+Any Critical/Important fix changes exact SHA and requires Linux + same-head full-ci again.
 
 - [ ] **Step 7: Mark implementation/evidence complete, integration pending**
 
-Only after Step 1-6 pass, mark PR ready and update #37/roadmap to say implementation/evidence complete; integration pending. Do not merge in this task.
+Only after all proof passes, mark PR ready and update #37/roadmap. Do not merge.
 
 ---
 
 ### Task 9: Explicit integration gate
 
 **Files:**
-- Bookkeeping only after successful integration: PR, issue #37, roadmap #2.
+- Bookkeeping only after successful integration: PR, #37, #2.
 
 **Interfaces:**
-- Consumes: proven exact-head full-ci from Task 8.
-- Produces: integrated master proof and closes #37.
+- Consumes proven Task-8 exact-head full-ci.
+- Produces integrated master proof and closes #37.
 
-A plan executor must stop before this task until the user gives separate explicit integration authorization.
+Plan executor stops before Task 9 until user gives separate explicit integration authorization.
 
 - [ ] **Step 1: Re-fetch merge state immediately before merge**
 
@@ -1767,7 +1770,7 @@ Require:
 
 ```text
 PR open + ready
-head SHA exactly equals proven full-ci SHA
+head exactly proven SHA
 base master expected descendant
 mergeable true
 no unresolved review thread
@@ -1775,32 +1778,32 @@ no new review/comment blocker
 same-head full-ci success
 ```
 
-- [ ] **Step 2: Merge with `expected_head_sha` and merge method `merge`**
+- [ ] **Step 2: Merge with `expected_head_sha`, method `merge`**
 
-GitHub must reject if head moved.
+Head movement must reject merge.
 
-- [ ] **Step 3: Verify integrated master push workflow by merge SHA**
+- [ ] **Step 3: Verify integrated master push run by merge SHA**
 
-Do not close #37 from PR CI. Find the `push` run whose `head_sha` equals merge commit and require:
+Do not close from PR CI. Require push run:
 
 ```text
-Linux static + all CTests       success
-Linux ASan/UBSan + all CTests  success
-macOS                           success
-Windows DLL                     success
+Linux static success
+Linux ASan/UBSan success
+macOS success
+Windows DLL success
 ```
 
-Inspect Windows integrated logs to confirm mutation CTest runs.
+Inspect integrated Windows logs for mutation CTest.
 
-- [ ] **Step 4: Close bookkeeping after integrated GREEN only**
+- [ ] **Step 4: Close bookkeeping after integrated GREEN**
 
-Close #37 completed and update roadmap #2:
+Close #37 completed and update #2:
 
 ```text
 [x] Annotation mutation editor — #37 / PR #... — integrated
 ```
 
-Record final feature SHA, merge SHA, same-head full-ci workflow, and integrated-master push workflow. Leave subtype-specific geometry and Forms/widgets separate.
+Record final feature SHA, merge SHA, same-head full-ci run, integrated push run. Leave subtype geometry and Forms/widgets separate.
 
 ---
 
@@ -1819,7 +1822,7 @@ Task 5  create Text/FreeText/Square/Circle + create rollback
    ↓
 Task 6  update/delete + tombstone + full-u32 + Contents + rollback
    ↓
-Task 7  source/snapshot/JavaScript/public-output semantic proof
+Task 7  source/snapshot/JavaScript/public-output proof
    ↓
 Task 8  19/19 + sanitizers + same-SHA Linux/macOS/Windows full-ci + review
    ↓

--- a/docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
+++ b/docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
@@ -1,0 +1,1802 @@
+# ExtractPDF PDF Annotation Mutation V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an isolated PDF annotation editor that keeps `extractpdf_document` immutable, uses session-local annotation refs for atomic create/update/delete, and emits deterministic non-consuming `extractpdf_output` snapshots.
+
+**Architecture:** `extractpdf_pdf_edit_begin()` materializes a private full-PDF fork in its own MuPDF context, rejects encrypted/already-signed sources, disables JavaScript, and enables MuPDF journalling. Immutable annotation enumeration and editor discovery share one private classify/materialize implementation; editor refs map to private annotation objects through a non-recycled registry. Each CRUD call is one outer journal operation and `snapshot()` serializes the current fork into the existing immutable output abstraction without consuming the editor.
+
+**Tech Stack:** C11, CMake 3.20+, pinned MuPDF 1.28.2 through the existing vcpkg overlay, CTest, Linux ASan/UBSan, macOS, Windows DLL.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md`
+
+**Base:** integrated master `58525ce1b4b691ef53dfafc7c4e4d82753c966ba`; branch `feat/pdf-annotation-mutation`; issue #37; roadmap #2.
+
+## Global Constraints
+
+- Keep `extractpdf_document`, `extractpdf_page`, and all existing immutable snapshots read-only; no mutation API writes through those handles.
+- `extractpdf_pdf_edit_begin()` must become independent of the source lifetime after success.
+- No MuPDF type, PDF object number/generation, `/NM`, filename, or pointer becomes public mutation identity.
+- Immutable annotation indices remain snapshot-local/discovery-only and are never accepted by update/delete APIs.
+- Editor discovery must use exactly the same Link/Popup/Widget filtering, UNKNOWN mapping, order, and strict Rect/F/Contents materialization contract as Annotation Enumeration V1.
+- Public mutation bounds are finite normalized Fitz page-space rectangles. Reversed/non-finite input is `ARGUMENT`; V1 does not silently normalize input.
+- V1 create/bounds-update supports only TEXT, FREE_TEXT, SQUARE, and CIRCLE.
+- Recognized ordinary annotations may receive generic flags/Contents update and delete; UNKNOWN mutation is `UNSUPPORTED`.
+- Preserve the complete raw `uint32_t` `/F` range. Never narrow values above `INT_MAX` through MuPDF's `int` convenience setter.
+- Contents are counted UTF-8 with absent versus present-empty preserved. Present input must be valid UTF-8 and contain no embedded NUL.
+- Every create/update/delete is one atomic outer MuPDF journal operation. Any failure restores pre-call PDF and ref-registry observable state.
+- `snapshot()` is non-consuming, deterministic for unchanged editor state, leaves refs valid, and returns an independent existing `extractpdf_output`.
+- Reject every encrypted source and every source with an already-signed signature value as `UNSUPPORTED`. Unsigned signature fields remain allowed.
+- Disable JavaScript in the private editor before exposing it. Begin/CRUD/appearance update/snapshot must not execute PDF JavaScript.
+- No public undo/redo, incremental save, forms/widgets mutation, link mutation, Popup API, QuadPoints/line/vertex/Ink geometry, persistent identity, encrypted editing, or signed-PDF editing in V1.
+- Preserve reset-before-later-validation behavior for every new output pointer.
+- New option/update structs use the existing forward-compatible minimum-`struct_size` convention; larger structs are accepted.
+- Keep the current single-thread handle contract. Add no mutable process-global/TLS state.
+- RED precedes every production declaration/behavior. Final feature head requires Linux static + all CTests, Linux ASan/UBSan + all CTests, macOS, and Windows DLL proof.
+
+---
+
+## File Structure
+
+### Public/API
+
+- Modify `include/extractpdf/extractpdf.h`
+  - add opaque `extractpdf_pdf_edit`;
+  - add value `extractpdf_annotation_ref`;
+  - add update-field/create/update types;
+  - append `EXTRACTPDF_ERROR_STATE = 8`;
+  - add editor/discovery/getter/CRUD/snapshot/drop APIs.
+- Modify `src/status.c`
+  - add stable status text for `EXTRACTPDF_ERROR_STATE`.
+
+### Shared private annotation semantics
+
+- Create `src/pdf_annotation_common.h`
+  - private `extractpdf_pdf_annotation_view`;
+  - survivor classification and strict common-materialization declarations.
+- Create `src/pdf_annotation_common.c`
+  - move current subtype/filter/Rect/F/Contents logic out of `src/pdf_annotations.c` without changing behavior.
+- Modify `src/pdf_annotations.c`
+  - consume the shared helpers and retain only immutable snapshot allocation/copy/public accessors.
+
+### Editor implementation
+
+- Create `src/pdf_edit_internal.h`
+  - private editor struct, ref registry, token helpers, page/object resolution helpers, test-fault field under `EXTRACTPDF_TESTING`.
+- Create `src/pdf_edit.c`
+  - begin policy checks, private source clone/context lifecycle, signed-field scan, JavaScript disable, journal enable, snapshot, drop.
+- Create `src/pdf_edit_annotations.c`
+  - editor discovery, ref registry, getters, UTF-8 validation/copy, create/update/delete, full-uint32 flags write, appearance update, journal rollback.
+- Modify `CMakeLists.txt`
+  - compile the three new production `.c` files plus the shared annotation module.
+
+### Deterministic tests
+
+- Create `tests/test_pdf_annotation_mutation.c`
+  - one executable with named groups (`arguments`, `begin`, `discovery`, `create`, `update-delete`, `contents-flags`, `snapshot`, `javascript`) and no third-party test framework.
+- Create `tests/pdf_edit_test_api.h`
+  - private test-only fault enum/hook declaration; not installed and not included by the public header.
+- Create `tests/pdf_edit_fault_hook.c`
+  - test-only implementation compiled into `extractpdf` only when `EXTRACTPDF_BUILD_TESTS=ON`; fault state lives per editor, never globally.
+- Create checked-in deterministic fixtures:
+  - `tests/fixtures/annotation-mutation.pdf`
+  - `tests/fixtures/annotation-mutation-signed.pdf`
+  - `tests/fixtures/annotation-mutation-unsigned-signature.pdf`
+  - `tests/fixtures/annotation-mutation-js.pdf`
+- Reuse existing fixtures:
+  - `tests/fixtures/annotations-late-malformed.pdf`
+  - `tests/fixtures/encrypted-one-page.pdf` with password `user-pass`
+  - `tests/fixtures/composition-non-pdf.txt`
+- Modify `tests/CMakeLists.txt`
+  - register the new executable/CTest, fixture paths, output paths, and Windows DLL-copy list;
+  - conditionally add the private fault-hook source/definition to the library test build.
+
+No page/render/text/image/link/outline/metadata/composition behavior is refactored as part of this work.
+
+---
+
+### Task 1: Capture the strict full-surface RED
+
+**Files:**
+- Create: `tests/fixtures/annotation-mutation.pdf`
+- Create: `tests/fixtures/annotation-mutation-signed.pdf`
+- Create: `tests/fixtures/annotation-mutation-unsigned-signature.pdf`
+- Create: `tests/fixtures/annotation-mutation-js.pdf`
+- Create: `tests/pdf_edit_test_api.h`
+- Create: `tests/test_pdf_annotation_mutation.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: current public `extractpdf_document`, immutable annotation/output/metadata APIs.
+- Produces: the complete wished-for Mutation V1 contract as failing C tests. No production declaration is added in this task.
+
+- [ ] **Step 1: Generate the checked-in deterministic PDFs**
+
+Use this one-shot authoring script from the repository root. The script is **not** committed; only its PDF outputs are committed. It writes plain deterministic PDF objects and computes exact xref offsets, so runtime tests remain pure CTest and have no Python dependency.
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+OUT = Path("tests/fixtures")
+
+
+def write_pdf(path, objects, trailer_extra=""):
+    parts = [b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n"]
+    offsets = [0]
+    for number, body in enumerate(objects, 1):
+        offsets.append(sum(len(p) for p in parts))
+        parts.append(f"{number} 0 obj\n".encode("ascii"))
+        parts.append(body.encode("latin1"))
+        parts.append(b"\nendobj\n")
+    xref = sum(len(p) for p in parts)
+    parts.append(f"xref\n0 {len(objects)+1}\n".encode("ascii"))
+    parts.append(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        parts.append(f"{offset:010d} 00000 n \n".encode("ascii"))
+    parts.append(
+        (f"trailer\n<< /Size {len(objects)+1} /Root 1 0 R {trailer_extra} >>\n"
+         f"startxref\n{xref}\n%%EOF\n").encode("latin1")
+    )
+    path.write_bytes(b"".join(parts))
+
+
+write_pdf(OUT / "annotation-mutation.pdf", [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> "
+    "/Annots [5 0 R 17 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R] >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> "
+    "/Annots [13 0 R 14 0 R] >>",
+    "<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /F 2147483649 "
+    "/Contents (text-a) /Popup 9 0 R >>",
+    "<< /Type /Annot /Subtype /Link /Rect [20 20 40 40] "
+    "/A << /S /URI /URI (https://example.com/) >> >>",
+    "<< /Type /Annot /Subtype /Square /Rect [40 50 70 80] /F 4 /Contents (square-b) >>",
+    "<< /Type /Annot /Subtype /FutureThing /Rect [80 90 100 110] /F 64 /Contents (unknown-c) >>",
+    "<< /Type /Annot /Subtype /Popup /Rect [110 90 180 150] /Parent 5 0 R >>",
+    "<< /Type /Annot /Subtype /Widget /Rect [130 10 180 30] /FT /Tx /T (widget) >>",
+    "<< /Type /Annot /Subtype /Highlight /Rect [20 120 80 140] "
+    "/QuadPoints [20 140 80 140 20 120 80 120] /Contents (highlight-d) >>",
+    "<< /Type /Annot /Subtype /Ink /Rect [90 120 150 160] "
+    "/InkList [[90 120 120 140 150 160]] /Contents (ink-e) >>",
+    "<< /Type /Annot /Subtype /FreeText /Rect [10 10 80 40] "
+    "/DA (/Helv 12 Tf 0 g) /Contents (free-f) >>",
+    "<< /Type /Annot /Subtype /Circle /Rect [100 20 150 70] /Contents (circle-g) >>",
+])
+
+
+def signature_pdf(path, signed):
+    value = " /V 6 0 R" if signed else ""
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [5 0 R] >>",
+        "<< /Fields [5 0 R] /SigFlags 3 >>",
+        f"<< /Type /Annot /Subtype /Widget /FT /Sig /T (sig) /Rect [10 10 120 40] /P 3 0 R{value} >>",
+        "<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached "
+        "/ByteRange [0 0 0 0] /Contents <00> >>",
+    ]
+    write_pdf(path, objects)
+
+signature_pdf(OUT / "annotation-mutation-signed.pdf", True)
+signature_pdf(OUT / "annotation-mutation-unsigned-signature.pdf", False)
+
+write_pdf(OUT / "annotation-mutation-js.pdf", [
+    "<< /Type /Catalog /Pages 2 0 R /OpenAction 5 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [6 0 R] >>",
+    "<< /Title (SAFE) >>",
+    "<< /S /JavaScript /JS (this.title = \\\"EXECUTED\\\";) >>",
+    "<< /Type /Annot /Subtype /Text /Rect [10 10 30 30] /Contents (js-safe) >>",
+], "/Info 4 0 R")
+PY
+```
+
+Verify the four files exist and are stable across a second run:
+
+```bash
+sha256sum tests/fixtures/annotation-mutation*.pdf
+```
+
+Expected: rerunning the generator produces the same four hashes.
+
+- [ ] **Step 2: Add the private test-fault declaration without implementation**
+
+Create `tests/pdf_edit_test_api.h`:
+
+```c
+#ifndef EXTRACTPDF_PDF_EDIT_TEST_API_H
+#define EXTRACTPDF_PDF_EDIT_TEST_API_H
+
+#include <extractpdf/extractpdf.h>
+
+typedef enum extractpdf_test_pdf_edit_fault {
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE = 0,
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_FIRST_UPDATE_FIELD = 1,
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_CREATE_MUTATION = 2,
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH = 3
+} extractpdf_test_pdf_edit_fault;
+
+EXTRACTPDF_API void extractpdf_test_pdf_edit_set_fault(
+    extractpdf_pdf_edit *edit,
+    extractpdf_test_pdf_edit_fault fault);
+
+#endif
+```
+
+This is test-only surface. Its current compile failure is expected because `extractpdf_pdf_edit` is intentionally absent before RED is captured.
+
+- [ ] **Step 3: Add the full mutation test executable**
+
+Create `tests/test_pdf_annotation_mutation.c` with the existing lightweight `CHECK` style. Use an optional first CLI argument so individual groups can be run during incremental GREEN work while the umbrella CTest still runs all groups.
+
+Required helpers:
+
+```c
+#include <extractpdf/extractpdf.h>
+#include "pdf_edit_test_api.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    return (d < 0 ? -d : d) < 0.01f;
+}
+
+static void zero_ref(extractpdf_annotation_ref *ref)
+{
+    ref->opaque[0] = 0;
+    ref->opaque[1] = 0;
+}
+
+static int ref_is_zero(const extractpdf_annotation_ref *ref)
+{
+    return ref->opaque[0] == 0 && ref->opaque[1] == 0;
+}
+
+static void save_output(const extractpdf_output *out, const char *path)
+{
+    CHECK(extractpdf_output_save_file(out, path) == EXTRACTPDF_OK);
+}
+
+static void expect_snapshot_annotation(
+    const char *path,
+    size_t index,
+    extractpdf_annotation_type type,
+    const char *contents)
+{
+    extractpdf_document *doc = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_annotation_page *annots = NULL;
+    extractpdf_annotation_info info = {0};
+    const char *text = NULL;
+    size_t size = 0;
+
+    CHECK(extractpdf_open(path, NULL, &doc) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_annotations(page, &annots) == EXTRACTPDF_OK);
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_annotation_get_info(annots, index, &info) == EXTRACTPDF_OK);
+    CHECK(info.type == type);
+    CHECK(extractpdf_annotation_contents(annots, index, &text, &size) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(size == strlen(contents));
+    CHECK(memcmp(text, contents, size) == 0);
+
+    extractpdf_drop_annotation_page(annots);
+    extractpdf_drop_page(page);
+    extractpdf_close(doc);
+}
+```
+
+The RED file must contain these exact behavioral groups and assertions:
+
+```c
+static void test_arguments(void)
+{
+    int sentinel = 0;
+    extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
+    extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
+    extractpdf_output *out = (extractpdf_output *)&sentinel;
+    size_t count = 99;
+
+    CHECK(extractpdf_pdf_edit_begin(NULL, &edit) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(edit == NULL);
+    CHECK(extractpdf_pdf_edit_begin(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(NULL, 0, 0, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+
+    out = (extractpdf_output *)&sentinel;
+    CHECK(extractpdf_pdf_edit_snapshot(NULL, &out) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(out == NULL);
+    CHECK(extractpdf_pdf_edit_snapshot(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    extractpdf_drop_pdf_edit(NULL);
+
+    CHECK(strcmp(extractpdf_status_string(EXTRACTPDF_ERROR_STATE), "invalid state") == 0);
+}
+
+static void test_begin_lifetime_and_fail_closed(void)
+{
+    int sentinel = 0;
+    extractpdf_document *source = NULL;
+    extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
+    extractpdf_output *out = NULL;
+
+    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(edit != NULL);
+    extractpdf_close(source);
+    source = NULL;
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &out) == EXTRACTPDF_OK);
+    CHECK(out != NULL);
+    extractpdf_drop_output(out);
+    extractpdf_drop_pdf_edit(edit);
+
+    CHECK(extractpdf_open(ENCRYPTED_PDF, "user-pass", &source) == EXTRACTPDF_OK);
+    edit = (extractpdf_pdf_edit *)&sentinel;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(edit == NULL);
+    extractpdf_close(source);
+
+    CHECK(extractpdf_open(SIGNED_PDF, NULL, &source) == EXTRACTPDF_OK);
+    edit = (extractpdf_pdf_edit *)&sentinel;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(edit == NULL);
+    extractpdf_close(source);
+
+    CHECK(extractpdf_open(UNSIGNED_SIGNATURE_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    extractpdf_drop_pdf_edit(edit);
+    extractpdf_close(source);
+
+    CHECK(extractpdf_open(NON_PDF, NULL, &source) == EXTRACTPDF_OK);
+    edit = (extractpdf_pdf_edit *)&sentinel;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(edit == NULL);
+    extractpdf_close(source);
+}
+```
+
+Discovery/ref group:
+
+```c
+static void test_discovery_and_refs(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_pdf_edit *a = NULL;
+    extractpdf_pdf_edit *b = NULL;
+    extractpdf_annotation_ref text = {{0,0}};
+    extractpdf_annotation_ref square = {{0,0}};
+    extractpdf_annotation_ref square_again = {{0,0}};
+    extractpdf_annotation_ref wrong = {{0,0}};
+    extractpdf_annotation_info info = {0};
+    size_t count = 0;
+
+    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &a) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &b) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 6); /* Text, Square, UNKNOWN, Highlight, Ink + scalar filtering leaves 5? */
+    /* Correct the fixture expectation explicitly below: survivors are Text, Square,
+       FutureThing, Highlight, Ink = 5. */
+    CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) == EXTRACTPDF_OK);
+    CHECK(count == 5);
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 0, &text) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_again) == EXTRACTPDF_OK);
+    CHECK(memcmp(&square, &square_again, sizeof(square)) == 0);
+
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(a, &square, &info) == EXTRACTPDF_OK);
+    CHECK(info.type == EXTRACTPDF_ANNOTATION_SQUARE);
+    CHECK(info.flags == 4u);
+
+    wrong = square;
+    CHECK(extractpdf_pdf_edit_annotation_get_info(b, &wrong, &info) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_pdf_edit_annotation_count(a, -1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    zero_ref(&wrong);
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 99, &wrong) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&wrong));
+
+    extractpdf_drop_pdf_edit(b);
+    extractpdf_drop_pdf_edit(a);
+    extractpdf_close(source);
+}
+```
+
+**Important correction while authoring:** do **not** leave the temporary `count == 6` assertion shown above in the committed test. The committed code must contain only `count == 5`. This note exists to make the logical count auditable: page 0 survivors are Text, Square, FutureThing/UNKNOWN, Highlight, Ink; scalar 17, Link, Popup, Widget are filtered.
+
+Malformed-discovery atomicity must be in the same group:
+
+```c
+static void test_malformed_discovery_is_atomic(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+    extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
+    size_t count = 99;
+
+    CHECK(extractpdf_open(LATE_MALFORMED_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &count) == EXTRACTPDF_ERROR_FORMAT);
+    CHECK(count == 0);
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 0, &ref) == EXTRACTPDF_ERROR_FORMAT);
+    CHECK(ref_is_zero(&ref));
+    extractpdf_drop_pdf_edit(edit);
+    extractpdf_close(source);
+}
+```
+
+Create/update/delete group must cover all four create types and unsupported geometry. Use this common create helper:
+
+```c
+static extractpdf_annotation_ref create_rect_annot(
+    extractpdf_pdf_edit *edit,
+    int page,
+    extractpdf_annotation_type type,
+    extractpdf_rect bounds,
+    uint32_t flags,
+    const char *text,
+    size_t size)
+{
+    extractpdf_annotation_create_options options = {0};
+    extractpdf_annotation_ref ref = {{0,0}};
+    options.struct_size = sizeof(options);
+    options.type = type;
+    options.bounds = bounds;
+    options.flags = flags;
+    options.contents_utf8 = text;
+    options.contents_size = size;
+    CHECK(extractpdf_pdf_edit_annotation_create(edit, page, &options, &ref) == EXTRACTPDF_OK);
+    CHECK(!ref_is_zero(&ref));
+    return ref;
+}
+```
+
+In `test_create()` create TEXT, FREE_TEXT, SQUARE, CIRCLE with distinct rectangles/contents, then verify each through `extractpdf_pdf_edit_annotation_get_info()` and allocated `extractpdf_pdf_edit_annotation_contents()`. Also execute:
+
+```c
+options.type = EXTRACTPDF_ANNOTATION_HIGHLIGHT;
+zero_ref(&ref);
+CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &ref) == EXTRACTPDF_ERROR_UNSUPPORTED);
+CHECK(ref_is_zero(&ref));
+
+options.type = EXTRACTPDF_ANNOTATION_UNKNOWN;
+CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &ref) == EXTRACTPDF_ERROR_UNSUPPORTED);
+CHECK(ref_is_zero(&ref));
+```
+
+`test_update_delete()` must acquire Text and Square refs, delete Text, verify Text getter/update/delete/contents all return `EXTRACTPDF_ERROR_STATE`, reacquire current index 0 and prove it is the same Square ref, then update Square bounds/flags/Contents through the original ref. It must also acquire Highlight and prove `BOUNDS` update returns `UNSUPPORTED` while `FLAGS` and `CONTENTS` update succeeds. A zero-field update on a live UNKNOWN ref is `OK`; a zero-field update on a tombstone is `STATE`; a zero-field update with a ref from another editor is `ARGUMENT`.
+
+Atomic rollback tests use the private per-editor hook:
+
+```c
+extractpdf_annotation_update update = {0};
+update.struct_size = sizeof(update);
+update.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
+                EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+update.bounds = (extractpdf_rect){20, 20, 90, 90};
+update.contents_utf8 = "changed";
+update.contents_size = 7;
+
+extractpdf_test_pdf_edit_set_fault(
+    edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_FIRST_UPDATE_FIELD);
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &square, &update) != EXTRACTPDF_OK);
+/* Re-read info + contents and assert both equal the pre-call values. */
+```
+
+Create rollback:
+
+```c
+extractpdf_test_pdf_edit_set_fault(
+    edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_CREATE_MUTATION);
+zero_ref(&ref);
+CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &ref) != EXTRACTPDF_OK);
+CHECK(ref_is_zero(&ref));
+CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &after) == EXTRACTPDF_OK);
+CHECK(after == before);
+```
+
+Contents/flags group must include:
+
+```c
+/* Existing Text has /F 2147483649 = 0x80000001. */
+info.struct_size = sizeof(info);
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text, &info) == EXTRACTPDF_OK);
+CHECK(info.flags == UINT32_C(2147483649));
+
+update.struct_size = sizeof(update);
+update.fields = EXTRACTPDF_ANNOTATION_UPDATE_FLAGS;
+update.flags = UINT32_MAX;
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text, &info) == EXTRACTPDF_OK);
+CHECK(info.flags == UINT32_MAX);
+```
+
+Also test absent/present-empty/non-empty Contents, counted non-NUL-terminated input, invalid UTF-8, embedded NUL, and live getter ownership:
+
+```c
+static const char counted[3] = {'c','a','t'};
+static const char bad_utf8[2] = {(char)0xC0, (char)0xAF};
+static const char embedded_nul[3] = {'a','\0','b'};
+char *owned = NULL;
+size_t owned_size = 0;
+
+update.fields = EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+update.contents_utf8 = counted;
+update.contents_size = sizeof(counted);
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_contents(edit, &text, &owned, &owned_size) == EXTRACTPDF_OK);
+CHECK(owned_size == 3 && memcmp(owned, "cat", 3) == 0 && owned[3] == '\0');
+
+/* Mutate after the getter; the allocated old copy must remain "cat". */
+update.contents_utf8 = "dog";
+update.contents_size = 3;
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
+CHECK(memcmp(owned, "cat", 3) == 0);
+extractpdf_free(owned);
+
+update.contents_utf8 = bad_utf8;
+update.contents_size = sizeof(bad_utf8);
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_ERROR_ARGUMENT);
+
+update.contents_utf8 = embedded_nul;
+update.contents_size = sizeof(embedded_nul);
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_ERROR_ARGUMENT);
+```
+
+Snapshot group must copy A bytes before further mutation, produce B, and reparse both through public APIs:
+
+```c
+const unsigned char *a_data = NULL;
+const unsigned char *repeat_data = NULL;
+size_t a_size = 0, repeat_size = 0;
+unsigned char *a_copy = NULL;
+
+CHECK(extractpdf_pdf_edit_snapshot(edit, &a) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_snapshot(edit, &repeat) == EXTRACTPDF_OK);
+CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
+CHECK(extractpdf_output_data(repeat, &repeat_data, &repeat_size) == EXTRACTPDF_OK);
+CHECK(a_size == repeat_size && memcmp(a_data, repeat_data, a_size) == 0);
+a_copy = malloc(a_size);
+CHECK(a_copy != NULL);
+memcpy(a_copy, a_data, a_size);
+
+/* mutate existing Text contents to "snapshot-b" */
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_snapshot(edit, &b) == EXTRACTPDF_OK);
+CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
+CHECK(memcmp(a_data, a_copy, a_size) == 0);
+
+save_output(a, OUTPUT_A_PDF);
+save_output(b, OUTPUT_B_PDF);
+expect_snapshot_annotation(OUTPUT_A_PDF, 0, EXTRACTPDF_ANNOTATION_TEXT, "text-a");
+expect_snapshot_annotation(OUTPUT_B_PDF, 0, EXTRACTPDF_ANNOTATION_TEXT, "snapshot-b");
+
+extractpdf_test_pdf_edit_set_fault(
+    edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH);
+out = (extractpdf_output *)(uintptr_t)1;
+CHECK(extractpdf_pdf_edit_snapshot(edit, &out) != EXTRACTPDF_OK);
+CHECK(out == NULL);
+/* editor/ref must still work after failed snapshot */
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text, &info) == EXTRACTPDF_OK);
+```
+
+Source immutability belongs in the snapshot group: create a source-side immutable annotation snapshot **before** beginning mutations, mutate the editor, then re-read that old snapshot after source close and assert original `text-a`, original bounds, and original `2147483649` flags.
+
+JavaScript group:
+
+```c
+static void test_javascript_disabled(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_document *reparsed = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+    extractpdf_output *out = NULL;
+    char *title = NULL;
+    size_t title_size = 0;
+
+    CHECK(extractpdf_open(JS_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &out) == EXTRACTPDF_OK);
+    save_output(out, OUTPUT_JS_PDF);
+    CHECK(extractpdf_open(OUTPUT_JS_PDF, NULL, &reparsed) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_metadata(reparsed, EXTRACTPDF_METADATA_TITLE,
+                                       &title, &title_size) == EXTRACTPDF_OK);
+    CHECK(title_size == 4 && memcmp(title, "SAFE", 4) == 0);
+    extractpdf_free(title);
+    extractpdf_close(reparsed);
+    extractpdf_drop_output(out);
+    extractpdf_drop_pdf_edit(edit);
+    extractpdf_close(source);
+}
+```
+
+The fixture OpenAction uses MuPDF-supported document title assignment (`this.title = "EXECUTED"`). Therefore observing `SAFE` after begin/snapshot proves this editor path did not execute the script.
+
+`main()` must run every group with no argument and exactly one named group when an argument is supplied:
+
+```c
+static int selected(int argc, char **argv, const char *name)
+{
+    return argc == 1 || (argc == 2 && strcmp(argv[1], name) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    CHECK(argc <= 2);
+    if (selected(argc, argv, "arguments")) test_arguments();
+    if (selected(argc, argv, "begin")) test_begin_lifetime_and_fail_closed();
+    if (selected(argc, argv, "discovery")) {
+        test_discovery_and_refs();
+        test_malformed_discovery_is_atomic();
+    }
+    if (selected(argc, argv, "create")) test_create();
+    if (selected(argc, argv, "update-delete")) test_update_delete();
+    if (selected(argc, argv, "contents-flags")) test_contents_flags();
+    if (selected(argc, argv, "snapshot")) test_snapshot_isolation();
+    if (selected(argc, argv, "javascript")) test_javascript_disabled();
+    return 0;
+}
+```
+
+- [ ] **Step 4: Register the RED target**
+
+Append to `tests/CMakeLists.txt`:
+
+```cmake
+set(MUTATION_OUTPUT_A "${CMAKE_CURRENT_BINARY_DIR}/annotation-mutation-a.pdf")
+set(MUTATION_OUTPUT_B "${CMAKE_CURRENT_BINARY_DIR}/annotation-mutation-b.pdf")
+set(MUTATION_OUTPUT_JS "${CMAKE_CURRENT_BINARY_DIR}/annotation-mutation-js-output.pdf")
+
+add_executable(extractpdf_test_pdf_annotation_mutation
+  test_pdf_annotation_mutation.c)
+target_link_libraries(extractpdf_test_pdf_annotation_mutation PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_annotation_mutation PRIVATE
+  MUTATION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation.pdf"
+  SIGNED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-signed.pdf"
+  UNSIGNED_SIGNATURE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-unsigned-signature.pdf"
+  JS_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-js.pdf"
+  LATE_MALFORMED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-late-malformed.pdf"
+  ENCRYPTED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/encrypted-one-page.pdf"
+  NON_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-non-pdf.txt"
+  OUTPUT_A_PDF="${MUTATION_OUTPUT_A}"
+  OUTPUT_B_PDF="${MUTATION_OUTPUT_B}"
+  OUTPUT_JS_PDF="${MUTATION_OUTPUT_JS}")
+add_test(NAME extractpdf.pdf_annotation_mutation
+  COMMAND extractpdf_test_pdf_annotation_mutation)
+set_tests_properties(extractpdf.pdf_annotation_mutation PROPERTIES TIMEOUT 60)
+```
+
+Add `extractpdf_test_pdf_annotation_mutation` to the existing `WIN32 AND BUILD_SHARED_LIBS` DLL-copy list.
+
+Do **not** add `pdf_edit_fault_hook.c` to the library in RED. Its absence must not become the compile failure because the public mutation types themselves are still absent.
+
+- [ ] **Step 5: Run RED locally**
+
+Use the same Linux static configuration as CI after the pinned vcpkg dependency is available:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build --parallel 2
+```
+
+Expected RED:
+
+```text
+extractpdf library                                    builds
+all existing test targets through pdf_annotations     build
+extractpdf_test_pdf_annotation_mutation                fails to compile
+```
+
+The new target must fail on the **approved absent public ABI**: unknown `extractpdf_pdf_edit`, `extractpdf_annotation_ref`, create/update types/field constants, `EXTRACTPDF_ERROR_STATE`, and implicit/undefined new API declarations. A failure caused by malformed fixtures, missing fixture paths, missing `pdf_edit_test_api.h`, unrelated source warnings, or an existing test is not valid RED.
+
+- [ ] **Step 6: Commit and capture remote RED evidence**
+
+```bash
+git add tests/fixtures/annotation-mutation*.pdf \
+        tests/pdf_edit_test_api.h \
+        tests/test_pdf_annotation_mutation.c \
+        tests/CMakeLists.txt
+git commit -m "test: define PDF annotation mutation red"
+```
+
+Open a draft PR targeting `master` and linking #37 / roadmap #2. The first PR workflow must reproduce the same boundary: all existing library/test targets build and only the mutation target fails because the new ABI is absent. Record the exact RED SHA and workflow run in the PR body and #37 before adding production declarations.
+
+---
+
+### Task 2: Extract one shared annotation semantic core
+
+**Files:**
+- Create: `src/pdf_annotation_common.h`
+- Create: `src/pdf_annotation_common.c`
+- Modify: `src/pdf_annotations.c`
+- Modify: `CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: current Annotation Enumeration V1 behavior from `src/pdf_annotations.c`.
+- Produces:
+
+```c
+typedef struct extractpdf_pdf_annotation_view {
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+    int has_contents;
+} extractpdf_pdf_annotation_view;
+
+int extractpdf_pdf_annotation_classify(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_type *out_type);
+
+extractpdf_status extractpdf_pdf_annotation_read_view(
+    fz_context *ctx,
+    pdf_page *page,
+    pdf_obj *annotation,
+    extractpdf_annotation_type type,
+    extractpdf_pdf_annotation_view *out_view);
+```
+
+- [ ] **Step 1: Confirm the refactor safety net is green before editing**
+
+```bash
+ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
+```
+
+Expected: `extractpdf.pdf_annotations` passes on the integrated behavior.
+
+- [ ] **Step 2: Move classification/materialization helpers into the common module**
+
+Create `src/pdf_annotation_common.h` with the interface above and include `pdf_internal.h`.
+
+Move, without semantic changes, the current private logic for:
+
+```text
+dictionary key presence lookup
+Subtype mapping
+Link / Popup / Widget filtering
+UNKNOWN mapping
+strict Rect validation + direct pdf_page_transform() conversion
+strict uint32 /F validation
+strict optional /Contents string validation + decoded borrowed view
+```
+
+`extractpdf_pdf_annotation_read_view()` must initialize every field in `out_view`, call `pdf_page_transform()` directly for public bounds, and use `strlen()` on `pdf_to_text_string()` exactly as the current immutable implementation does. The returned `contents_utf8` is private/borrowed and may only be copied immediately by callers.
+
+- [ ] **Step 3: Rewrite immutable enumeration to consume the shared view**
+
+The first pass remains a raw `/Annots` scan using only `extractpdf_pdf_annotation_classify()`.
+
+The second pass becomes equivalent to:
+
+```c
+extractpdf_pdf_annotation_view view;
+status = extractpdf_pdf_annotation_read_view(
+    ctx, pdf_page, annotation, type, &view);
+if (status != EXTRACTPDF_OK)
+    break;
+
+item->type = view.type;
+item->bounds = view.bounds;
+item->flags = view.flags;
+if (view.has_contents) {
+    item->has_contents = 1;
+    status = extractpdf_annotation_append_string(
+        annotations,
+        view.contents_utf8,
+        &item->contents_offset,
+        &item->contents_size);
+}
+```
+
+Delete the duplicate static classify/Rect/F/Contents code from `pdf_annotations.c`.
+
+- [ ] **Step 4: Build and prove no enumeration regression**
+
+```bash
+cmake --build build --parallel 2
+ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
+ctest --test-dir build --output-on-failure
+```
+
+Expected: all existing 18 CTests pass. The mutation target remains the known compile RED until the public ABI is introduced; when building only existing targets, there is no behavior change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pdf_annotation_common.h src/pdf_annotation_common.c \
+        src/pdf_annotations.c CMakeLists.txt
+git commit -m "refactor: share PDF annotation semantics"
+```
+
+Reviewer gate: reject this task if any old annotation fixture changes meaning, if editor-specific behavior leaks into the common module, or if common helpers publish borrowed pointers through the public ABI.
+
+---
+
+### Task 3: Add the ABI shell and isolated editor lifecycle
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Modify: `src/status.c`
+- Create: `src/pdf_edit_internal.h`
+- Create: `src/pdf_edit.c`
+- Create: `src/pdf_edit_annotations.c`
+- Create: `tests/pdf_edit_fault_hook.c`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: `extractpdf_serialize_pdf()`, existing `extractpdf_output`, MuPDF 1.28.2 `pdf_document_from_fz_document`, `pdf_open_document_with_stream`, `pdf_disable_js`, `pdf_enable_journal`, `pdf_walk_tree`, signature helpers.
+- Produces: every approved public Mutation V1 symbol so the RED test binary links; lifecycle/begin/snapshot/drop and fail-closed policy are real, while annotation-specific calls may temporarily return `UNSUPPORTED` after correct output resets until Tasks 4-6.
+
+- [ ] **Step 1: Add the exact public ABI**
+
+Append the new opaque handle near the other handles:
+
+```c
+typedef struct extractpdf_pdf_edit extractpdf_pdf_edit;
+
+typedef struct extractpdf_annotation_ref {
+    uint64_t opaque[2];
+} extractpdf_annotation_ref;
+```
+
+Add:
+
+```c
+typedef enum extractpdf_annotation_update_field {
+    EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS = 1u << 0,
+    EXTRACTPDF_ANNOTATION_UPDATE_FLAGS = 1u << 1,
+    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS = 1u << 2
+} extractpdf_annotation_update_field;
+
+typedef struct extractpdf_annotation_create_options {
+    size_t struct_size;
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+} extractpdf_annotation_create_options;
+
+typedef struct extractpdf_annotation_update {
+    size_t struct_size;
+    uint32_t fields;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+} extractpdf_annotation_update;
+```
+
+Append to `extractpdf_status` without renumbering existing values:
+
+```c
+EXTRACTPDF_ERROR_STATE = 8
+```
+
+Add the nine approved functions exactly as written in the spec: begin, count, ref_at, get_info, contents, create, update, delete, snapshot, plus `extractpdf_drop_pdf_edit()`.
+
+- [ ] **Step 2: Add the stable status text**
+
+In `src/status.c`:
+
+```c
+case EXTRACTPDF_ERROR_STATE:
+    return "invalid state";
+```
+
+- [ ] **Step 3: Define private editor ownership**
+
+Create `src/pdf_edit_internal.h`:
+
+```c
+#ifndef EXTRACTPDF_PDF_EDIT_INTERNAL_H
+#define EXTRACTPDF_PDF_EDIT_INTERNAL_H
+
+#include "pdf_annotation_common.h"
+
+typedef struct extractpdf_pdf_edit_annotation_entry {
+    pdf_obj *object;
+    int page_index;
+    uint32_t tag;
+    int live;
+} extractpdf_pdf_edit_annotation_entry;
+
+struct extractpdf_pdf_edit {
+    fz_context *ctx;
+    pdf_document *document;
+    extractpdf_output *seed_output; /* owns bytes backing the private input stream */
+    uint64_t session_cookie;
+    extractpdf_pdf_edit_annotation_entry *entries;
+    size_t entry_count;
+    size_t entry_capacity;
+#if defined(EXTRACTPDF_TESTING)
+    int test_fault;
+#endif
+};
+
+extractpdf_status extractpdf_pdf_edit_load_page(
+    extractpdf_pdf_edit *edit, int page_index, pdf_page **out_page);
+
+#endif
+```
+
+Do not put editor state into `struct extractpdf_document`.
+
+- [ ] **Step 4: Implement signed-field scanning without loading widgets or executing actions**
+
+In `src/pdf_edit.c`, use `pdf_walk_tree()` on `Root/AcroForm/Fields` with inherited `/FT`. The arrive callback checks signature fields with `pdf_signature_is_signed()` and sets a local flag. It must not enable JavaScript or dispatch events.
+
+Equivalent private callback shape:
+
+```c
+typedef struct extractpdf_signed_scan {
+    pdf_document *document;
+    int found;
+} extractpdf_signed_scan;
+
+static void scan_signed_field(
+    fz_context *ctx, pdf_obj *field, void *arg, pdf_obj **inherited)
+{
+    extractpdf_signed_scan *scan = arg;
+    pdf_obj *ft = pdf_dict_get(ctx, field, PDF_NAME(FT));
+    if (ft == NULL)
+        ft = inherited[0];
+    if (!scan->found && pdf_name_eq(ctx, ft, PDF_NAME(Sig)) &&
+        pdf_signature_is_signed(ctx, scan->document, field))
+        scan->found = 1;
+}
+```
+
+Use `pdf_walk_tree()`'s cycle/depth protection rather than writing recursive unbounded traversal.
+
+- [ ] **Step 5: Implement `extractpdf_pdf_edit_begin()` atomically**
+
+Required sequence:
+
+```text
+reset *out_edit
+validate source internals
+pdf_document_from_fz_document -> NULL means UNSUPPORTED
+raw trailer /Encrypt present -> UNSUPPORTED
+signed field scan -> signed means UNSUPPORTED
+serialize source with extractpdf_serialize_pdf() into seed_output
+allocate editor
+new independent fz_context
+set discard warning/error callbacks
+fz_open_memory(seed_output->data, seed_output->size)
+pdf_open_document_with_stream()
+pdf_disable_js()
+pdf_enable_journal()
+create nonzero private session cookie
+publish editor
+```
+
+Keep `seed_output` alive for the whole editor lifetime because the private PDF stream may continue reading its memory after open. Drop the local stream reference after `pdf_open_document_with_stream()` because the PDF document keeps its own stream reference.
+
+Generate `session_cookie` with editor-local data only; no global counter. A suitable private mix is:
+
+```c
+static uint64_t mix64(uint64_t x)
+{
+    x ^= x >> 30;
+    x *= UINT64_C(0xbf58476d1ce4e5b9);
+    x ^= x >> 27;
+    x *= UINT64_C(0x94d049bb133111eb);
+    x ^= x >> 31;
+    return x;
+}
+```
+
+Mix `uintptr_t(edit)`, `uintptr_t(edit->ctx)`, and bytes from `fz_memrnd(edit->ctx, ...)`; force zero to a nonzero constant. This token is an opaque session discriminator, not a cryptographic authentication promise and exposes no PDF identity.
+
+Every caught MuPDF exception maps through `extractpdf_status_from_mupdf()` and tears down all partial editor state before return.
+
+- [ ] **Step 6: Implement non-consuming baseline snapshot/drop**
+
+`extractpdf_pdf_edit_snapshot()`:
+
+```c
+extractpdf_output *result = NULL;
+if (out_output == NULL)
+    return EXTRACTPDF_ERROR_ARGUMENT;
+*out_output = NULL;
+if (edit == NULL || edit->ctx == NULL || edit->document == NULL)
+    return EXTRACTPDF_ERROR_ARGUMENT;
+status = extractpdf_serialize_pdf(edit->ctx, edit->document, &result);
+if (status != EXTRACTPDF_OK)
+    return status;
+#if defined(EXTRACTPDF_TESTING)
+if (edit->test_fault == EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH) {
+    edit->test_fault = EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE;
+    extractpdf_drop_output(result);
+    return EXTRACTPDF_ERROR_MUPDF;
+}
+#endif
+*out_output = result;
+return EXTRACTPDF_OK;
+```
+
+`extractpdf_drop_pdf_edit()` drops all kept registry objects, registry storage, private PDF document, private context, and `seed_output`; NULL is a no-op. Drop the PDF document before the context and drop `seed_output` only after the PDF document no longer references its memory stream.
+
+- [ ] **Step 7: Add linkable annotation API shells with correct reset semantics**
+
+In `src/pdf_edit_annotations.c`, define all remaining public mutation functions so the test binary links. At this task they may return `EXTRACTPDF_ERROR_UNSUPPORTED` after required pointer/reset/`struct_size` checks when passed an otherwise valid editor. Do not fake discovery or CRUD success.
+
+Examples:
+
+```c
+extractpdf_status extractpdf_pdf_edit_annotation_count(
+    extractpdf_pdf_edit *edit, int page_index, size_t *out_count)
+{
+    if (out_count != NULL)
+        *out_count = 0;
+    if (edit == NULL || out_count == NULL || page_index < 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
+    extractpdf_pdf_edit *edit, int page_index, size_t index,
+    extractpdf_annotation_ref *out_ref)
+{
+    (void)index;
+    if (out_ref != NULL)
+        memset(out_ref, 0, sizeof(*out_ref));
+    if (edit == NULL || out_ref == NULL || page_index < 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+```
+
+- [ ] **Step 8: Add the private per-editor deterministic fault hook**
+
+In `tests/CMakeLists.txt`:
+
+```cmake
+target_sources(extractpdf PRIVATE pdf_edit_fault_hook.c)
+target_compile_definitions(extractpdf PRIVATE EXTRACTPDF_TESTING=1)
+```
+
+Create `tests/pdf_edit_fault_hook.c`:
+
+```c
+#include "../src/pdf_edit_internal.h"
+#include "pdf_edit_test_api.h"
+
+void extractpdf_test_pdf_edit_set_fault(
+    extractpdf_pdf_edit *edit,
+    extractpdf_test_pdf_edit_fault fault)
+{
+#if defined(EXTRACTPDF_TESTING)
+    if (edit != NULL)
+        edit->test_fault = (int)fault;
+#else
+    (void)edit;
+    (void)fault;
+#endif
+}
+```
+
+Because this source is added to the library only from the tests subdirectory, the hook is not part of test-disabled production builds or the installed public header. Fault state is per editor, satisfying the no-global-state constraint.
+
+- [ ] **Step 9: Register production sources and run lifecycle groups**
+
+Add to root `add_library(extractpdf ...)`:
+
+```cmake
+src/pdf_annotation_common.c
+src/pdf_edit.c
+src/pdf_edit_annotations.c
+```
+
+Run:
+
+```bash
+cmake -S . -B build ...same pinned-vcpkg args...
+cmake --build build --parallel 2
+./build/tests/extractpdf_test_pdf_annotation_mutation arguments
+./build/tests/extractpdf_test_pdf_annotation_mutation begin
+./build/tests/extractpdf_test_pdf_annotation_mutation javascript
+```
+
+Expected: `arguments`, `begin`, and baseline `javascript` pass. Discovery/CRUD groups are still behavioral RED (`UNSUPPORTED`) and must not be claimed GREEN yet.
+
+If two baseline snapshots with no mutation are not byte-identical, stop this task and fix `snapshot()` without weakening the spec; direct `pdf_write_document()` use is acceptable only if the unchanged-state determinism/non-consuming tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add include/extractpdf/extractpdf.h src/status.c \
+        src/pdf_edit_internal.h src/pdf_edit.c src/pdf_edit_annotations.c \
+        tests/pdf_edit_fault_hook.c tests/CMakeLists.txt CMakeLists.txt
+git commit -m "feat: add isolated PDF editor lifecycle"
+```
+
+---
+
+### Task 4: Implement discovery, canonical session refs, and live getters
+
+**Files:**
+- Modify: `src/pdf_edit_internal.h`
+- Modify: `src/pdf_edit_annotations.c`
+- Test: `tests/test_pdf_annotation_mutation.c`
+
+**Interfaces:**
+- Consumes: shared `extractpdf_pdf_annotation_classify/read_view`, private editor PDF.
+- Produces: real count/ref_at/get_info/contents behavior and canonical session refs that survive index shifts.
+
+- [ ] **Step 1: Run the focused failing discovery group**
+
+```bash
+./build/tests/extractpdf_test_pdf_annotation_mutation discovery
+```
+
+Expected: FAIL because count/ref_at/getters still return `UNSUPPORTED`.
+
+- [ ] **Step 2: Add identity comparison and registry reserve helpers**
+
+Registry entries keep a private `pdf_obj *` reference and page index. Compare indirect objects by private object number+generation and direct dictionaries by object pointer; never compare dictionary contents, because two distinct annotations may be value-equal.
+
+```c
+static int same_pdf_identity(fz_context *ctx, pdf_obj *a, pdf_obj *b)
+{
+    int ai = pdf_is_indirect(ctx, a);
+    int bi = pdf_is_indirect(ctx, b);
+    if (ai || bi)
+        return ai && bi &&
+               pdf_to_num(ctx, a) == pdf_to_num(ctx, b) &&
+               pdf_to_gen(ctx, a) == pdf_to_gen(ctx, b);
+    return a == b;
+}
+```
+
+`reserve_entries(edit, needed)` must overflow-check `SIZE_MAX / sizeof(entry)` and allocate before any operation that cannot safely fail afterward.
+
+- [ ] **Step 3: Canonicalize one ref per annotation object**
+
+Before allocating a new slot, search all registry entries for the same private identity. If found live, return its existing token. Never recycle a tombstoned slot during the edit session.
+
+Token layout is private but concrete:
+
+```text
+opaque[0] = edit->session_cookie
+opaque[1] = (uint64_t(entry->tag) << 32) | uint64_t(slot + 1)
+```
+
+Limit registry slots to `UINT32_MAX - 1`; exceeding that is `NOMEM`. Generate a nonzero 32-bit `tag` from the editor-local random/mix helper.
+
+Resolution checks, in order:
+
+```text
+NULL edit/ref                       ARGUMENT
+opaque[0] != session_cookie         ARGUMENT
+slot field == 0/out of range        ARGUMENT
+tag mismatch                        ARGUMENT
+matching entry live==0              STATE
+matching live entry                 OK
+```
+
+- [ ] **Step 4: Scan and validate a whole page before returning count/ref**
+
+Implement a private scanner that loads `pdf_page`, reads raw `/Annots`, filters via shared classify, and calls shared strict `read_view()` for **every survivor**. It records count and optionally keeps the object at one requested survivor index only after the entire scan succeeds.
+
+Pseudo-interface:
+
+```c
+static extractpdf_status scan_page(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t wanted_index,
+    int want_object,
+    size_t *out_count,
+    pdf_obj **out_object);
+```
+
+On malformed later survivor, return `FORMAT` and publish/register nothing from the prefix.
+
+- [ ] **Step 5: Implement count/ref_at**
+
+`count()` resets output, validates page range using `pdf_count_pages`, scans the full page, and publishes count only on success.
+
+`ref_at()` zeros token, scans/validates the full page, rejects `index >= count`, then canonical-registers the wanted object and publishes the token.
+
+- [ ] **Step 6: Implement getters from ref**
+
+Resolve the entry, load its page, confirm the object is still present as a surviving ordinary annotation on that page, then use shared `read_view()`.
+
+`get_info()` preserves caller `struct_size`, validates the existing minimum size through `flags`, resets type/bounds/flags, and copies type/bounds/flags.
+
+`contents()` independently resets non-NULL outputs, requires both, and deep-copies the view string:
+
+```c
+if (!view.has_contents)
+    return EXTRACTPDF_OK;
+copy = malloc(view.contents_size + 1);
+if (copy == NULL)
+    return EXTRACTPDF_ERROR_NOMEM;
+memcpy(copy, view.contents_utf8, view.contents_size + 1);
+*out_utf8 = copy;
+*out_size = view.contents_size;
+```
+
+If a registry entry is marked live but its object is no longer present because of an internal consistency change, return `EXTRACTPDF_ERROR_STATE` rather than silently retargeting another index.
+
+- [ ] **Step 7: Run focused and old-semantic tests**
+
+```bash
+cmake --build build --parallel 2
+./build/tests/extractpdf_test_pdf_annotation_mutation discovery
+ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
+```
+
+Expected: discovery group passes; immutable enumeration still passes unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pdf_edit_internal.h src/pdf_edit_annotations.c
+git commit -m "feat: add annotation edit refs and discovery"
+```
+
+---
+
+### Task 5: Implement safe Rect-based annotation creation
+
+**Files:**
+- Modify: `src/pdf_edit_annotations.c`
+- Test: `tests/test_pdf_annotation_mutation.c`
+
+**Interfaces:**
+- Consumes: editor page loading, registry reserve/canonical publication, MuPDF journal/create/setter APIs.
+- Produces: atomic TEXT/FREE_TEXT/SQUARE/CIRCLE creation with immediate live ref.
+
+- [ ] **Step 1: Run the focused failing create group**
+
+```bash
+./build/tests/extractpdf_test_pdf_annotation_mutation create
+```
+
+Expected: FAIL because create still returns `UNSUPPORTED`.
+
+- [ ] **Step 2: Implement counted UTF-8 validation/copy**
+
+Add a private validator that rejects NUL and invalid UTF-8, including overlong encodings, UTF-16 surrogate code points, values above U+10FFFF, and truncated continuations. Accept ASCII plus canonical 2/3/4-byte sequences.
+
+Use these byte ranges:
+
+```text
+1 byte: 00..7F, except 00 is rejected by Contents policy
+2 byte: C2..DF 80..BF
+3 byte: E0 A0..BF 80..BF
+        E1..EC 80..BF 80..BF
+        ED 80..9F 80..BF
+        EE..EF 80..BF 80..BF
+4 byte: F0 90..BF 80..BF 80..BF
+        F1..F3 80..BF 80..BF 80..BF
+        F4 80..8F 80..BF 80..BF
+```
+
+For present input allocate `size + 1` with overflow check, copy exactly `size` bytes, append `\0`, and return the temporary C string. NULL/0 remains the absent marker and allocates nothing.
+
+- [ ] **Step 3: Validate creation inputs before mutation**
+
+Minimum struct size is:
+
+```c
+offsetof(extractpdf_annotation_create_options, contents_size) +
+    sizeof(options->contents_size)
+```
+
+Require valid page index, supported type, finite ordered bounds, and valid Contents tuple. Zero-width/height is accepted.
+
+Map only:
+
+```c
+TEXT      -> PDF_ANNOT_TEXT
+FREE_TEXT -> PDF_ANNOT_FREE_TEXT
+SQUARE    -> PDF_ANNOT_SQUARE
+CIRCLE    -> PDF_ANNOT_CIRCLE
+```
+
+All other public types are `UNSUPPORTED`.
+
+- [ ] **Step 4: Implement full-uint32 `/F` writing**
+
+Add one private helper used by create and update:
+
+```c
+static void set_annot_flags_u32(
+    fz_context *ctx, pdf_annot *annot, uint32_t flags)
+{
+    if (flags <= (uint32_t)INT_MAX) {
+        pdf_set_annot_flags(ctx, annot, (int)flags);
+    } else {
+        pdf_obj *obj = pdf_annot_obj(ctx, annot);
+        pdf_dict_put_int(ctx, obj, PDF_NAME(F), (int64_t)(uint64_t)flags);
+        pdf_annot_request_resynthesis(ctx, annot);
+    }
+}
+```
+
+Do not cast `UINT32_MAX` through signed `int`.
+
+- [ ] **Step 5: Create inside one outer journal operation**
+
+Before `pdf_begin_operation()`, reserve one registry slot so no registry allocation is needed after a successful PDF operation.
+
+Inside `fz_try`:
+
+```c
+pdf_begin_operation(ctx, edit->document, "ExtractPDF create annotation");
+annot = pdf_create_annot(ctx, page, mupdf_type);
+pdf_set_annot_rect(ctx, annot, public_bounds);
+set_annot_flags_u32(ctx, annot, options->flags);
+if (options->contents_utf8 != NULL)
+    pdf_set_annot_contents(ctx, annot, temporary_nul_terminated_text);
+pdf_update_annot(ctx, annot);
+```
+
+Under test builds, if fault `AFTER_CREATE_MUTATION` is armed, clear it and `fz_throw(ctx, FZ_ERROR_GENERIC, "ExtractPDF test create fault")` before `pdf_end_operation()`.
+
+On normal success, call `pdf_end_operation()` first, then fill the already-reserved registry entry from `pdf_annot_obj()` and publish the token. `pdf_keep_obj()` is only a refcount increment and must not introduce an allocation/publication failure after commit.
+
+On exception, call `pdf_abandon_operation()`, drop the returned annot reference, free temporary Contents, and leave `out_ref` zero.
+
+- [ ] **Step 6: Run create + full flags seed checks**
+
+```bash
+cmake --build build --parallel 2
+./build/tests/extractpdf_test_pdf_annotation_mutation create
+./build/tests/extractpdf_test_pdf_annotation_mutation contents-flags
+```
+
+At this point the create assertions should pass. The contents-flags group may still fail on update-specific assertions; the pre-existing high-bit `/F` getter assertion must already pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pdf_edit_annotations.c
+git commit -m "feat: create Rect-based PDF annotations"
+```
+
+---
+
+### Task 6: Implement partial update, delete, and deterministic rollback
+
+**Files:**
+- Modify: `src/pdf_edit_annotations.c`
+- Test: `tests/test_pdf_annotation_mutation.c`
+
+**Interfaces:**
+- Consumes: canonical refs, UTF-8 helper, full-u32 flags helper, MuPDF journal/setter/delete APIs, private test fault.
+- Produces: atomic partial update/delete with tombstone semantics.
+
+- [ ] **Step 1: Run focused failing groups**
+
+```bash
+./build/tests/extractpdf_test_pdf_annotation_mutation update-delete
+./build/tests/extractpdf_test_pdf_annotation_mutation contents-flags
+```
+
+Expected: update/delete behavior is still RED.
+
+- [ ] **Step 2: Validate the whole update request before opening the operation**
+
+Require non-NULL edit/ref/update and minimum struct size through `contents_size`. Resolve the ref first.
+
+Then:
+
+```c
+const uint32_t known =
+    EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
+    EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
+    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+if (update->fields & ~known)
+    return EXTRACTPDF_ERROR_ARGUMENT;
+if (update->fields == 0)
+    return EXTRACTPDF_OK;
+```
+
+This ordering is mandatory: wrong-session zero-mask -> `ARGUMENT`, tombstone zero-mask -> `STATE`, live UNKNOWN zero-mask -> `OK`.
+
+For nonzero fields, UNKNOWN -> `UNSUPPORTED`. BOUNDS on anything except TEXT/FREE_TEXT/SQUARE/CIRCLE -> `UNSUPPORTED`. Prevalidate bounds and Contents before mutation.
+
+- [ ] **Step 3: Implement absent/present Contents mutation**
+
+Present string uses `pdf_set_annot_contents()`.
+
+Removing `/Contents` must be journalled directly:
+
+```c
+pdf_obj *obj = pdf_annot_obj(ctx, annot);
+pdf_dict_del(ctx, obj, PDF_NAME(Contents));
+pdf_annot_request_resynthesis(ctx, annot);
+```
+
+This preserves absent versus present-empty instead of converting removal into an empty string.
+
+- [ ] **Step 4: Apply updates in fixed order inside one outer operation**
+
+Use fixed private order BOUNDS -> FLAGS -> CONTENTS. After each actually applied field increment `applied_fields`. When the test fault `AFTER_FIRST_UPDATE_FIELD` is armed and `applied_fields == 1`, clear it and throw before applying later fields.
+
+After all requested setters/raw edits:
+
+```c
+pdf_update_annot(ctx, annot);
+pdf_end_operation(ctx, edit->document);
+```
+
+Any exception calls `pdf_abandon_operation()` and returns mapped error. The registry is unchanged by update.
+
+- [ ] **Step 5: Implement delete + tombstone only after success**
+
+Resolve ref and locate the current `pdf_annot *` by private object identity on its page. UNKNOWN delete is `UNSUPPORTED`; every recognized ordinary subtype is allowed.
+
+```c
+pdf_begin_operation(ctx, edit->document, "ExtractPDF delete annotation");
+pdf_delete_annot(ctx, page, annot);
+pdf_end_operation(ctx, edit->document);
+entry->live = 0;
+```
+
+If delete throws, abandon and leave `entry->live == 1`.
+
+Do not recycle the slot. Associated Popup cleanup remains MuPDF internal behavior.
+
+- [ ] **Step 6: Run rollback/tombstone/index-shift tests**
+
+```bash
+cmake --build build --parallel 2
+./build/tests/extractpdf_test_pdf_annotation_mutation update-delete
+./build/tests/extractpdf_test_pdf_annotation_mutation contents-flags
+```
+
+Expected:
+
+```text
+failed two-field update -> old bounds + old Contents both remain
+failed create fault     -> count unchanged + zero ref
+delete Text              -> Text ref STATE
+Square index shifts      -> old Square ref still targets Square
+Highlight bounds         -> UNSUPPORTED
+Highlight flags/content  -> succeeds
+UINT32_MAX flags         -> round-trip unchanged
+invalid UTF-8/NUL        -> ARGUMENT before mutation
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pdf_edit_annotations.c
+git commit -m "feat: atomically update and delete annotations"
+```
+
+---
+
+### Task 7: Prove source isolation, snapshot isolation, output reparse, and JavaScript non-execution
+
+**Files:**
+- Modify if verification exposes an implementation defect: `src/pdf_edit.c`
+- Modify if verification exposes a mutation defect: `src/pdf_edit_annotations.c`
+- Test: `tests/test_pdf_annotation_mutation.c`
+
+**Interfaces:**
+- Consumes: complete editor/ref/CRUD behavior.
+- Produces: final public semantic proof before all-suite GREEN.
+
+- [ ] **Step 1: Run snapshot group before changing production code**
+
+```bash
+./build/tests/extractpdf_test_pdf_annotation_mutation snapshot
+```
+
+Expected after Tasks 3-6: PASS. If it fails, treat the failure as a product bug; do not weaken byte-identity, source-isolation, or non-consuming assertions.
+
+- [ ] **Step 2: Confirm immutable source state survives editor mutation**
+
+The test must hold an `extractpdf_annotation_page` from the source before `edit_begin`, close source after begin, mutate the editor, and then verify the old source snapshot remains:
+
+```text
+TEXT
+original Fitz bounds [10,160,30,180]
+flags 2147483649
+Contents "text-a"
+```
+
+No source handle is kept alive merely to make this pass.
+
+- [ ] **Step 3: Confirm snapshot A/B semantics through only public reparse APIs**
+
+Required checks are already in RED and must all pass:
+
+```text
+snapshot A == repeat snapshot bytes when no mutation intervenes
+A stays byte-identical after later mutation
+B differs after later mutation
+A reparse immutable enumeration -> old Contents
+B reparse immutable enumeration -> new Contents
+snapshot does not invalidate Text ref
+failed snapshot fault returns NULL output
+failed snapshot leaves editor/ref usable
+output remains valid after drop editor
+```
+
+If direct `extractpdf_serialize_pdf(edit->document)` changes editor bookkeeping enough to violate these tests, do not special-case the assertions. Introduce a private serialization strategy that preserves the editor's observable state and keep the public contract unchanged.
+
+- [ ] **Step 4: Run JavaScript group after CRUD/appearance paths exist**
+
+```bash
+./build/tests/extractpdf_test_pdf_annotation_mutation javascript
+```
+
+Extend the group to perform one Text Contents update before snapshot, so `pdf_update_annot()` is exercised. Reparsed metadata Title must remain `SAFE`, never `EXECUTED`.
+
+- [ ] **Step 5: Verify outputs with immutable annotation enumeration**
+
+The test must not use raw MuPDF objects to prove the core result. `extractpdf_open` + `extractpdf_load_page` + `extractpdf_extract_annotations` is the acceptance surface for created/updated/deleted results and full `uint32_t` flags.
+
+- [ ] **Step 6: Run the complete mutation executable**
+
+```bash
+./build/tests/extractpdf_test_pdf_annotation_mutation
+```
+
+Expected: PASS with all named groups.
+
+- [ ] **Step 7: Commit only if this task required production/test corrections**
+
+```bash
+git add src/pdf_edit.c src/pdf_edit_annotations.c tests/test_pdf_annotation_mutation.c
+git commit -m "test: lock PDF annotation editor isolation"
+```
+
+If no file changed, do not create an empty commit.
+
+---
+
+### Task 8: Reach full GREEN and exact-head cross-platform proof
+
+**Files:**
+- No planned feature expansion.
+- Modify only files already in the approved scope if a real portability/compiler defect is found.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: merge-ready exact-head evidence; does not merge.
+
+- [ ] **Step 1: Fresh Linux static build and all CTests**
+
+```bash
+rm -rf build
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build --parallel 2
+ctest --test-dir build --output-on-failure
+```
+
+Expected: **19/19 CTests pass**, with `extractpdf.pdf_annotation_mutation` present as the new test.
+
+- [ ] **Step 2: Fresh Linux ASan/UBSan build and all CTests**
+
+```bash
+rm -rf build-asan
+cmake -S . -B build-asan \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+cmake --build build-asan --parallel 2
+ctest --test-dir build-asan --output-on-failure
+```
+
+Expected: 19/19 pass with no sanitizer finding in ExtractPDF-owned editor/ref/string/registry code.
+
+- [ ] **Step 3: Exact-head diff review**
+
+Compare feature head against base `58525ce1b4b691ef53dfafc7c4e4d82753c966ba`.
+
+Allowed production paths:
+
+```text
+include/extractpdf/extractpdf.h
+src/status.c
+src/pdf_annotation_common.h
+src/pdf_annotation_common.c
+src/pdf_annotations.c
+src/pdf_edit_internal.h
+src/pdf_edit.c
+src/pdf_edit_annotations.c
+CMakeLists.txt
+```
+
+Allowed test/docs paths:
+
+```text
+docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md
+docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
+tests/CMakeLists.txt
+tests/pdf_edit_test_api.h
+tests/pdf_edit_fault_hook.c
+tests/test_pdf_annotation_mutation.c
+tests/fixtures/annotation-mutation.pdf
+tests/fixtures/annotation-mutation-signed.pdf
+tests/fixtures/annotation-mutation-unsigned-signature.pdf
+tests/fixtures/annotation-mutation-js.pdf
+```
+
+No unrelated page/render/text/image/link/outline/metadata/composition/output-file changes are acceptable. `pdf_output.c` should remain unchanged unless a demonstrated snapshot-contract defect requires a narrowly reviewed serializer fix.
+
+- [ ] **Step 4: Push final GREEN and capture Linux PR CI**
+
+The normal PR synchronize run on the final exact SHA must pass Linux static + all CTests and Linux ASan/UBSan + all CTests. Update the draft PR body and #37 with:
+
+```text
+RED SHA + workflow
+first production GREEN SHA + workflow
+final exact SHA
+19/19 Linux static
+19/19 Linux ASan/UBSan
+```
+
+- [ ] **Step 5: Trigger same-head `full-ci`**
+
+Add label `full-ci` to the draft PR **only after the final exact SHA is fixed**. Because the workflow's macOS/Windows PR jobs run only on the labeled event, verify the labeled workflow uses the same final `head_sha`.
+
+Acceptance:
+
+```text
+Linux static + 19/19 CTests       success
+Linux ASan/UBSan + 19/19 CTests  success
+macOS build + 19/19 CTests        success
+Windows DLL build + 19/19 CTests success
+```
+
+Windows logs must explicitly show construction/linking of the new editor sources, `extractpdf_test_pdf_annotation_mutation.exe`, and `extractpdf.pdf_annotation_mutation` passing through the DLL configuration.
+
+- [ ] **Step 6: Final review gate**
+
+Review exact head against these locked boundaries:
+
+```text
+source immutability
+begin lifetime independence
+discovery semantic reuse
+ref canonicality + wrong-session + tombstone
+full uint32 flags
+Contents absent/empty/counting/UTF-8 ownership
+create type matrix
+update/delete atomic rollback
+appearance before journal completion
+snapshot determinism/non-consumption/output independence
+encrypted + signed fail-closed
+JavaScript never executed
+no MuPDF/PDF identity in public ABI
+```
+
+Any Critical/Important finding gets a new commit and invalidates the previous exact-head proof; rerun Linux and same-head full-ci after the fix.
+
+- [ ] **Step 7: Mark PR ready only after evidence is complete**
+
+Update PR/issue/roadmap bookkeeping to say **implementation/evidence complete; integration pending**. Do not merge as part of this task.
+
+---
+
+### Task 9: Explicit integration gate
+
+**Files:**
+- Bookkeeping only after successful merge/proof: PR #37 successor PR body, issue #37, roadmap #2.
+
+**Interfaces:**
+- Consumes: final reviewed exact-head full-ci evidence.
+- Produces: integrated master proof and closes #37.
+
+This task requires a separate explicit integration authorization after Task 8. A plan executor must stop before merge if that authorization has not been given.
+
+- [ ] **Step 1: Re-fetch merge state immediately before merging**
+
+Confirm:
+
+```text
+PR open + ready
+head SHA exactly equals proven full-ci SHA
+base master is expected integrated base/descendant
+mergeable true
+no unresolved review thread
+no new review/comment blocker
+same-head full-ci success
+```
+
+- [ ] **Step 2: Merge with `expected_head_sha`**
+
+Use merge method `merge`, not an unreviewed squash/rebase transformation. GitHub must reject if head moved.
+
+- [ ] **Step 3: Verify integrated master push workflow**
+
+Find the `push` workflow whose `head_sha` equals the merge commit. Do not close #37 based only on PR CI.
+
+Required integrated evidence:
+
+```text
+Linux static + all CTests       success
+Linux ASan/UBSan + all CTests  success
+macOS                           success
+Windows DLL                     success
+```
+
+Inspect Windows logs to confirm the mutation test runs in the integrated DLL build.
+
+- [ ] **Step 4: Close bookkeeping only after integrated GREEN**
+
+Close #37 as completed and update roadmap #2 to:
+
+```text
+[x] Annotation mutation editor — #37 / PR #... — integrated
+```
+
+Record final feature SHA, merge SHA, same-head full-ci workflow, and integrated master push workflow. Keep Forms/widgets and subtype-specific geometry as separate future work.
+
+---
+
+## Execution Checkpoints
+
+```text
+Task 1  strict compile RED + remote RED evidence
+   ↓
+Task 2  shared annotation semantics; old 18-test regression gate
+   ↓
+Task 3  ABI + isolated lifecycle + fail-closed + baseline snapshot
+   ↓
+Task 4  discovery + canonical refs + live getters
+   ↓
+Task 5  create TEXT/FREE_TEXT/SQUARE/CIRCLE
+   ↓
+Task 6  update/delete + rollback + tombstone
+   ↓
+Task 7  source/snapshot/JS/output semantic proof
+   ↓
+Task 8  19/19 + sanitizers + same-SHA Linux/macOS/Windows full-ci + review
+   ↓
+STOP: explicit integration authorization
+   ↓
+Task 9  expected-head merge + integrated master proof + close #37
+```
+
+The implementation is not complete merely because CRUD works. The completion boundary is: deterministic public reparse proves the edited output, all ref/rollback/fail-closed contracts are locked, and the exact feature head passes all three operating-system jobs before integration.

--- a/docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
+++ b/docs/superpowers/plans/2026-08-29-extractpdf-pdf-annotation-mutation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add an isolated PDF annotation editor that keeps `extractpdf_document` immutable, uses session-local annotation refs for atomic create/update/delete, and emits deterministic non-consuming `extractpdf_output` snapshots.
 
-**Architecture:** `extractpdf_pdf_edit_begin()` materializes a private full-PDF fork in its own MuPDF context, rejects encrypted/already-signed sources, disables JavaScript, and enables MuPDF journalling. Immutable annotation enumeration and editor discovery share one private classify/materialize implementation; editor refs map to private annotation objects through a non-recycled registry. Each CRUD call is one outer journal operation and `snapshot()` serializes the current fork into the existing immutable output abstraction without consuming the editor.
+**Architecture:** `extractpdf_pdf_edit_begin()` first rejects unsupported source policies, then serializes the accepted source into deterministic owned bytes and reopens those bytes in a private MuPDF context. Immutable annotation enumeration and editor discovery share one private classifier/materializer. Editor refs are canonical session-local value tokens backed by a non-recycled private registry. Each CRUD call is one outer MuPDF journal operation; editor snapshots use MuPDF 1.28.2 `pdf_write_snapshot()` so the in-memory edit journal is not finalized or consumed.
 
 **Tech Stack:** C11, CMake 3.20+, pinned MuPDF 1.28.2 through the existing vcpkg overlay, CTest, Linux ASan/UBSan, macOS, Windows DLL.
 
@@ -15,24 +15,24 @@
 ## Global Constraints
 
 - Keep `extractpdf_document`, `extractpdf_page`, and all existing immutable snapshots read-only; no mutation API writes through those handles.
-- `extractpdf_pdf_edit_begin()` must become independent of the source lifetime after success.
+- `extractpdf_pdf_edit_begin()` becomes independent of the source lifetime after success.
 - No MuPDF type, PDF object number/generation, `/NM`, filename, or pointer becomes public mutation identity.
 - Immutable annotation indices remain snapshot-local/discovery-only and are never accepted by update/delete APIs.
-- Editor discovery must use exactly the same Link/Popup/Widget filtering, UNKNOWN mapping, order, and strict Rect/F/Contents materialization contract as Annotation Enumeration V1.
-- Public mutation bounds are finite normalized Fitz page-space rectangles. Reversed/non-finite input is `ARGUMENT`; V1 does not silently normalize input.
+- Editor discovery uses exactly the same Link/Popup/Widget filtering, UNKNOWN mapping, relative order, and strict Rect/F/Contents materialization contract as Annotation Enumeration V1.
+- Public mutation bounds are finite ordered Fitz page-space rectangles. Reversed/non-finite input is `ARGUMENT`; V1 does not silently normalize mutation input.
 - V1 create/bounds-update supports only TEXT, FREE_TEXT, SQUARE, and CIRCLE.
-- Recognized ordinary annotations may receive generic flags/Contents update and delete; UNKNOWN mutation is `UNSUPPORTED`.
+- Recognized ordinary annotations may receive generic flags/Contents update and delete. UNKNOWN mutation is `UNSUPPORTED`; a zero-field update is a validated no-op rather than a mutation.
 - Preserve the complete raw `uint32_t` `/F` range. Never narrow values above `INT_MAX` through MuPDF's `int` convenience setter.
 - Contents are counted UTF-8 with absent versus present-empty preserved. Present input must be valid UTF-8 and contain no embedded NUL.
-- Every create/update/delete is one atomic outer MuPDF journal operation. Any failure restores pre-call PDF and ref-registry observable state.
+- Every create/update/delete is one atomic outer MuPDF journal operation. Any failure restores the pre-call PDF and ref-registry observable state.
 - `snapshot()` is non-consuming, deterministic for unchanged editor state, leaves refs valid, and returns an independent existing `extractpdf_output`.
 - Reject every encrypted source and every source with an already-signed signature value as `UNSUPPORTED`. Unsigned signature fields remain allowed.
 - Disable JavaScript in the private editor before exposing it. Begin/CRUD/appearance update/snapshot must not execute PDF JavaScript.
-- No public undo/redo, incremental save, forms/widgets mutation, link mutation, Popup API, QuadPoints/line/vertex/Ink geometry, persistent identity, encrypted editing, or signed-PDF editing in V1.
+- No public undo/redo, incremental-save API, forms/widgets mutation, link mutation, Popup API, QuadPoints/line/vertex/Ink geometry, persistent identity, encrypted editing, or signed-PDF editing in V1.
 - Preserve reset-before-later-validation behavior for every new output pointer.
 - New option/update structs use the existing forward-compatible minimum-`struct_size` convention; larger structs are accepted.
 - Keep the current single-thread handle contract. Add no mutable process-global/TLS state.
-- RED precedes every production declaration/behavior. Final feature head requires Linux static + all CTests, Linux ASan/UBSan + all CTests, macOS, and Windows DLL proof.
+- Strict RED precedes all new production declarations/behavior. Final feature head requires Linux static + all CTests, Linux ASan/UBSan + all CTests, macOS, and Windows DLL proof.
 
 ---
 
@@ -45,7 +45,7 @@
   - add value `extractpdf_annotation_ref`;
   - add update-field/create/update types;
   - append `EXTRACTPDF_ERROR_STATE = 8`;
-  - add editor/discovery/getter/CRUD/snapshot/drop APIs.
+  - add begin/discovery/getter/CRUD/snapshot/drop APIs.
 - Modify `src/status.c`
   - add stable status text for `EXTRACTPDF_ERROR_STATE`.
 
@@ -55,43 +55,42 @@
   - private `extractpdf_pdf_annotation_view`;
   - survivor classification and strict common-materialization declarations.
 - Create `src/pdf_annotation_common.c`
-  - move current subtype/filter/Rect/F/Contents logic out of `src/pdf_annotations.c` without changing behavior.
+  - move the current subtype/filter/Rect/F/Contents logic out of `src/pdf_annotations.c` without changing its behavior.
 - Modify `src/pdf_annotations.c`
-  - consume the shared helpers and retain only immutable snapshot allocation/copy/public accessors.
+  - consume the shared helpers and retain immutable snapshot allocation/copy/public accessors.
 
 ### Editor implementation
 
 - Create `src/pdf_edit_internal.h`
-  - private editor struct, ref registry, token helpers, page/object resolution helpers, test-fault field under `EXTRACTPDF_TESTING`.
+  - private editor struct, ref registry, token helpers, page/object resolution helpers, and test-fault numeric constants under `EXTRACTPDF_TESTING`.
 - Create `src/pdf_edit.c`
-  - begin policy checks, private source clone/context lifecycle, signed-field scan, JavaScript disable, journal enable, snapshot, drop.
+  - begin policy checks, source-to-private clone/context lifecycle, signed-field scan, JavaScript disable, journal enable, non-consuming snapshot, drop.
 - Create `src/pdf_edit_annotations.c`
-  - editor discovery, ref registry, getters, UTF-8 validation/copy, create/update/delete, full-uint32 flags write, appearance update, journal rollback.
+  - editor discovery, canonical ref registry, live getters, counted UTF-8 validation/copy, create/update/delete, full-uint32 flags write, appearance update, journal rollback.
 - Modify `CMakeLists.txt`
-  - compile the three new production `.c` files plus the shared annotation module.
+  - compile the new production modules.
 
 ### Deterministic tests
 
 - Create `tests/test_pdf_annotation_mutation.c`
-  - one executable with named groups (`arguments`, `begin`, `discovery`, `create`, `update-delete`, `contents-flags`, `snapshot`, `javascript`) and no third-party test framework.
+  - one executable with named groups `arguments`, `begin`, `discovery`, `create`, `update-delete`, `contents-flags`, `snapshot`, `javascript` and no third-party framework.
 - Create `tests/pdf_edit_test_api.h`
-  - private test-only fault enum/hook declaration; not installed and not included by the public header.
+  - test-only fault enum/hook declaration; not installed and not included by the public header.
 - Create `tests/pdf_edit_fault_hook.c`
-  - test-only implementation compiled into `extractpdf` only when `EXTRACTPDF_BUILD_TESTS=ON`; fault state lives per editor, never globally.
+  - test-only exported hook compiled into `extractpdf` only when tests are built; state remains per editor, never global.
 - Create checked-in deterministic fixtures:
   - `tests/fixtures/annotation-mutation.pdf`
   - `tests/fixtures/annotation-mutation-signed.pdf`
   - `tests/fixtures/annotation-mutation-unsigned-signature.pdf`
   - `tests/fixtures/annotation-mutation-js.pdf`
-- Reuse existing fixtures:
+- Reuse:
   - `tests/fixtures/annotations-late-malformed.pdf`
   - `tests/fixtures/encrypted-one-page.pdf` with password `user-pass`
   - `tests/fixtures/composition-non-pdf.txt`
 - Modify `tests/CMakeLists.txt`
-  - register the new executable/CTest, fixture paths, output paths, and Windows DLL-copy list;
-  - conditionally add the private fault-hook source/definition to the library test build.
+  - register the mutation target/CTest, fixture/output paths, fault-hook compilation, and Windows DLL-copy target.
 
-No page/render/text/image/link/outline/metadata/composition behavior is refactored as part of this work.
+No page/render/text/image/link/outline/metadata/composition behavior is refactored as part of this feature.
 
 ---
 
@@ -107,12 +106,12 @@ No page/render/text/image/link/outline/metadata/composition behavior is refactor
 - Modify: `tests/CMakeLists.txt`
 
 **Interfaces:**
-- Consumes: current public `extractpdf_document`, immutable annotation/output/metadata APIs.
-- Produces: the complete wished-for Mutation V1 contract as failing C tests. No production declaration is added in this task.
+- Consumes: current public document, immutable annotation, metadata, and output APIs.
+- Produces: the complete wished-for Mutation V1 contract as a compile RED. No new production declaration appears in this task.
 
-- [ ] **Step 1: Generate the checked-in deterministic PDFs**
+- [ ] **Step 1: Generate deterministic checked-in PDFs**
 
-Use this one-shot authoring script from the repository root. The script is **not** committed; only its PDF outputs are committed. It writes plain deterministic PDF objects and computes exact xref offsets, so runtime tests remain pure CTest and have no Python dependency.
+Run this one-shot authoring script from repository root. Do not commit the script; commit only its outputs.
 
 ```bash
 python3 - <<'PY'
@@ -125,19 +124,18 @@ def write_pdf(path, objects, trailer_extra=""):
     parts = [b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n"]
     offsets = [0]
     for number, body in enumerate(objects, 1):
-        offsets.append(sum(len(p) for p in parts))
+        offsets.append(sum(len(part) for part in parts))
         parts.append(f"{number} 0 obj\n".encode("ascii"))
         parts.append(body.encode("latin1"))
         parts.append(b"\nendobj\n")
-    xref = sum(len(p) for p in parts)
+    xref = sum(len(part) for part in parts)
     parts.append(f"xref\n0 {len(objects)+1}\n".encode("ascii"))
     parts.append(b"0000000000 65535 f \n")
     for offset in offsets[1:]:
         parts.append(f"{offset:010d} 00000 n \n".encode("ascii"))
     parts.append(
         (f"trailer\n<< /Size {len(objects)+1} /Root 1 0 R {trailer_extra} >>\n"
-         f"startxref\n{xref}\n%%EOF\n").encode("latin1")
-    )
+         f"startxref\n{xref}\n%%EOF\n").encode("latin1"))
     path.write_bytes(b"".join(parts))
 
 
@@ -168,7 +166,7 @@ write_pdf(OUT / "annotation-mutation.pdf", [
 
 def signature_pdf(path, signed):
     value = " /V 6 0 R" if signed else ""
-    objects = [
+    write_pdf(path, [
         "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>",
         "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
         "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [5 0 R] >>",
@@ -176,8 +174,8 @@ def signature_pdf(path, signed):
         f"<< /Type /Annot /Subtype /Widget /FT /Sig /T (sig) /Rect [10 10 120 40] /P 3 0 R{value} >>",
         "<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached "
         "/ByteRange [0 0 0 0] /Contents <00> >>",
-    ]
-    write_pdf(path, objects)
+    ])
+
 
 signature_pdf(OUT / "annotation-mutation-signed.pdf", True)
 signature_pdf(OUT / "annotation-mutation-unsigned-signature.pdf", False)
@@ -191,17 +189,26 @@ write_pdf(OUT / "annotation-mutation-js.pdf", [
     "<< /Type /Annot /Subtype /Text /Rect [10 10 30 30] /Contents (js-safe) >>",
 ], "/Info 4 0 R")
 PY
-```
-
-Verify the four files exist and are stable across a second run:
-
-```bash
 sha256sum tests/fixtures/annotation-mutation*.pdf
 ```
 
-Expected: rerunning the generator produces the same four hashes.
+Run the generator a second time and repeat `sha256sum`. The four hashes must be unchanged.
 
-- [ ] **Step 2: Add the private test-fault declaration without implementation**
+Fixture contract:
+
+```text
+annotation-mutation.pdf page 0 survivors:
+0 Text       flags 2147483649  contents text-a
+1 Square     flags 4           contents square-b
+2 UNKNOWN    flags 64          contents unknown-c
+3 Highlight  flags 0           contents highlight-d
+4 Ink        flags 0           contents ink-e
+
+filtered page-0 entries: scalar 17, Link, Popup, Widget
+page 1: FreeText then Circle
+```
+
+- [ ] **Step 2: Add the test-only fault declaration, with no implementation yet**
 
 Create `tests/pdf_edit_test_api.h`:
 
@@ -225,13 +232,11 @@ EXTRACTPDF_API void extractpdf_test_pdf_edit_set_fault(
 #endif
 ```
 
-This is test-only surface. Its current compile failure is expected because `extractpdf_pdf_edit` is intentionally absent before RED is captured.
+The unknown `extractpdf_pdf_edit` type is intentionally part of RED.
 
-- [ ] **Step 3: Add the full mutation test executable**
+- [ ] **Step 3: Add the mutation test executable and common helpers**
 
-Create `tests/test_pdf_annotation_mutation.c` with the existing lightweight `CHECK` style. Use an optional first CLI argument so individual groups can be run during incremental GREEN work while the umbrella CTest still runs all groups.
-
-Required helpers:
+Create `tests/test_pdf_annotation_mutation.c` using the existing `CHECK` style:
 
 ```c
 #include <extractpdf/extractpdf.h>
@@ -255,7 +260,7 @@ static void check_impl(int ok, const char *expr, int line)
 static int close_float(float a, float b)
 {
     float d = a - b;
-    return (d < 0 ? -d : d) < 0.01f;
+    return (d < 0.0f ? -d : d) < 0.01f;
 }
 
 static void zero_ref(extractpdf_annotation_ref *ref)
@@ -268,200 +273,159 @@ static int ref_is_zero(const extractpdf_annotation_ref *ref)
 {
     return ref->opaque[0] == 0 && ref->opaque[1] == 0;
 }
-
-static void save_output(const extractpdf_output *out, const char *path)
-{
-    CHECK(extractpdf_output_save_file(out, path) == EXTRACTPDF_OK);
-}
-
-static void expect_snapshot_annotation(
-    const char *path,
-    size_t index,
-    extractpdf_annotation_type type,
-    const char *contents)
-{
-    extractpdf_document *doc = NULL;
-    extractpdf_page *page = NULL;
-    extractpdf_annotation_page *annots = NULL;
-    extractpdf_annotation_info info = {0};
-    const char *text = NULL;
-    size_t size = 0;
-
-    CHECK(extractpdf_open(path, NULL, &doc) == EXTRACTPDF_OK);
-    CHECK(extractpdf_load_page(doc, 0, &page) == EXTRACTPDF_OK);
-    CHECK(extractpdf_extract_annotations(page, &annots) == EXTRACTPDF_OK);
-    info.struct_size = sizeof(info);
-    CHECK(extractpdf_annotation_get_info(annots, index, &info) == EXTRACTPDF_OK);
-    CHECK(info.type == type);
-    CHECK(extractpdf_annotation_contents(annots, index, &text, &size) == EXTRACTPDF_OK);
-    CHECK(text != NULL);
-    CHECK(size == strlen(contents));
-    CHECK(memcmp(text, contents, size) == 0);
-
-    extractpdf_drop_annotation_page(annots);
-    extractpdf_drop_page(page);
-    extractpdf_close(doc);
-}
 ```
 
-The RED file must contain these exact behavioral groups and assertions:
+Add helpers that:
+
+```text
+open source document
+save extractpdf_output with extractpdf_output_save_file
+read live edit info/Contents
+reparse saved output through extractpdf_open -> load_page -> extract_annotations
+verify missing/present-empty/non-empty Contents distinctly
+```
+
+`expect_snapshot_annotation()` must verify type, bounds, flags, and Contents through public immutable APIs; it must not inspect raw PDF objects.
+
+- [ ] **Step 4: Lock output reset, struct-size, and basic argument contracts**
+
+`test_arguments()` must include these exact checks:
 
 ```c
-static void test_arguments(void)
-{
-    int sentinel = 0;
-    extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
-    extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
-    extractpdf_output *out = (extractpdf_output *)&sentinel;
-    size_t count = 99;
+int sentinel = 0;
+extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
+extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
+extractpdf_annotation_info info = {0};
+extractpdf_annotation_create_options create = {0};
+extractpdf_annotation_update update = {0};
+extractpdf_output *output = (extractpdf_output *)&sentinel;
+char *text = (char *)(uintptr_t)1;
+size_t size = 99;
+size_t count = 99;
 
-    CHECK(extractpdf_pdf_edit_begin(NULL, &edit) == EXTRACTPDF_ERROR_ARGUMENT);
-    CHECK(edit == NULL);
-    CHECK(extractpdf_pdf_edit_begin(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(extractpdf_pdf_edit_begin(NULL, &edit) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(edit == NULL);
+CHECK(extractpdf_pdf_edit_begin(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
 
-    CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
-    CHECK(count == 0);
-    CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, &count) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(count == 0);
+CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
 
-    CHECK(extractpdf_pdf_edit_annotation_ref_at(NULL, 0, 0, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
-    CHECK(ref_is_zero(&ref));
+CHECK(extractpdf_pdf_edit_annotation_ref_at(NULL, 0, 0, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(ref_is_zero(&ref));
 
-    out = (extractpdf_output *)&sentinel;
-    CHECK(extractpdf_pdf_edit_snapshot(NULL, &out) == EXTRACTPDF_ERROR_ARGUMENT);
-    CHECK(out == NULL);
-    CHECK(extractpdf_pdf_edit_snapshot(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
-    extractpdf_drop_pdf_edit(NULL);
+info.struct_size = offsetof(extractpdf_annotation_info, flags);
+CHECK(extractpdf_pdf_edit_annotation_get_info(NULL, &ref, &info) == EXTRACTPDF_ERROR_ARGUMENT);
 
-    CHECK(strcmp(extractpdf_status_string(EXTRACTPDF_ERROR_STATE), "invalid state") == 0);
-}
+text = (char *)(uintptr_t)1;
+size = 99;
+CHECK(extractpdf_pdf_edit_annotation_contents(NULL, &ref, &text, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(text == NULL && size == 0);
 
-static void test_begin_lifetime_and_fail_closed(void)
-{
-    int sentinel = 0;
-    extractpdf_document *source = NULL;
-    extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
-    extractpdf_output *out = NULL;
+create.struct_size = offsetof(extractpdf_annotation_create_options, contents_size);
+zero_ref(&ref);
+CHECK(extractpdf_pdf_edit_annotation_create(NULL, 0, &create, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(ref_is_zero(&ref));
 
-    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
-    CHECK(edit != NULL);
-    extractpdf_close(source);
-    source = NULL;
-    CHECK(extractpdf_pdf_edit_snapshot(edit, &out) == EXTRACTPDF_OK);
-    CHECK(out != NULL);
-    extractpdf_drop_output(out);
-    extractpdf_drop_pdf_edit(edit);
+update.struct_size = offsetof(extractpdf_annotation_update, contents_size);
+CHECK(extractpdf_pdf_edit_annotation_update(NULL, &ref, &update) == EXTRACTPDF_ERROR_ARGUMENT);
 
-    CHECK(extractpdf_open(ENCRYPTED_PDF, "user-pass", &source) == EXTRACTPDF_OK);
-    edit = (extractpdf_pdf_edit *)&sentinel;
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
-    CHECK(edit == NULL);
-    extractpdf_close(source);
+output = (extractpdf_output *)&sentinel;
+CHECK(extractpdf_pdf_edit_snapshot(NULL, &output) == EXTRACTPDF_ERROR_ARGUMENT);
+CHECK(output == NULL);
+CHECK(extractpdf_pdf_edit_snapshot(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
 
-    CHECK(extractpdf_open(SIGNED_PDF, NULL, &source) == EXTRACTPDF_OK);
-    edit = (extractpdf_pdf_edit *)&sentinel;
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
-    CHECK(edit == NULL);
-    extractpdf_close(source);
-
-    CHECK(extractpdf_open(UNSIGNED_SIGNATURE_PDF, NULL, &source) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
-    extractpdf_drop_pdf_edit(edit);
-    extractpdf_close(source);
-
-    CHECK(extractpdf_open(NON_PDF, NULL, &source) == EXTRACTPDF_OK);
-    edit = (extractpdf_pdf_edit *)&sentinel;
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
-    CHECK(edit == NULL);
-    extractpdf_close(source);
-}
+extractpdf_drop_pdf_edit(NULL);
+CHECK(strcmp(extractpdf_status_string(EXTRACTPDF_ERROR_STATE), "invalid state") == 0);
 ```
 
-Discovery/ref group:
+After a real editor is available later, this same group must also verify too-small create/update `struct_size`, unknown update bits, bad page indices, and reset values. Larger-than-V1 structs must be accepted by providing a wrapper struct whose first member is the V1 struct plus trailing bytes.
+
+- [ ] **Step 5: Lock begin lifetime and fail-closed policies**
+
+`test_begin_lifetime_and_fail_closed()`:
 
 ```c
-static void test_discovery_and_refs(void)
-{
-    extractpdf_document *source = NULL;
-    extractpdf_pdf_edit *a = NULL;
-    extractpdf_pdf_edit *b = NULL;
-    extractpdf_annotation_ref text = {{0,0}};
-    extractpdf_annotation_ref square = {{0,0}};
-    extractpdf_annotation_ref square_again = {{0,0}};
-    extractpdf_annotation_ref wrong = {{0,0}};
-    extractpdf_annotation_info info = {0};
-    size_t count = 0;
+extractpdf_document *source = NULL;
+extractpdf_pdf_edit *edit = NULL;
+extractpdf_output *output = NULL;
 
-    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_begin(source, &a) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_begin(source, &b) == EXTRACTPDF_OK);
+CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+CHECK(edit != NULL);
+extractpdf_close(source);
+source = NULL;
+CHECK(extractpdf_pdf_edit_snapshot(edit, &output) == EXTRACTPDF_OK);
+CHECK(output != NULL);
+extractpdf_drop_output(output);
+extractpdf_drop_pdf_edit(edit);
 
-    CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) == EXTRACTPDF_OK);
-    CHECK(count == 6); /* Text, Square, UNKNOWN, Highlight, Ink + scalar filtering leaves 5? */
-    /* Correct the fixture expectation explicitly below: survivors are Text, Square,
-       FutureThing, Highlight, Ink = 5. */
-    CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) == EXTRACTPDF_OK);
-    CHECK(count == 5);
+CHECK(extractpdf_open(ENCRYPTED_PDF, "user-pass", &source) == EXTRACTPDF_OK);
+edit = (extractpdf_pdf_edit *)(uintptr_t)1;
+CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
+CHECK(edit == NULL);
+extractpdf_close(source);
 
-    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 0, &text) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_again) == EXTRACTPDF_OK);
-    CHECK(memcmp(&square, &square_again, sizeof(square)) == 0);
+CHECK(extractpdf_open(SIGNED_PDF, NULL, &source) == EXTRACTPDF_OK);
+edit = (extractpdf_pdf_edit *)(uintptr_t)1;
+CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
+CHECK(edit == NULL);
+extractpdf_close(source);
 
-    info.struct_size = sizeof(info);
-    CHECK(extractpdf_pdf_edit_annotation_get_info(a, &square, &info) == EXTRACTPDF_OK);
-    CHECK(info.type == EXTRACTPDF_ANNOTATION_SQUARE);
-    CHECK(info.flags == 4u);
+CHECK(extractpdf_open(UNSIGNED_SIGNATURE_PDF, NULL, &source) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+extractpdf_drop_pdf_edit(edit);
+extractpdf_close(source);
 
-    wrong = square;
-    CHECK(extractpdf_pdf_edit_annotation_get_info(b, &wrong, &info) == EXTRACTPDF_ERROR_ARGUMENT);
-
-    CHECK(extractpdf_pdf_edit_annotation_count(a, -1, &count) == EXTRACTPDF_ERROR_ARGUMENT);
-    CHECK(count == 0);
-    zero_ref(&wrong);
-    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 99, &wrong) == EXTRACTPDF_ERROR_ARGUMENT);
-    CHECK(ref_is_zero(&wrong));
-
-    extractpdf_drop_pdf_edit(b);
-    extractpdf_drop_pdf_edit(a);
-    extractpdf_close(source);
-}
+CHECK(extractpdf_open(NON_PDF, NULL, &source) == EXTRACTPDF_OK);
+edit = (extractpdf_pdf_edit *)(uintptr_t)1;
+CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_ERROR_UNSUPPORTED);
+CHECK(edit == NULL);
+extractpdf_close(source);
 ```
 
-**Important correction while authoring:** do **not** leave the temporary `count == 6` assertion shown above in the committed test. The committed code must contain only `count == 5`. This note exists to make the logical count auditable: page 0 survivors are Text, Square, FutureThing/UNKNOWN, Highlight, Ink; scalar 17, Link, Popup, Widget are filtered.
+- [ ] **Step 6: Lock discovery/ref identity and malformed atomicity**
 
-Malformed-discovery atomicity must be in the same group:
+`test_discovery_and_refs()` must assert exactly five page-0 survivors and canonical repeated ref acquisition:
 
 ```c
-static void test_malformed_discovery_is_atomic(void)
-{
-    extractpdf_document *source = NULL;
-    extractpdf_pdf_edit *edit = NULL;
-    extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
-    size_t count = 99;
-
-    CHECK(extractpdf_open(LATE_MALFORMED_PDF, NULL, &source) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &count) == EXTRACTPDF_ERROR_FORMAT);
-    CHECK(count == 0);
-    CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 0, &ref) == EXTRACTPDF_ERROR_FORMAT);
-    CHECK(ref_is_zero(&ref));
-    extractpdf_drop_pdf_edit(edit);
-    extractpdf_close(source);
-}
+CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) == EXTRACTPDF_OK);
+CHECK(count == 5);
+CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 0, &text_ref) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_ref) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_again) == EXTRACTPDF_OK);
+CHECK(memcmp(&square_ref, &square_again, sizeof(square_ref)) == 0);
 ```
 
-Create/update/delete group must cover all four create types and unsupported geometry. Use this common create helper:
+Open the same source into editor B and verify `square_ref` used with B returns `ARGUMENT`. Verify page `-1`, page `2`, and index `99` are `ARGUMENT` with reset outputs.
+
+For `annotations-late-malformed.pdf`:
+
+```c
+count = 99;
+CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &count) == EXTRACTPDF_ERROR_FORMAT);
+CHECK(count == 0);
+ref.opaque[0] = UINT64_MAX;
+ref.opaque[1] = UINT64_MAX;
+CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 0, &ref) == EXTRACTPDF_ERROR_FORMAT);
+CHECK(ref_is_zero(&ref));
+```
+
+No prefix ref may be registered by the failed scan.
+
+- [ ] **Step 7: Lock create/update/delete/rollback/type-matrix behavior**
+
+Create helper:
 
 ```c
 static extractpdf_annotation_ref create_rect_annot(
     extractpdf_pdf_edit *edit,
-    int page,
+    int page_index,
     extractpdf_annotation_type type,
     extractpdf_rect bounds,
     uint32_t flags,
-    const char *text,
-    size_t size)
+    const char *contents,
+    size_t contents_size)
 {
     extractpdf_annotation_create_options options = {0};
     extractpdf_annotation_ref ref = {{0,0}};
@@ -469,176 +433,173 @@ static extractpdf_annotation_ref create_rect_annot(
     options.type = type;
     options.bounds = bounds;
     options.flags = flags;
-    options.contents_utf8 = text;
-    options.contents_size = size;
-    CHECK(extractpdf_pdf_edit_annotation_create(edit, page, &options, &ref) == EXTRACTPDF_OK);
+    options.contents_utf8 = contents;
+    options.contents_size = contents_size;
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, page_index, &options, &ref) == EXTRACTPDF_OK);
     CHECK(!ref_is_zero(&ref));
     return ref;
 }
 ```
 
-In `test_create()` create TEXT, FREE_TEXT, SQUARE, CIRCLE with distinct rectangles/contents, then verify each through `extractpdf_pdf_edit_annotation_get_info()` and allocated `extractpdf_pdf_edit_annotation_contents()`. Also execute:
+`test_create()` creates these four exact cases and verifies each through live getters:
 
-```c
-options.type = EXTRACTPDF_ANNOTATION_HIGHLIGHT;
-zero_ref(&ref);
-CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &ref) == EXTRACTPDF_ERROR_UNSUPPORTED);
-CHECK(ref_is_zero(&ref));
-
-options.type = EXTRACTPDF_ANNOTATION_UNKNOWN;
-CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &ref) == EXTRACTPDF_ERROR_UNSUPPORTED);
-CHECK(ref_is_zero(&ref));
+```text
+page 0 TEXT      [20,20,35,35]   flags 1   Contents "new-text"
+page 1 FREE_TEXT [20,20,90,55]   flags 4   Contents "new-free"
+page 1 SQUARE    [100,20,150,70] flags 8   Contents absent
+page 1 CIRCLE    [20,90,70,140]  flags 16  Contents present-empty
 ```
 
-`test_update_delete()` must acquire Text and Square refs, delete Text, verify Text getter/update/delete/contents all return `EXTRACTPDF_ERROR_STATE`, reacquire current index 0 and prove it is the same Square ref, then update Square bounds/flags/Contents through the original ref. It must also acquire Highlight and prove `BOUNDS` update returns `UNSUPPORTED` while `FLAGS` and `CONTENTS` update succeeds. A zero-field update on a live UNKNOWN ref is `OK`; a zero-field update on a tombstone is `STATE`; a zero-field update with a ref from another editor is `ARGUMENT`.
+Then set the same valid options to HIGHLIGHT and UNKNOWN and require `UNSUPPORTED + zero ref`.
 
-Atomic rollback tests use the private per-editor hook:
+`test_update_delete()` must:
+
+```text
+1. acquire Text ref and Square ref from page 0;
+2. delete Text;
+3. require Text get_info/contents/update/delete => STATE;
+4. reacquire page-0 index 0 and require byte-equal token to original Square ref;
+5. update Square bounds + flags + Contents using original Square ref;
+6. verify all three changed;
+7. acquire Highlight ref; BOUNDS update => UNSUPPORTED;
+8. Highlight FLAGS|CONTENTS update => OK;
+9. live UNKNOWN zero-field update => OK;
+10. tombstone zero-field update => STATE;
+11. wrong-session zero-field update => ARGUMENT.
+```
+
+Atomic update fault must save pre-call values explicitly:
 
 ```c
-extractpdf_annotation_update update = {0};
-update.struct_size = sizeof(update);
-update.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
-                EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
-update.bounds = (extractpdf_rect){20, 20, 90, 90};
-update.contents_utf8 = "changed";
-update.contents_size = 7;
+extractpdf_annotation_info before = {0};
+extractpdf_annotation_info after = {0};
+char *before_text = NULL;
+char *after_text = NULL;
+size_t before_size = 0;
+size_t after_size = 0;
+extractpdf_annotation_update change = {0};
 
+before.struct_size = sizeof(before);
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &square_ref, &before) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_contents(
+          edit, &square_ref, &before_text, &before_size) == EXTRACTPDF_OK);
+
+change.struct_size = sizeof(change);
+change.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
+                EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+change.bounds = (extractpdf_rect){20, 20, 90, 90};
+change.contents_utf8 = "rollback-new";
+change.contents_size = sizeof("rollback-new") - 1;
 extractpdf_test_pdf_edit_set_fault(
     edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_FIRST_UPDATE_FIELD);
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &square, &update) != EXTRACTPDF_OK);
-/* Re-read info + contents and assert both equal the pre-call values. */
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &square_ref, &change) != EXTRACTPDF_OK);
+
+after.struct_size = sizeof(after);
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &square_ref, &after) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_contents(
+          edit, &square_ref, &after_text, &after_size) == EXTRACTPDF_OK);
+CHECK(close_float(before.bounds.x0, after.bounds.x0));
+CHECK(close_float(before.bounds.y0, after.bounds.y0));
+CHECK(close_float(before.bounds.x1, after.bounds.x1));
+CHECK(close_float(before.bounds.y1, after.bounds.y1));
+CHECK(before_size == after_size);
+CHECK(before_size == 0 || memcmp(before_text, after_text, before_size) == 0);
+extractpdf_free(before_text);
+extractpdf_free(after_text);
 ```
 
 Create rollback:
 
 ```c
+CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &before_count) == EXTRACTPDF_OK);
 extractpdf_test_pdf_edit_set_fault(
     edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_CREATE_MUTATION);
-zero_ref(&ref);
-CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &ref) != EXTRACTPDF_OK);
-CHECK(ref_is_zero(&ref));
-CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &after) == EXTRACTPDF_OK);
-CHECK(after == before);
+zero_ref(&new_ref);
+CHECK(extractpdf_pdf_edit_annotation_create(edit, 0, &options, &new_ref) != EXTRACTPDF_OK);
+CHECK(ref_is_zero(&new_ref));
+CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &after_count) == EXTRACTPDF_OK);
+CHECK(after_count == before_count);
 ```
 
-Contents/flags group must include:
+- [ ] **Step 8: Lock full-u32 flags and counted Contents semantics**
+
+`test_contents_flags()` begins with the existing Text:
 
 ```c
-/* Existing Text has /F 2147483649 = 0x80000001. */
 info.struct_size = sizeof(info);
-CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text, &info) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text_ref, &info) == EXTRACTPDF_OK);
 CHECK(info.flags == UINT32_C(2147483649));
 
 update.struct_size = sizeof(update);
 update.fields = EXTRACTPDF_ANNOTATION_UPDATE_FLAGS;
 update.flags = UINT32_MAX;
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
-CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text, &info) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text_ref, &update) == EXTRACTPDF_OK);
+CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text_ref, &info) == EXTRACTPDF_OK);
 CHECK(info.flags == UINT32_MAX);
 ```
 
-Also test absent/present-empty/non-empty Contents, counted non-NUL-terminated input, invalid UTF-8, embedded NUL, and live getter ownership:
+Also use:
 
 ```c
 static const char counted[3] = {'c','a','t'};
 static const char bad_utf8[2] = {(char)0xC0, (char)0xAF};
 static const char embedded_nul[3] = {'a','\0','b'};
-char *owned = NULL;
-size_t owned_size = 0;
-
-update.fields = EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
-update.contents_utf8 = counted;
-update.contents_size = sizeof(counted);
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
-CHECK(extractpdf_pdf_edit_annotation_contents(edit, &text, &owned, &owned_size) == EXTRACTPDF_OK);
-CHECK(owned_size == 3 && memcmp(owned, "cat", 3) == 0 && owned[3] == '\0');
-
-/* Mutate after the getter; the allocated old copy must remain "cat". */
-update.contents_utf8 = "dog";
-update.contents_size = 3;
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
-CHECK(memcmp(owned, "cat", 3) == 0);
-extractpdf_free(owned);
-
-update.contents_utf8 = bad_utf8;
-update.contents_size = sizeof(bad_utf8);
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_ERROR_ARGUMENT);
-
-update.contents_utf8 = embedded_nul;
-update.contents_size = sizeof(embedded_nul);
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_ERROR_ARGUMENT);
 ```
 
-Snapshot group must copy A bytes before further mutation, produce B, and reparse both through public APIs:
+Required sequence:
+
+```text
+CONTENTS=counted/3 -> OK, getter returns allocated "cat" + NUL
+mutate to "dog" -> previously returned allocated copy still equals "cat"
+CONTENTS=NULL/0 -> remove; getter returns NULL/0
+CONTENTS=nonNULL/0 -> present empty; getter returns nonNULL/0
+bad_utf8/2 -> ARGUMENT, state unchanged
+embedded_nul/3 -> ARGUMENT, state unchanged
+NULL/1 -> ARGUMENT
+```
+
+- [ ] **Step 9: Lock source/snapshot/output isolation and JavaScript non-execution**
+
+Before beginning an editor, obtain an immutable source annotation snapshot and retain it. After begin succeeds, close source, mutate editor, then prove the retained source snapshot still reads:
+
+```text
+Text bounds [10,160,30,180]
+flags 2147483649
+Contents "text-a"
+```
+
+Snapshot test:
 
 ```c
-const unsigned char *a_data = NULL;
-const unsigned char *repeat_data = NULL;
-size_t a_size = 0, repeat_size = 0;
-unsigned char *a_copy = NULL;
-
 CHECK(extractpdf_pdf_edit_snapshot(edit, &a) == EXTRACTPDF_OK);
 CHECK(extractpdf_pdf_edit_snapshot(edit, &repeat) == EXTRACTPDF_OK);
 CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
 CHECK(extractpdf_output_data(repeat, &repeat_data, &repeat_size) == EXTRACTPDF_OK);
-CHECK(a_size == repeat_size && memcmp(a_data, repeat_data, a_size) == 0);
+CHECK(a_size == repeat_size);
+CHECK(memcmp(a_data, repeat_data, a_size) == 0);
+
 a_copy = malloc(a_size);
 CHECK(a_copy != NULL);
 memcpy(a_copy, a_data, a_size);
 
-/* mutate existing Text contents to "snapshot-b" */
-CHECK(extractpdf_pdf_edit_annotation_update(edit, &text, &update) == EXTRACTPDF_OK);
+update.fields = EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+update.contents_utf8 = "snapshot-b";
+update.contents_size = sizeof("snapshot-b") - 1;
+CHECK(extractpdf_pdf_edit_annotation_update(edit, &text_ref, &update) == EXTRACTPDF_OK);
 CHECK(extractpdf_pdf_edit_snapshot(edit, &b) == EXTRACTPDF_OK);
+
 CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
 CHECK(memcmp(a_data, a_copy, a_size) == 0);
-
-save_output(a, OUTPUT_A_PDF);
-save_output(b, OUTPUT_B_PDF);
-expect_snapshot_annotation(OUTPUT_A_PDF, 0, EXTRACTPDF_ANNOTATION_TEXT, "text-a");
-expect_snapshot_annotation(OUTPUT_B_PDF, 0, EXTRACTPDF_ANNOTATION_TEXT, "snapshot-b");
-
-extractpdf_test_pdf_edit_set_fault(
-    edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH);
-out = (extractpdf_output *)(uintptr_t)1;
-CHECK(extractpdf_pdf_edit_snapshot(edit, &out) != EXTRACTPDF_OK);
-CHECK(out == NULL);
-/* editor/ref must still work after failed snapshot */
-CHECK(extractpdf_pdf_edit_annotation_get_info(edit, &text, &info) == EXTRACTPDF_OK);
 ```
 
-Source immutability belongs in the snapshot group: create a source-side immutable annotation snapshot **before** beginning mutations, mutate the editor, then re-read that old snapshot after source close and assert original `text-a`, original bounds, and original `2147483649` flags.
+Save A/B, reparse both through immutable annotation enumeration, and require A=`text-a`, B=`snapshot-b`. Drop the editor and re-read A/B output bytes again to prove output lifetime independence.
 
-JavaScript group:
+Arm `SNAPSHOT_BEFORE_PUBLISH`, require failure + NULL output, then perform a real Contents update through the same ref and require success; a mere getter is not sufficient proof that the editor remains usable after failed snapshot.
 
-```c
-static void test_javascript_disabled(void)
-{
-    extractpdf_document *source = NULL;
-    extractpdf_document *reparsed = NULL;
-    extractpdf_pdf_edit *edit = NULL;
-    extractpdf_output *out = NULL;
-    char *title = NULL;
-    size_t title_size = 0;
+JavaScript fixture starts with `/Info /Title (SAFE)` and `/OpenAction` JavaScript `this.title = "EXECUTED"`. `test_javascript_disabled()` must begin an editor, update the Text annotation so `pdf_update_annot()` executes, snapshot, reparse, and require public metadata Title remains exactly `SAFE`.
 
-    CHECK(extractpdf_open(JS_PDF, NULL, &source) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
-    CHECK(extractpdf_pdf_edit_snapshot(edit, &out) == EXTRACTPDF_OK);
-    save_output(out, OUTPUT_JS_PDF);
-    CHECK(extractpdf_open(OUTPUT_JS_PDF, NULL, &reparsed) == EXTRACTPDF_OK);
-    CHECK(extractpdf_document_metadata(reparsed, EXTRACTPDF_METADATA_TITLE,
-                                       &title, &title_size) == EXTRACTPDF_OK);
-    CHECK(title_size == 4 && memcmp(title, "SAFE", 4) == 0);
-    extractpdf_free(title);
-    extractpdf_close(reparsed);
-    extractpdf_drop_output(out);
-    extractpdf_drop_pdf_edit(edit);
-    extractpdf_close(source);
-}
-```
-
-The fixture OpenAction uses MuPDF-supported document title assignment (`this.title = "EXECUTED"`). Therefore observing `SAFE` after begin/snapshot proves this editor path did not execute the script.
-
-`main()` must run every group with no argument and exactly one named group when an argument is supplied:
+- [ ] **Step 10: Add named test-group dispatch**
 
 ```c
 static int selected(int argc, char **argv, const char *name)
@@ -664,7 +625,7 @@ int main(int argc, char **argv)
 }
 ```
 
-- [ ] **Step 4: Register the RED target**
+- [ ] **Step 11: Register the RED target**
 
 Append to `tests/CMakeLists.txt`:
 
@@ -692,15 +653,12 @@ add_test(NAME extractpdf.pdf_annotation_mutation
 set_tests_properties(extractpdf.pdf_annotation_mutation PROPERTIES TIMEOUT 60)
 ```
 
-Add `extractpdf_test_pdf_annotation_mutation` to the existing `WIN32 AND BUILD_SHARED_LIBS` DLL-copy list.
+Add `extractpdf_test_pdf_annotation_mutation` to the existing Windows DLL-copy list. Do **not** add `pdf_edit_fault_hook.c` in RED.
 
-Do **not** add `pdf_edit_fault_hook.c` to the library in RED. Its absence must not become the compile failure because the public mutation types themselves are still absent.
-
-- [ ] **Step 5: Run RED locally**
-
-Use the same Linux static configuration as CI after the pinned vcpkg dependency is available:
+- [ ] **Step 12: Run and capture strict RED**
 
 ```bash
+rm -rf build
 cmake -S . -B build \
   -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
   -DVCPKG_TARGET_TRIPLET=x64-linux \
@@ -709,27 +667,31 @@ cmake -S . -B build \
 cmake --build build --parallel 2
 ```
 
-Expected RED:
+Valid RED:
 
 ```text
-extractpdf library                                    builds
-all existing test targets through pdf_annotations     build
-extractpdf_test_pdf_annotation_mutation                fails to compile
+extractpdf library builds
+all 18 pre-existing test targets build
+only extractpdf_test_pdf_annotation_mutation fails to compile
+failure is absent approved ABI: editor/ref/types/status/constants/functions
 ```
 
-The new target must fail on the **approved absent public ABI**: unknown `extractpdf_pdf_edit`, `extractpdf_annotation_ref`, create/update types/field constants, `EXTRACTPDF_ERROR_STATE`, and implicit/undefined new API declarations. A failure caused by malformed fixtures, missing fixture paths, missing `pdf_edit_test_api.h`, unrelated source warnings, or an existing test is not valid RED.
+A fixture/runtime error, missing header/path, or old target regression is not valid RED.
 
-- [ ] **Step 6: Commit and capture remote RED evidence**
+Commit:
 
 ```bash
-git add tests/fixtures/annotation-mutation*.pdf \
+git add tests/fixtures/annotation-mutation.pdf \
+        tests/fixtures/annotation-mutation-signed.pdf \
+        tests/fixtures/annotation-mutation-unsigned-signature.pdf \
+        tests/fixtures/annotation-mutation-js.pdf \
         tests/pdf_edit_test_api.h \
         tests/test_pdf_annotation_mutation.c \
         tests/CMakeLists.txt
 git commit -m "test: define PDF annotation mutation red"
 ```
 
-Open a draft PR targeting `master` and linking #37 / roadmap #2. The first PR workflow must reproduce the same boundary: all existing library/test targets build and only the mutation target fails because the new ABI is absent. Record the exact RED SHA and workflow run in the PR body and #37 before adding production declarations.
+Open a draft PR to `master`, link #37/#2, push, and record exact RED SHA + workflow in PR #body and #37 before any production ABI is added.
 
 ---
 
@@ -742,7 +704,7 @@ Open a draft PR targeting `master` and linking #37 / roadmap #2. The first PR wo
 - Modify: `CMakeLists.txt`
 
 **Interfaces:**
-- Consumes: current Annotation Enumeration V1 behavior from `src/pdf_annotations.c`.
+- Consumes: current immutable Annotation Enumeration V1 behavior.
 - Produces:
 
 ```c
@@ -762,48 +724,50 @@ int extractpdf_pdf_annotation_classify(
 
 extractpdf_status extractpdf_pdf_annotation_read_view(
     fz_context *ctx,
-    pdf_page *page,
     pdf_obj *annotation,
     extractpdf_annotation_type type,
+    fz_matrix page_ctm,
     extractpdf_pdf_annotation_view *out_view);
 ```
 
-- [ ] **Step 1: Confirm the refactor safety net is green before editing**
+- [ ] **Step 1: Prove the existing annotation target is green before refactor**
+
+The RED build already produced every old executable before failing the new target. Run:
 
 ```bash
 ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
 ```
 
-Expected: `extractpdf.pdf_annotations` passes on the integrated behavior.
+Expected: pass.
 
-- [ ] **Step 2: Move classification/materialization helpers into the common module**
+- [ ] **Step 2: Move classification/materialization helpers without behavior changes**
 
-Create `src/pdf_annotation_common.h` with the interface above and include `pdf_internal.h`.
-
-Move, without semantic changes, the current private logic for:
+Create `src/pdf_annotation_common.h/.c`. Move the existing private logic for:
 
 ```text
 dictionary key presence lookup
-Subtype mapping
-Link / Popup / Widget filtering
+Subtype explicit mapping
+Link/Popup/Widget filtering
 UNKNOWN mapping
-strict Rect validation + direct pdf_page_transform() conversion
+strict four-finite-number Rect validation
 strict uint32 /F validation
-strict optional /Contents string validation + decoded borrowed view
+strict optional PDF-string /Contents validation + pdf_to_text_string decoding
 ```
 
-`extractpdf_pdf_annotation_read_view()` must initialize every field in `out_view`, call `pdf_page_transform()` directly for public bounds, and use `strlen()` on `pdf_to_text_string()` exactly as the current immutable implementation does. The returned `contents_utf8` is private/borrowed and may only be copied immediately by callers.
+`read_view()` receives a caller-computed `page_ctm`; it must not recompute page transform for each annotation. It zero-initializes all output fields and maps normalized PDF Rect to normalized Fitz bounds with `fz_transform_rect(raw, page_ctm)`.
 
-- [ ] **Step 3: Rewrite immutable enumeration to consume the shared view**
+The returned Contents pointer is private/borrowed and must be copied before leaving the current MuPDF access scope.
 
-The first pass remains a raw `/Annots` scan using only `extractpdf_pdf_annotation_classify()`.
+- [ ] **Step 3: Rewrite immutable enumeration to use shared helpers**
 
-The second pass becomes equivalent to:
+First pass continues raw `/Annots` traversal and calls only `classify()`.
+
+Second pass computes `pdf_page_transform()` once, then:
 
 ```c
 extractpdf_pdf_annotation_view view;
 status = extractpdf_pdf_annotation_read_view(
-    ctx, pdf_page, annotation, type, &view);
+    ctx, annotation, type, page_ctm, &view);
 if (status != EXTRACTPDF_OK)
     break;
 
@@ -820,17 +784,34 @@ if (view.has_contents) {
 }
 ```
 
-Delete the duplicate static classify/Rect/F/Contents code from `pdf_annotations.c`.
+Delete the duplicate static classifier/Rect/F/Contents code from `src/pdf_annotations.c`.
 
-- [ ] **Step 4: Build and prove no enumeration regression**
+- [ ] **Step 4: Build every old target explicitly while mutation stays compile-RED**
 
 ```bash
-cmake --build build --parallel 2
-ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
-ctest --test-dir build --output-on-failure
+cmake --build build --parallel 2 --target \
+  extractpdf_test_status \
+  extractpdf_test_document \
+  extractpdf_test_render \
+  extractpdf_test_text \
+  extractpdf_test_structured_text \
+  extractpdf_test_text_search \
+  extractpdf_test_images \
+  extractpdf_test_image_bitmap \
+  extractpdf_test_links \
+  extractpdf_test_pdf_export \
+  extractpdf_test_pdf_range \
+  extractpdf_test_pdf_order \
+  extractpdf_test_pdf_delete \
+  extractpdf_test_pdf_merge \
+  extractpdf_test_output_file \
+  extractpdf_test_pdf_metadata \
+  extractpdf_test_pdf_outline \
+  extractpdf_test_pdf_annotations
+ctest --test-dir build -E '^extractpdf\.pdf_annotation_mutation$' --output-on-failure
 ```
 
-Expected: all existing 18 CTests pass. The mutation target remains the known compile RED until the public ABI is introduced; when building only existing targets, there is no behavior change.
+Expected: 18/18 old CTests pass. Do not run a full default build and misclassify the still-intentional mutation compile RED as a refactor regression.
 
 - [ ] **Step 5: Commit**
 
@@ -840,7 +821,7 @@ git add src/pdf_annotation_common.h src/pdf_annotation_common.c \
 git commit -m "refactor: share PDF annotation semantics"
 ```
 
-Reviewer gate: reject this task if any old annotation fixture changes meaning, if editor-specific behavior leaks into the common module, or if common helpers publish borrowed pointers through the public ABI.
+Reviewer rejects this task if any old annotation behavior changes or editor-specific state enters the common module.
 
 ---
 
@@ -857,12 +838,12 @@ Reviewer gate: reject this task if any old annotation fixture changes meaning, i
 - Modify: `CMakeLists.txt`
 
 **Interfaces:**
-- Consumes: `extractpdf_serialize_pdf()`, existing `extractpdf_output`, MuPDF 1.28.2 `pdf_document_from_fz_document`, `pdf_open_document_with_stream`, `pdf_disable_js`, `pdf_enable_journal`, `pdf_walk_tree`, signature helpers.
-- Produces: every approved public Mutation V1 symbol so the RED test binary links; lifecycle/begin/snapshot/drop and fail-closed policy are real, while annotation-specific calls may temporarily return `UNSUPPORTED` after correct output resets until Tasks 4-6.
+- Consumes: `extractpdf_serialize_pdf()`, private `extractpdf_output` bytes, MuPDF PDF document/stream/javascript/journal/signature APIs.
+- Produces: complete linkable public Mutation V1 ABI; real begin/snapshot/drop; annotation calls initially provide exact reset/validation shells and otherwise `UNSUPPORTED` until Tasks 4-6.
 
-- [ ] **Step 1: Add the exact public ABI**
+- [ ] **Step 1: Add exact public ABI**
 
-Append the new opaque handle near the other handles:
+Add to `include/extractpdf/extractpdf.h`:
 
 ```c
 typedef struct extractpdf_pdf_edit extractpdf_pdf_edit;
@@ -870,11 +851,7 @@ typedef struct extractpdf_pdf_edit extractpdf_pdf_edit;
 typedef struct extractpdf_annotation_ref {
     uint64_t opaque[2];
 } extractpdf_annotation_ref;
-```
 
-Add:
-
-```c
 typedef enum extractpdf_annotation_update_field {
     EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS = 1u << 0,
     EXTRACTPDF_ANNOTATION_UPDATE_FLAGS = 1u << 1,
@@ -900,15 +877,37 @@ typedef struct extractpdf_annotation_update {
 } extractpdf_annotation_update;
 ```
 
-Append to `extractpdf_status` without renumbering existing values:
+Append status value without renumbering old values:
 
 ```c
 EXTRACTPDF_ERROR_STATE = 8
 ```
 
-Add the nine approved functions exactly as written in the spec: begin, count, ref_at, get_info, contents, create, update, delete, snapshot, plus `extractpdf_drop_pdf_edit()`.
+Add exactly these public functions:
 
-- [ ] **Step 2: Add the stable status text**
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_begin(
+    extractpdf_document *, extractpdf_pdf_edit **);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_count(
+    extractpdf_pdf_edit *, int, size_t *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
+    extractpdf_pdf_edit *, int, size_t, extractpdf_annotation_ref *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_get_info(
+    extractpdf_pdf_edit *, const extractpdf_annotation_ref *, extractpdf_annotation_info *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_contents(
+    extractpdf_pdf_edit *, const extractpdf_annotation_ref *, char **, size_t *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_create(
+    extractpdf_pdf_edit *, int, const extractpdf_annotation_create_options *, extractpdf_annotation_ref *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_update(
+    extractpdf_pdf_edit *, const extractpdf_annotation_ref *, const extractpdf_annotation_update *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_delete(
+    extractpdf_pdf_edit *, const extractpdf_annotation_ref *);
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_snapshot(
+    extractpdf_pdf_edit *, extractpdf_output **);
+EXTRACTPDF_API void extractpdf_drop_pdf_edit(extractpdf_pdf_edit *);
+```
+
+- [ ] **Step 2: Add stable STATE string**
 
 In `src/status.c`:
 
@@ -917,7 +916,7 @@ case EXTRACTPDF_ERROR_STATE:
     return "invalid state";
 ```
 
-- [ ] **Step 3: Define private editor ownership**
+- [ ] **Step 3: Define private editor/registry/test-fault representation**
 
 Create `src/pdf_edit_internal.h`:
 
@@ -934,10 +933,19 @@ typedef struct extractpdf_pdf_edit_annotation_entry {
     int live;
 } extractpdf_pdf_edit_annotation_entry;
 
+#if defined(EXTRACTPDF_TESTING)
+enum {
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE = 0,
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_FIRST_UPDATE_FIELD = 1,
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_CREATE_MUTATION = 2,
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_SNAPSHOT_BEFORE_PUBLISH = 3
+};
+#endif
+
 struct extractpdf_pdf_edit {
     fz_context *ctx;
     pdf_document *document;
-    extractpdf_output *seed_output; /* owns bytes backing the private input stream */
+    extractpdf_output *seed_output;
     uint64_t session_cookie;
     extractpdf_pdf_edit_annotation_entry *entries;
     size_t entry_count;
@@ -947,66 +955,39 @@ struct extractpdf_pdf_edit {
 #endif
 };
 
-extractpdf_status extractpdf_pdf_edit_load_page(
-    extractpdf_pdf_edit *edit, int page_index, pdf_page **out_page);
-
 #endif
 ```
 
-Do not put editor state into `struct extractpdf_document`.
+The test header and private enum intentionally share numeric values but not a header dependency from `src/` to `tests/`.
 
-- [ ] **Step 4: Implement signed-field scanning without loading widgets or executing actions**
+- [ ] **Step 4: Implement signed-field scan without widget/event execution**
 
-In `src/pdf_edit.c`, use `pdf_walk_tree()` on `Root/AcroForm/Fields` with inherited `/FT`. The arrive callback checks signature fields with `pdf_signature_is_signed()` and sets a local flag. It must not enable JavaScript or dispatch events.
+In `src/pdf_edit.c`, walk `Root/AcroForm/Fields` using `pdf_walk_tree()` and inherited `/FT`. For a `/Sig` field call `pdf_signature_is_signed(ctx, document, field)`. A found signed field is enough to reject the source. Do not load widgets, enable JS, or dispatch events for this scan.
 
-Equivalent private callback shape:
+- [ ] **Step 5: Implement atomic `extractpdf_pdf_edit_begin()`**
 
-```c
-typedef struct extractpdf_signed_scan {
-    pdf_document *document;
-    int found;
-} extractpdf_signed_scan;
-
-static void scan_signed_field(
-    fz_context *ctx, pdf_obj *field, void *arg, pdf_obj **inherited)
-{
-    extractpdf_signed_scan *scan = arg;
-    pdf_obj *ft = pdf_dict_get(ctx, field, PDF_NAME(FT));
-    if (ft == NULL)
-        ft = inherited[0];
-    if (!scan->found && pdf_name_eq(ctx, ft, PDF_NAME(Sig)) &&
-        pdf_signature_is_signed(ctx, scan->document, field))
-        scan->found = 1;
-}
-```
-
-Use `pdf_walk_tree()`'s cycle/depth protection rather than writing recursive unbounded traversal.
-
-- [ ] **Step 5: Implement `extractpdf_pdf_edit_begin()` atomically**
-
-Required sequence:
+Required order:
 
 ```text
 reset *out_edit
 validate source internals
-pdf_document_from_fz_document -> NULL means UNSUPPORTED
-raw trailer /Encrypt present -> UNSUPPORTED
-signed field scan -> signed means UNSUPPORTED
-serialize source with extractpdf_serialize_pdf() into seed_output
-allocate editor
-new independent fz_context
-set discard warning/error callbacks
-fz_open_memory(seed_output->data, seed_output->size)
-pdf_open_document_with_stream()
-pdf_disable_js()
-pdf_enable_journal()
-create nonzero private session cookie
-publish editor
+pdf_document_from_fz_document -> NULL => UNSUPPORTED
+raw trailer /Encrypt present => UNSUPPORTED
+signed-field scan => signed => UNSUPPORTED
+extractpdf_serialize_pdf(source ctx/pdf) -> seed_output
+allocate edit
+new independent fz_context + discard callbacks
+fz_open_memory(seed_output bytes)
+pdf_open_document_with_stream
+pdf_disable_js
+pdf_enable_journal
+create nonzero session_cookie
+publish edit
 ```
 
-Keep `seed_output` alive for the whole editor lifetime because the private PDF stream may continue reading its memory after open. Drop the local stream reference after `pdf_open_document_with_stream()` because the PDF document keeps its own stream reference.
+Keep `seed_output` alive for the whole editor lifetime because the private document's input stream may reference its memory.
 
-Generate `session_cookie` with editor-local data only; no global counter. A suitable private mix is:
+Use a private 64-bit mixer:
 
 ```c
 static uint64_t mix64(uint64_t x)
@@ -1020,73 +1001,96 @@ static uint64_t mix64(uint64_t x)
 }
 ```
 
-Mix `uintptr_t(edit)`, `uintptr_t(edit->ctx)`, and bytes from `fz_memrnd(edit->ctx, ...)`; force zero to a nonzero constant. This token is an opaque session discriminator, not a cryptographic authentication promise and exposes no PDF identity.
+Build the nonzero session discriminator from editor/context addresses, `time(NULL)`, `clock()`, and eight bytes from editor-local `fz_memrnd()`. This is an opaque session discriminator, not a cryptographic authentication boundary; no mutable global counter/state is introduced.
 
-Every caught MuPDF exception maps through `extractpdf_status_from_mupdf()` and tears down all partial editor state before return.
+Any exception tears down all partial state and maps through `extractpdf_status_from_mupdf()`.
 
-- [ ] **Step 6: Implement non-consuming baseline snapshot/drop**
+- [ ] **Step 6: Implement non-consuming snapshot with MuPDF's snapshot writer**
 
-`extractpdf_pdf_edit_snapshot()`:
+Do **not** call the existing full-finalizing `extractpdf_serialize_pdf()` on the live edit document. MuPDF 1.28.2 provides `pdf_write_snapshot()`, specifically documented to avoid finalizing the in-memory incremental xref.
 
-```c
-extractpdf_output *result = NULL;
-if (out_output == NULL)
-    return EXTRACTPDF_ERROR_ARGUMENT;
-*out_output = NULL;
-if (edit == NULL || edit->ctx == NULL || edit->document == NULL)
-    return EXTRACTPDF_ERROR_ARGUMENT;
-status = extractpdf_serialize_pdf(edit->ctx, edit->document, &result);
-if (status != EXTRACTPDF_OK)
-    return status;
-#if defined(EXTRACTPDF_TESTING)
-if (edit->test_fault == EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH) {
-    edit->test_fault = EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE;
-    extractpdf_drop_output(result);
-    return EXTRACTPDF_ERROR_MUPDF;
-}
-#endif
-*out_output = result;
-return EXTRACTPDF_OK;
-```
-
-`extractpdf_drop_pdf_edit()` drops all kept registry objects, registry storage, private PDF document, private context, and `seed_output`; NULL is a no-op. Drop the PDF document before the context and drop `seed_output` only after the PDF document no longer references its memory stream.
-
-- [ ] **Step 7: Add linkable annotation API shells with correct reset semantics**
-
-In `src/pdf_edit_annotations.c`, define all remaining public mutation functions so the test binary links. At this task they may return `EXTRACTPDF_ERROR_UNSUPPORTED` after required pointer/reset/`struct_size` checks when passed an otherwise valid editor. Do not fake discovery or CRUD success.
-
-Examples:
+In `src/pdf_edit.c`, implement a private buffer materializer:
 
 ```c
-extractpdf_status extractpdf_pdf_edit_annotation_count(
-    extractpdf_pdf_edit *edit, int page_index, size_t *out_count)
+static extractpdf_status snapshot_pdf(
+    extractpdf_pdf_edit *edit,
+    extractpdf_output **out_output)
 {
-    if (out_count != NULL)
-        *out_count = 0;
-    if (edit == NULL || out_count == NULL || page_index < 0)
-        return EXTRACTPDF_ERROR_ARGUMENT;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
-}
+    fz_buffer *buffer = NULL;
+    fz_output *memory_output = NULL;
+    unsigned char *data = NULL;
+    size_t size = 0;
+    extractpdf_output *result = NULL;
+    int caught = FZ_ERROR_NONE;
 
-extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
-    extractpdf_pdf_edit *edit, int page_index, size_t index,
-    extractpdf_annotation_ref *out_ref)
-{
-    (void)index;
-    if (out_ref != NULL)
-        memset(out_ref, 0, sizeof(*out_ref));
-    if (edit == NULL || out_ref == NULL || page_index < 0)
-        return EXTRACTPDF_ERROR_ARGUMENT;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    *out_output = NULL;
+    fz_var(buffer);
+    fz_var(memory_output);
+    fz_var(data);
+    fz_var(size);
+    fz_var(caught);
+
+    fz_try(edit->ctx) {
+        buffer = fz_new_buffer(edit->ctx, 0);
+        memory_output = fz_new_output_with_buffer(edit->ctx, buffer);
+        pdf_write_snapshot(edit->ctx, edit->document, memory_output);
+        fz_close_output(edit->ctx, memory_output);
+        size = fz_buffer_storage(edit->ctx, buffer, &data);
+    }
+    fz_catch(edit->ctx) {
+        caught = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+    if (caught != FZ_ERROR_NONE) {
+        if (memory_output != NULL) fz_drop_output(edit->ctx, memory_output);
+        if (buffer != NULL) fz_drop_buffer(edit->ctx, buffer);
+        return extractpdf_status_from_mupdf(caught);
+    }
+    if (data == NULL || size == 0) {
+        fz_drop_output(edit->ctx, memory_output);
+        fz_drop_buffer(edit->ctx, buffer);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+
+    result = calloc(1, sizeof(*result));
+    if (result == NULL) {
+        fz_drop_output(edit->ctx, memory_output);
+        fz_drop_buffer(edit->ctx, buffer);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    result->data = malloc(size);
+    if (result->data == NULL) {
+        free(result);
+        fz_drop_output(edit->ctx, memory_output);
+        fz_drop_buffer(edit->ctx, buffer);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    memcpy(result->data, data, size);
+    result->size = size;
+    fz_drop_output(edit->ctx, memory_output);
+    fz_drop_buffer(edit->ctx, buffer);
+    *out_output = result;
+    return EXTRACTPDF_OK;
 }
 ```
 
-- [ ] **Step 8: Add the private per-editor deterministic fault hook**
+`extractpdf_pdf_edit_snapshot()` resets output, validates edit, calls this helper, then under `EXTRACTPDF_TESTING` consumes `SNAPSHOT_BEFORE_PUBLISH` by dropping the just-created result and returning `EXTRACTPDF_ERROR_MUPDF`. Otherwise publish result.
+
+The same-state byte-identity RED test is the acceptance proof that the pinned snapshot writer is deterministic for this editor model; do not weaken that assertion.
+
+- [ ] **Step 7: Implement drop and exact annotation API shells**
+
+`extractpdf_drop_pdf_edit()` drops every kept registry object, registry allocation, private PDF document, private context, and finally `seed_output`; NULL is no-op. Drop document before context and seed bytes only after document no longer references its input stream.
+
+Define all annotation functions in `src/pdf_edit_annotations.c` so the test executable links. At this task they must implement exact output reset/pointer/`struct_size` validation and otherwise return `UNSUPPORTED` for a valid editor until the corresponding later task.
+
+- [ ] **Step 8: Add per-editor test fault hook**
 
 In `tests/CMakeLists.txt`:
 
 ```cmake
-target_sources(extractpdf PRIVATE pdf_edit_fault_hook.c)
+target_sources(extractpdf PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/pdf_edit_fault_hook.c")
 target_compile_definitions(extractpdf PRIVATE EXTRACTPDF_TESTING=1)
 ```
 
@@ -1110,7 +1114,7 @@ void extractpdf_test_pdf_edit_set_fault(
 }
 ```
 
-Because this source is added to the library only from the tests subdirectory, the hook is not part of test-disabled production builds or the installed public header. Fault state is per editor, satisfying the no-global-state constraint.
+Production sources compare `edit->test_fault` only against the private `EXTRACTPDF_PDF_EDIT_TEST_FAULT_*` constants, never identifiers from `tests/pdf_edit_test_api.h`.
 
 - [ ] **Step 9: Register production sources and run lifecycle groups**
 
@@ -1122,19 +1126,21 @@ src/pdf_edit.c
 src/pdf_edit_annotations.c
 ```
 
-Run:
+Then:
 
 ```bash
-cmake -S . -B build ...same pinned-vcpkg args...
+rm -rf build
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DVCPKG_OVERLAY_PORTS="$PWD/vcpkg-ports" \
+  -DBUILD_SHARED_LIBS=OFF
 cmake --build build --parallel 2
 ./build/tests/extractpdf_test_pdf_annotation_mutation arguments
 ./build/tests/extractpdf_test_pdf_annotation_mutation begin
-./build/tests/extractpdf_test_pdf_annotation_mutation javascript
 ```
 
-Expected: `arguments`, `begin`, and baseline `javascript` pass. Discovery/CRUD groups are still behavioral RED (`UNSUPPORTED`) and must not be claimed GREEN yet.
-
-If two baseline snapshots with no mutation are not byte-identical, stop this task and fix `snapshot()` without weakening the spec; direct `pdf_write_document()` use is acceptable only if the unchanged-state determinism/non-consuming tests pass.
+Expected: `arguments` and `begin` pass. Discovery/CRUD groups remain behavioral RED because their shells return `UNSUPPORTED`.
 
 - [ ] **Step 10: Commit**
 
@@ -1147,7 +1153,7 @@ git commit -m "feat: add isolated PDF editor lifecycle"
 
 ---
 
-### Task 4: Implement discovery, canonical session refs, and live getters
+### Task 4: Implement discovery, canonical refs, and live getters
 
 **Files:**
 - Modify: `src/pdf_edit_internal.h`
@@ -1155,20 +1161,20 @@ git commit -m "feat: add isolated PDF editor lifecycle"
 - Test: `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: shared `extractpdf_pdf_annotation_classify/read_view`, private editor PDF.
-- Produces: real count/ref_at/get_info/contents behavior and canonical session refs that survive index shifts.
+- Consumes: shared annotation classifier/view and private editor PDF.
+- Produces: real count/ref_at/get_info/contents plus canonical refs that survive index shifts.
 
-- [ ] **Step 1: Run the focused failing discovery group**
+- [ ] **Step 1: Run focused failing discovery group**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation discovery
 ```
 
-Expected: FAIL because count/ref_at/getters still return `UNSUPPORTED`.
+Expected: fail on current `UNSUPPORTED` shells.
 
-- [ ] **Step 2: Add identity comparison and registry reserve helpers**
+- [ ] **Step 2: Add private identity and registry-capacity helpers**
 
-Registry entries keep a private `pdf_obj *` reference and page index. Compare indirect objects by private object number+generation and direct dictionaries by object pointer; never compare dictionary contents, because two distinct annotations may be value-equal.
+Compare private annotation identity exactly:
 
 ```c
 static int same_pdf_identity(fz_context *ctx, pdf_obj *a, pdf_obj *b)
@@ -1183,37 +1189,37 @@ static int same_pdf_identity(fz_context *ctx, pdf_obj *a, pdf_obj *b)
 }
 ```
 
-`reserve_entries(edit, needed)` must overflow-check `SIZE_MAX / sizeof(entry)` and allocate before any operation that cannot safely fail afterward.
+Never compare dictionary contents. `reserve_entries()` overflow-checks allocation and runs before an operation that cannot tolerate a later allocation failure.
 
-- [ ] **Step 3: Canonicalize one ref per annotation object**
+- [ ] **Step 3: Define canonical token encoding and validation**
 
-Before allocating a new slot, search all registry entries for the same private identity. If found live, return its existing token. Never recycle a tombstoned slot during the edit session.
+Never recycle a tombstoned slot. Repeated acquisition of a live object returns its existing slot/token.
 
-Token layout is private but concrete:
+Concrete token layout:
 
 ```text
 opaque[0] = edit->session_cookie
 opaque[1] = (uint64_t(entry->tag) << 32) | uint64_t(slot + 1)
 ```
 
-Limit registry slots to `UINT32_MAX - 1`; exceeding that is `NOMEM`. Generate a nonzero 32-bit `tag` from the editor-local random/mix helper.
+Maximum slots: `UINT32_MAX - 1`; exceeding it is `NOMEM`.
 
-Resolution checks, in order:
+Derive `entry->tag` deterministically from `mix64(edit->session_cookie ^ (slot + 1))`, force zero to `1`; no second random/global state is required.
+
+Resolution order:
 
 ```text
-NULL edit/ref                       ARGUMENT
-opaque[0] != session_cookie         ARGUMENT
-slot field == 0/out of range        ARGUMENT
-tag mismatch                        ARGUMENT
-matching entry live==0              STATE
-matching live entry                 OK
+NULL edit/ref                        ARGUMENT
+opaque[0] != session_cookie          ARGUMENT
+encoded slot 0/out of range          ARGUMENT
+tag mismatch                         ARGUMENT
+matching slot with live==0           STATE
+matching live entry                  OK
 ```
 
-- [ ] **Step 4: Scan and validate a whole page before returning count/ref**
+- [ ] **Step 4: Scan and validate the entire requested page before publication**
 
-Implement a private scanner that loads `pdf_page`, reads raw `/Annots`, filters via shared classify, and calls shared strict `read_view()` for **every survivor**. It records count and optionally keeps the object at one requested survivor index only after the entire scan succeeds.
-
-Pseudo-interface:
+Implement:
 
 ```c
 static extractpdf_status scan_page(
@@ -1225,25 +1231,56 @@ static extractpdf_status scan_page(
     pdf_obj **out_object);
 ```
 
-On malformed later survivor, return `FORMAT` and publish/register nothing from the prefix.
+Sequence:
+
+```text
+validate page index with pdf_count_pages
+pdf_load_page
+pdf_page_transform once
+raw page->obj /Annots walk
+non-dict skip
+shared classify: Link/Popup/Widget skip; other dict survives
+shared read_view for EVERY survivor
+only after whole scan succeeds keep wanted object
+release page
+publish count/object
+```
+
+A malformed late survivor returns `FORMAT`; it publishes no new object/ref from the prefix.
 
 - [ ] **Step 5: Implement count/ref_at**
 
-`count()` resets output, validates page range using `pdf_count_pages`, scans the full page, and publishes count only on success.
+`count()` resets output and publishes the scanned count only on complete success.
 
-`ref_at()` zeros token, scans/validates the full page, rejects `index >= count`, then canonical-registers the wanted object and publishes the token.
+`ref_at()` zeros output, scans/validates the complete page, checks `index < count`, then either finds the existing canonical registry entry or appends one kept private `pdf_obj *` and publishes its token.
 
-- [ ] **Step 6: Implement getters from ref**
+- [ ] **Step 6: Resolve a ref to a live `pdf_page` + borrowed `pdf_annot`**
 
-Resolve the entry, load its page, confirm the object is still present as a surviving ordinary annotation on that page, then use shared `read_view()`.
+Do not return a `pdf_annot *` after its page is dropped because the annotation borrows its page pointer.
 
-`get_info()` preserves caller `struct_size`, validates the existing minimum size through `flags`, resets type/bounds/flags, and copies type/bounds/flags.
+Private resolver shape:
 
-`contents()` independently resets non-NULL outputs, requires both, and deep-copies the view string:
+```c
+static extractpdf_status resolve_live_annot(
+    extractpdf_pdf_edit *edit,
+    extractpdf_pdf_edit_annotation_entry *entry,
+    pdf_page **out_page,
+    pdf_annot **out_annot);
+```
+
+It loads `entry->page_index`, iterates `pdf_first_annot()/pdf_next_annot()`, compares `pdf_annot_obj()` to the kept registry object, and returns a borrowed annot while `*out_page` remains alive. Caller drops the page after all work. If the registry says live but object is no longer present, return `STATE`.
+
+- [ ] **Step 7: Implement live getters**
+
+`get_info()` validates minimum existing `extractpdf_annotation_info` size, preserves `struct_size`, resets known fields, resolves page/annot, computes one page CTM, calls shared `read_view()`, and copies type/bounds/flags.
+
+`contents()` independently resets non-NULL outputs, requires both outputs, resolves/read_view, and returns an allocated copy:
 
 ```c
 if (!view.has_contents)
     return EXTRACTPDF_OK;
+if (view.contents_size == SIZE_MAX)
+    return EXTRACTPDF_ERROR_NOMEM;
 copy = malloc(view.contents_size + 1);
 if (copy == NULL)
     return EXTRACTPDF_ERROR_NOMEM;
@@ -1252,9 +1289,7 @@ memcpy(copy, view.contents_utf8, view.contents_size + 1);
 *out_size = view.contents_size;
 ```
 
-If a registry entry is marked live but its object is no longer present because of an internal consistency change, return `EXTRACTPDF_ERROR_STATE` rather than silently retargeting another index.
-
-- [ ] **Step 7: Run focused and old-semantic tests**
+- [ ] **Step 8: Run discovery + immutable regression gates**
 
 ```bash
 cmake --build build --parallel 2
@@ -1262,9 +1297,9 @@ cmake --build build --parallel 2
 ctest --test-dir build -R '^extractpdf\.pdf_annotations$' --output-on-failure
 ```
 
-Expected: discovery group passes; immutable enumeration still passes unchanged.
+Expected: both pass.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
 git add src/pdf_edit_internal.h src/pdf_edit_annotations.c
@@ -1280,47 +1315,45 @@ git commit -m "feat: add annotation edit refs and discovery"
 - Test: `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: editor page loading, registry reserve/canonical publication, MuPDF journal/create/setter APIs.
-- Produces: atomic TEXT/FREE_TEXT/SQUARE/CIRCLE creation with immediate live ref.
+- Consumes: editor page loading, registry reserve/publish, MuPDF journal/create/setter APIs.
+- Produces: atomic TEXT/FREE_TEXT/SQUARE/CIRCLE create with immediate canonical live ref.
 
-- [ ] **Step 1: Run the focused failing create group**
+- [ ] **Step 1: Run focused failing create group**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation create
 ```
 
-Expected: FAIL because create still returns `UNSUPPORTED`.
+Expected: fail on create `UNSUPPORTED` shell.
 
 - [ ] **Step 2: Implement counted UTF-8 validation/copy**
 
-Add a private validator that rejects NUL and invalid UTF-8, including overlong encodings, UTF-16 surrogate code points, values above U+10FFFF, and truncated continuations. Accept ASCII plus canonical 2/3/4-byte sequences.
-
-Use these byte ranges:
+Canonical accepted byte forms:
 
 ```text
-1 byte: 00..7F, except 00 is rejected by Contents policy
-2 byte: C2..DF 80..BF
-3 byte: E0 A0..BF 80..BF
+ASCII: 01..7F
+2-byte: C2..DF 80..BF
+3-byte: E0 A0..BF 80..BF
         E1..EC 80..BF 80..BF
         ED 80..9F 80..BF
         EE..EF 80..BF 80..BF
-4 byte: F0 90..BF 80..BF 80..BF
+4-byte: F0 90..BF 80..BF 80..BF
         F1..F3 80..BF 80..BF 80..BF
         F4 80..8F 80..BF 80..BF
 ```
 
-For present input allocate `size + 1` with overflow check, copy exactly `size` bytes, append `\0`, and return the temporary C string. NULL/0 remains the absent marker and allocates nothing.
+Reject byte 00 anywhere in a present counted range, overlong sequences, surrogates, >U+10FFFF, and truncated/invalid continuations. For present data, overflow-check `size + 1`, allocate, copy exactly `size`, append NUL. NULL/0 is the absent marker and allocates nothing.
 
-- [ ] **Step 3: Validate creation inputs before mutation**
+- [ ] **Step 3: Validate create request before journal mutation**
 
-Minimum struct size is:
+Minimum size:
 
 ```c
 offsetof(extractpdf_annotation_create_options, contents_size) +
     sizeof(options->contents_size)
 ```
 
-Require valid page index, supported type, finite ordered bounds, and valid Contents tuple. Zero-width/height is accepted.
+Validate page index, supported type, finite ordered bounds, and Contents tuple. Allow zero-width/zero-height rectangles.
 
 Map only:
 
@@ -1331,11 +1364,9 @@ SQUARE    -> PDF_ANNOT_SQUARE
 CIRCLE    -> PDF_ANNOT_CIRCLE
 ```
 
-All other public types are `UNSUPPORTED`.
+All other types are `UNSUPPORTED`.
 
-- [ ] **Step 4: Implement full-uint32 `/F` writing**
-
-Add one private helper used by create and update:
+- [ ] **Step 4: Implement full-uint32 flag writer**
 
 ```c
 static void set_annot_flags_u32(
@@ -1344,46 +1375,46 @@ static void set_annot_flags_u32(
     if (flags <= (uint32_t)INT_MAX) {
         pdf_set_annot_flags(ctx, annot, (int)flags);
     } else {
-        pdf_obj *obj = pdf_annot_obj(ctx, annot);
-        pdf_dict_put_int(ctx, obj, PDF_NAME(F), (int64_t)(uint64_t)flags);
-        pdf_annot_request_resynthesis(ctx, annot);
+        pdf_dict_put_int(
+            ctx,
+            pdf_annot_obj(ctx, annot),
+            PDF_NAME(F),
+            (int64_t)(uint64_t)flags);
     }
 }
 ```
 
-Do not cast `UINT32_MAX` through signed `int`.
+This mirrors the low-range setter's dictionary result without signed narrowing. The enclosing public operation and later `pdf_update_annot()` provide the same mutation/appearance boundary.
 
-- [ ] **Step 5: Create inside one outer journal operation**
+- [ ] **Step 5: Implement create inside one outer journal operation**
 
-Before `pdf_begin_operation()`, reserve one registry slot so no registry allocation is needed after a successful PDF operation.
+Reserve registry capacity before `pdf_begin_operation()`.
 
-Inside `fz_try`:
-
-```c
-pdf_begin_operation(ctx, edit->document, "ExtractPDF create annotation");
-annot = pdf_create_annot(ctx, page, mupdf_type);
-pdf_set_annot_rect(ctx, annot, public_bounds);
-set_annot_flags_u32(ctx, annot, options->flags);
-if (options->contents_utf8 != NULL)
-    pdf_set_annot_contents(ctx, annot, temporary_nul_terminated_text);
-pdf_update_annot(ctx, annot);
+```text
+begin outer operation
+pdf_create_annot
+set Rect
+set full-u32 flags
+set Contents only when present
+pdf_update_annot
+optional deterministic test fault before outer end
+pdf_end_operation
+fill pre-reserved registry slot from pdf_annot_obj
+publish token
 ```
 
-Under test builds, if fault `AFTER_CREATE_MUTATION` is armed, clear it and `fz_throw(ctx, FZ_ERROR_GENERIC, "ExtractPDF test create fault")` before `pdf_end_operation()`.
+Under `EXTRACTPDF_TESTING`, `AFTER_CREATE_MUTATION` clears itself and throws `FZ_ERROR_GENERIC` before `pdf_end_operation()`.
 
-On normal success, call `pdf_end_operation()` first, then fill the already-reserved registry entry from `pdf_annot_obj()` and publish the token. `pdf_keep_obj()` is only a refcount increment and must not introduce an allocation/publication failure after commit.
+On exception: `pdf_abandon_operation()`, drop owned annot/page/temp Contents, leave output ref zero, and do not increment registry count.
 
-On exception, call `pdf_abandon_operation()`, drop the returned annot reference, free temporary Contents, and leave `out_ref` zero.
-
-- [ ] **Step 6: Run create + full flags seed checks**
+- [ ] **Step 6: Run create group and create-rollback assertions**
 
 ```bash
 cmake --build build --parallel 2
 ./build/tests/extractpdf_test_pdf_annotation_mutation create
-./build/tests/extractpdf_test_pdf_annotation_mutation contents-flags
 ```
 
-At this point the create assertions should pass. The contents-flags group may still fail on update-specific assertions; the pre-existing high-bit `/F` getter assertion must already pass.
+Expected: all four create types pass, Highlight/UNKNOWN create are `UNSUPPORTED`, injected create failure leaves count unchanged and output ref zero.
 
 - [ ] **Step 7: Commit**
 
@@ -1394,15 +1425,15 @@ git commit -m "feat: create Rect-based PDF annotations"
 
 ---
 
-### Task 6: Implement partial update, delete, and deterministic rollback
+### Task 6: Implement partial update, delete, Contents ownership, and rollback
 
 **Files:**
 - Modify: `src/pdf_edit_annotations.c`
 - Test: `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: canonical refs, UTF-8 helper, full-u32 flags helper, MuPDF journal/setter/delete APIs, private test fault.
-- Produces: atomic partial update/delete with tombstone semantics.
+- Consumes: canonical refs, UTF-8 helper, full-u32 flags helper, journal/setter/delete APIs, per-editor fault.
+- Produces: atomic partial update/delete, tombstones, exact Contents presence semantics, full-u32 round-trip.
 
 - [ ] **Step 1: Run focused failing groups**
 
@@ -1411,59 +1442,62 @@ git commit -m "feat: create Rect-based PDF annotations"
 ./build/tests/extractpdf_test_pdf_annotation_mutation contents-flags
 ```
 
-Expected: update/delete behavior is still RED.
+Expected: fail on current update/delete shells.
 
-- [ ] **Step 2: Validate the whole update request before opening the operation**
+- [ ] **Step 2: Validate entire update request before mutation**
 
-Require non-NULL edit/ref/update and minimum struct size through `contents_size`. Resolve the ref first.
-
-Then:
+Minimum size is through `contents_size`. Resolve ref **before** zero-field no-op handling.
 
 ```c
 const uint32_t known =
     EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
     EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
     EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+
 if (update->fields & ~known)
     return EXTRACTPDF_ERROR_ARGUMENT;
 if (update->fields == 0)
     return EXTRACTPDF_OK;
 ```
 
-This ordering is mandatory: wrong-session zero-mask -> `ARGUMENT`, tombstone zero-mask -> `STATE`, live UNKNOWN zero-mask -> `OK`.
+Then:
 
-For nonzero fields, UNKNOWN -> `UNSUPPORTED`. BOUNDS on anything except TEXT/FREE_TEXT/SQUARE/CIRCLE -> `UNSUPPORTED`. Prevalidate bounds and Contents before mutation.
+```text
+UNKNOWN + nonzero fields -> UNSUPPORTED
+BOUNDS on non Text/FreeText/Square/Circle -> UNSUPPORTED
+requested bounds -> validate finite/ordered
+requested Contents -> validate tuple/UTF-8 and allocate temp C string before operation
+```
 
-- [ ] **Step 3: Implement absent/present Contents mutation**
+- [ ] **Step 3: Preserve absent versus present-empty Contents**
 
 Present string uses `pdf_set_annot_contents()`.
 
-Removing `/Contents` must be journalled directly:
+Removal uses:
 
 ```c
-pdf_obj *obj = pdf_annot_obj(ctx, annot);
-pdf_dict_del(ctx, obj, PDF_NAME(Contents));
+pdf_dict_del(ctx, pdf_annot_obj(ctx, annot), PDF_NAME(Contents));
 pdf_annot_request_resynthesis(ctx, annot);
 ```
 
-This preserves absent versus present-empty instead of converting removal into an empty string.
+Do not turn removal into `pdf_set_annot_contents(annot, "")`.
 
-- [ ] **Step 4: Apply updates in fixed order inside one outer operation**
+- [ ] **Step 4: Apply fixed-order update atomically**
 
-Use fixed private order BOUNDS -> FLAGS -> CONTENTS. After each actually applied field increment `applied_fields`. When the test fault `AFTER_FIRST_UPDATE_FIELD` is armed and `applied_fields == 1`, clear it and throw before applying later fields.
+Order: BOUNDS -> FLAGS -> CONTENTS. After each requested field increments `applied_fields`; when `AFTER_FIRST_UPDATE_FIELD` is armed and `applied_fields == 1`, clear it and throw before the next field.
 
-After all requested setters/raw edits:
+After all fields:
 
 ```c
 pdf_update_annot(ctx, annot);
 pdf_end_operation(ctx, edit->document);
 ```
 
-Any exception calls `pdf_abandon_operation()` and returns mapped error. The registry is unchanged by update.
+Any exception abandons the outer operation and leaves registry state untouched.
 
-- [ ] **Step 5: Implement delete + tombstone only after success**
+- [ ] **Step 5: Implement delete and tombstone only after successful PDF delete**
 
-Resolve ref and locate the current `pdf_annot *` by private object identity on its page. UNKNOWN delete is `UNSUPPORTED`; every recognized ordinary subtype is allowed.
+Resolve the live ref to page/annot. UNKNOWN is `UNSUPPORTED`; any recognized ordinary annotation is deletable.
 
 ```c
 pdf_begin_operation(ctx, edit->document, "ExtractPDF delete annotation");
@@ -1472,11 +1506,9 @@ pdf_end_operation(ctx, edit->document);
 entry->live = 0;
 ```
 
-If delete throws, abandon and leave `entry->live == 1`.
+On exception abandon and keep `entry->live == 1`. Never recycle that slot. Associated Popup removal performed by MuPDF is accepted internal consistency behavior.
 
-Do not recycle the slot. Associated Popup cleanup remains MuPDF internal behavior.
-
-- [ ] **Step 6: Run rollback/tombstone/index-shift tests**
+- [ ] **Step 6: Run update/delete/Contents/full-u32 tests**
 
 ```bash
 cmake --build build --parallel 2
@@ -1487,103 +1519,104 @@ cmake --build build --parallel 2
 Expected:
 
 ```text
-failed two-field update -> old bounds + old Contents both remain
-failed create fault     -> count unchanged + zero ref
-delete Text              -> Text ref STATE
-Square index shifts      -> old Square ref still targets Square
-Highlight bounds         -> UNSUPPORTED
-Highlight flags/content  -> succeeds
-UINT32_MAX flags         -> round-trip unchanged
-invalid UTF-8/NUL        -> ARGUMENT before mutation
+failed multi-field update restores all fields
+Text tombstone returns STATE from get/info/contents/update/delete
+Square ref remains stable after Text deletion shifts index
+Highlight bounds UNSUPPORTED, generic flags/Contents OK
+live UNKNOWN zero-mask OK
+wrong-session zero-mask ARGUMENT
+tombstone zero-mask STATE
+raw 2147483649 and UINT32_MAX round-trip exactly
+counted non-NUL-terminated input works
+owned getter string survives later edit mutation
+absent vs present-empty preserved
+invalid UTF-8 / embedded NUL / NULL+nonzero rejected before mutation
 ```
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add src/pdf_edit_annotations.c
+git add src/pdf_edit_annotations.c tests/test_pdf_annotation_mutation.c
 git commit -m "feat: atomically update and delete annotations"
 ```
 
 ---
 
-### Task 7: Prove source isolation, snapshot isolation, output reparse, and JavaScript non-execution
+### Task 7: Prove snapshot/source isolation and JavaScript non-execution through public outputs
 
 **Files:**
-- Modify if verification exposes an implementation defect: `src/pdf_edit.c`
-- Modify if verification exposes a mutation defect: `src/pdf_edit_annotations.c`
-- Test: `tests/test_pdf_annotation_mutation.c`
+- Modify only if a real defect is exposed: `src/pdf_edit.c`, `src/pdf_edit_annotations.c`, `tests/test_pdf_annotation_mutation.c`
 
 **Interfaces:**
-- Consumes: complete editor/ref/CRUD behavior.
-- Produces: final public semantic proof before all-suite GREEN.
+- Consumes: completed lifecycle/discovery/CRUD implementation.
+- Produces: final semantic proof before all-suite GREEN.
 
-- [ ] **Step 1: Run snapshot group before changing production code**
+- [ ] **Step 1: Run snapshot group unchanged**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation snapshot
 ```
 
-Expected after Tasks 3-6: PASS. If it fails, treat the failure as a product bug; do not weaken byte-identity, source-isolation, or non-consuming assertions.
+Expected: pass. Failure is a product defect; do not weaken same-state byte identity, source isolation, output independence, or non-consuming assertions.
 
-- [ ] **Step 2: Confirm immutable source state survives editor mutation**
+- [ ] **Step 2: Require retained source snapshot to stay original after source close + editor mutation**
 
-The test must hold an `extractpdf_annotation_page` from the source before `edit_begin`, close source after begin, mutate the editor, and then verify the old source snapshot remains:
+Verify through retained immutable snapshot:
 
 ```text
-TEXT
-original Fitz bounds [10,160,30,180]
+Text type
+Fitz bounds 10,160,30,180
 flags 2147483649
-Contents "text-a"
+Contents text-a
 ```
 
-No source handle is kept alive merely to make this pass.
+No source handle remains open solely for this assertion.
 
-- [ ] **Step 3: Confirm snapshot A/B semantics through only public reparse APIs**
+- [ ] **Step 3: Reparse snapshots A and B only through public immutable APIs**
 
-Required checks are already in RED and must all pass:
+Required:
 
 ```text
-snapshot A == repeat snapshot bytes when no mutation intervenes
-A stays byte-identical after later mutation
-B differs after later mutation
-A reparse immutable enumeration -> old Contents
-B reparse immutable enumeration -> new Contents
-snapshot does not invalidate Text ref
-failed snapshot fault returns NULL output
-failed snapshot leaves editor/ref usable
-output remains valid after drop editor
+A bytes == repeat bytes with no mutation
+A bytes remain unchanged after mutation
+B contains later mutation
+A reparse -> text-a
+B reparse -> snapshot-b
+existing Text ref stays valid after snapshots
+outputs remain valid after editor drop
 ```
 
-If direct `extractpdf_serialize_pdf(edit->document)` changes editor bookkeeping enough to violate these tests, do not special-case the assertions. Introduce a private serialization strategy that preserves the editor's observable state and keep the public contract unchanged.
+- [ ] **Step 4: Prove failed snapshot does not consume/corrupt editor**
 
-- [ ] **Step 4: Run JavaScript group after CRUD/appearance paths exist**
+Arm `SNAPSHOT_BEFORE_PUBLISH`, require non-OK + NULL output, then update Contents to `after-failed-snapshot`, read it through the same ref, snapshot again, reparse, and require the new value. This proves post-failure mutation and publication both remain usable.
+
+- [ ] **Step 5: Run JavaScript group after real appearance path exists**
 
 ```bash
 ./build/tests/extractpdf_test_pdf_annotation_mutation javascript
 ```
 
-Extend the group to perform one Text Contents update before snapshot, so `pdf_update_annot()` is exercised. Reparsed metadata Title must remain `SAFE`, never `EXECUTED`.
+The group performs a Text Contents update, snapshots, reparses metadata, and requires Title `SAFE`. Any `EXECUTED` result is a blocker.
 
-- [ ] **Step 5: Verify outputs with immutable annotation enumeration**
-
-The test must not use raw MuPDF objects to prove the core result. `extractpdf_open` + `extractpdf_load_page` + `extractpdf_extract_annotations` is the acceptance surface for created/updated/deleted results and full `uint32_t` flags.
-
-- [ ] **Step 6: Run the complete mutation executable**
+- [ ] **Step 6: Run full mutation executable**
 
 ```bash
+cmake --build build --parallel 2
 ./build/tests/extractpdf_test_pdf_annotation_mutation
 ```
 
-Expected: PASS with all named groups.
+Expected: all groups pass.
 
-- [ ] **Step 7: Commit only if this task required production/test corrections**
+- [ ] **Step 7: Commit only real corrections**
+
+If Step 1-6 required changes:
 
 ```bash
 git add src/pdf_edit.c src/pdf_edit_annotations.c tests/test_pdf_annotation_mutation.c
 git commit -m "test: lock PDF annotation editor isolation"
 ```
 
-If no file changed, do not create an empty commit.
+If no files changed, create no empty commit.
 
 ---
 
@@ -1591,13 +1624,13 @@ If no file changed, do not create an empty commit.
 
 **Files:**
 - No planned feature expansion.
-- Modify only files already in the approved scope if a real portability/compiler defect is found.
+- Modify only approved-scope files if a real compiler/portability defect is found.
 
 **Interfaces:**
-- Consumes: all prior tasks.
+- Consumes: Tasks 1-7.
 - Produces: merge-ready exact-head evidence; does not merge.
 
-- [ ] **Step 1: Fresh Linux static build and all CTests**
+- [ ] **Step 1: Fresh Linux static build + all CTests**
 
 ```bash
 rm -rf build
@@ -1610,9 +1643,9 @@ cmake --build build --parallel 2
 ctest --test-dir build --output-on-failure
 ```
 
-Expected: **19/19 CTests pass**, with `extractpdf.pdf_annotation_mutation` present as the new test.
+Expected: **19/19 CTests pass**.
 
-- [ ] **Step 2: Fresh Linux ASan/UBSan build and all CTests**
+- [ ] **Step 2: Fresh Linux ASan/UBSan + all CTests**
 
 ```bash
 rm -rf build-asan
@@ -1627,11 +1660,9 @@ cmake --build build-asan --parallel 2
 ctest --test-dir build-asan --output-on-failure
 ```
 
-Expected: 19/19 pass with no sanitizer finding in ExtractPDF-owned editor/ref/string/registry code.
+Expected: 19/19, no sanitizer issue in editor/ref/string/registry code.
 
-- [ ] **Step 3: Exact-head diff review**
-
-Compare feature head against base `58525ce1b4b691ef53dfafc7c4e4d82753c966ba`.
+- [ ] **Step 3: Exact-head scope review**
 
 Allowed production paths:
 
@@ -1662,97 +1693,95 @@ tests/fixtures/annotation-mutation-unsigned-signature.pdf
 tests/fixtures/annotation-mutation-js.pdf
 ```
 
-No unrelated page/render/text/image/link/outline/metadata/composition/output-file changes are acceptable. `pdf_output.c` should remain unchanged unless a demonstrated snapshot-contract defect requires a narrowly reviewed serializer fix.
+No unrelated page/render/text/image/link/outline/metadata/composition/output-file change is acceptable.
 
-- [ ] **Step 4: Push final GREEN and capture Linux PR CI**
+- [ ] **Step 4: Push final GREEN and capture exact-head Linux PR CI**
 
-The normal PR synchronize run on the final exact SHA must pass Linux static + all CTests and Linux ASan/UBSan + all CTests. Update the draft PR body and #37 with:
+Normal PR synchronize on the final exact SHA must pass:
 
 ```text
-RED SHA + workflow
-first production GREEN SHA + workflow
-final exact SHA
-19/19 Linux static
-19/19 Linux ASan/UBSan
+Linux strict static build + 19/19 CTests
+Linux ASan/UBSan + 19/19 CTests
 ```
+
+Update draft PR and #37 with RED SHA/workflow, first production GREEN SHA/workflow, and final exact SHA.
 
 - [ ] **Step 5: Trigger same-head `full-ci`**
 
-Add label `full-ci` to the draft PR **only after the final exact SHA is fixed**. Because the workflow's macOS/Windows PR jobs run only on the labeled event, verify the labeled workflow uses the same final `head_sha`.
+Add `full-ci` only after final SHA is fixed. Verify labeled workflow `head_sha` equals that SHA.
 
 Acceptance:
 
 ```text
-Linux static + 19/19 CTests       success
-Linux ASan/UBSan + 19/19 CTests  success
-macOS build + 19/19 CTests        success
-Windows DLL build + 19/19 CTests success
+Linux static + 19/19                 success
+Linux ASan/UBSan + 19/19            success
+macOS configure/build/19/19         success
+Windows DLL configure/build/19/19   success
 ```
 
-Windows logs must explicitly show construction/linking of the new editor sources, `extractpdf_test_pdf_annotation_mutation.exe`, and `extractpdf.pdf_annotation_mutation` passing through the DLL configuration.
+Windows logs must show editor source compilation, `extractpdf_test_pdf_annotation_mutation.exe`, and `extractpdf.pdf_annotation_mutation` passing through the DLL build.
 
-- [ ] **Step 6: Final review gate**
+- [ ] **Step 6: Final exact-head review against every locked boundary**
 
-Review exact head against these locked boundaries:
+Review:
 
 ```text
 source immutability
-begin lifetime independence
-discovery semantic reuse
-ref canonicality + wrong-session + tombstone
+begin source-lifetime independence
+encrypted/signed fail-closed
+JavaScript disabled
+discovery semantic reuse + malformed atomicity
+canonical refs + wrong-session + tombstone + no slot reuse
 full uint32 flags
-Contents absent/empty/counting/UTF-8 ownership
+Contents absent/empty/counting/UTF-8/ownership
 create type matrix
-update/delete atomic rollback
-appearance before journal completion
+zero-field validation ordering
+update/create rollback
+appearance update before operation completion
 snapshot determinism/non-consumption/output independence
-encrypted + signed fail-closed
-JavaScript never executed
 no MuPDF/PDF identity in public ABI
 ```
 
-Any Critical/Important finding gets a new commit and invalidates the previous exact-head proof; rerun Linux and same-head full-ci after the fix.
+Any Critical/Important fix creates a new exact SHA and requires Linux + same-head full-ci proof again.
 
-- [ ] **Step 7: Mark PR ready only after evidence is complete**
+- [ ] **Step 7: Mark implementation/evidence complete, integration pending**
 
-Update PR/issue/roadmap bookkeeping to say **implementation/evidence complete; integration pending**. Do not merge as part of this task.
+Only after Step 1-6 pass, mark PR ready and update #37/roadmap to say implementation/evidence complete; integration pending. Do not merge in this task.
 
 ---
 
 ### Task 9: Explicit integration gate
 
 **Files:**
-- Bookkeeping only after successful merge/proof: PR #37 successor PR body, issue #37, roadmap #2.
+- Bookkeeping only after successful integration: PR, issue #37, roadmap #2.
 
 **Interfaces:**
-- Consumes: final reviewed exact-head full-ci evidence.
+- Consumes: proven exact-head full-ci from Task 8.
 - Produces: integrated master proof and closes #37.
 
-This task requires a separate explicit integration authorization after Task 8. A plan executor must stop before merge if that authorization has not been given.
+A plan executor must stop before this task until the user gives separate explicit integration authorization.
 
-- [ ] **Step 1: Re-fetch merge state immediately before merging**
+- [ ] **Step 1: Re-fetch merge state immediately before merge**
 
-Confirm:
+Require:
 
 ```text
 PR open + ready
 head SHA exactly equals proven full-ci SHA
-base master is expected integrated base/descendant
+base master expected descendant
 mergeable true
 no unresolved review thread
 no new review/comment blocker
 same-head full-ci success
 ```
 
-- [ ] **Step 2: Merge with `expected_head_sha`**
+- [ ] **Step 2: Merge with `expected_head_sha` and merge method `merge`**
 
-Use merge method `merge`, not an unreviewed squash/rebase transformation. GitHub must reject if head moved.
+GitHub must reject if head moved.
 
-- [ ] **Step 3: Verify integrated master push workflow**
+- [ ] **Step 3: Verify integrated master push workflow by merge SHA**
 
-Find the `push` workflow whose `head_sha` equals the merge commit. Do not close #37 based only on PR CI.
-
-Required integrated evidence:
+Do not close #37 from PR CI. Find the `push` run whose `head_sha` equals merge commit and require:
 
 ```text
 Linux static + all CTests       success
@@ -1761,17 +1790,17 @@ macOS                           success
 Windows DLL                     success
 ```
 
-Inspect Windows logs to confirm the mutation test runs in the integrated DLL build.
+Inspect Windows integrated logs to confirm mutation CTest runs.
 
-- [ ] **Step 4: Close bookkeeping only after integrated GREEN**
+- [ ] **Step 4: Close bookkeeping after integrated GREEN only**
 
-Close #37 as completed and update roadmap #2 to:
+Close #37 completed and update roadmap #2:
 
 ```text
 [x] Annotation mutation editor — #37 / PR #... — integrated
 ```
 
-Record final feature SHA, merge SHA, same-head full-ci workflow, and integrated master push workflow. Keep Forms/widgets and subtype-specific geometry as separate future work.
+Record final feature SHA, merge SHA, same-head full-ci workflow, and integrated-master push workflow. Leave subtype-specific geometry and Forms/widgets separate.
 
 ---
 
@@ -1780,17 +1809,17 @@ Record final feature SHA, merge SHA, same-head full-ci workflow, and integrated 
 ```text
 Task 1  strict compile RED + remote RED evidence
    ↓
-Task 2  shared annotation semantics; old 18-test regression gate
+Task 2  shared semantics refactor; 18/18 old-test gate while new target remains RED
    ↓
-Task 3  ABI + isolated lifecycle + fail-closed + baseline snapshot
+Task 3  public ABI + isolated lifecycle + fail-closed + non-consuming snapshot
    ↓
 Task 4  discovery + canonical refs + live getters
    ↓
-Task 5  create TEXT/FREE_TEXT/SQUARE/CIRCLE
+Task 5  create Text/FreeText/Square/Circle + create rollback
    ↓
-Task 6  update/delete + rollback + tombstone
+Task 6  update/delete + tombstone + full-u32 + Contents + rollback
    ↓
-Task 7  source/snapshot/JS/output semantic proof
+Task 7  source/snapshot/JavaScript/public-output semantic proof
    ↓
 Task 8  19/19 + sanitizers + same-SHA Linux/macOS/Windows full-ci + review
    ↓
@@ -1799,4 +1828,4 @@ STOP: explicit integration authorization
 Task 9  expected-head merge + integrated master proof + close #37
 ```
 
-The implementation is not complete merely because CRUD works. The completion boundary is: deterministic public reparse proves the edited output, all ref/rollback/fail-closed contracts are locked, and the exact feature head passes all three operating-system jobs before integration.
+The completion boundary is not “CRUD works.” It is: public reparse proves edited outputs, every identity/rollback/fail-closed/ownership contract is deterministic, and the exact feature head passes all three operating-system jobs before integration.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md
@@ -1,0 +1,645 @@
+# ExtractPDF PDF Annotation Mutation V1 Design
+
+## Status
+
+Approved Phase 5 Interactive PDF design for issue #37 under roadmap #2.
+
+Base: integrated annotation-enumeration master exact SHA `58525ce1b4b691ef53dfafc7c4e4d82753c966ba`, verified by integrated push workflow #180 (`33181186725`) across Linux static + ASan/UBSan, macOS, and Windows DLL.
+
+Design branch: `feat/pdf-annotation-mutation`.
+
+This slice introduces the first mutable PDF surface, but mutation is deliberately isolated from the existing read-only `extractpdf_document` / `extractpdf_page` model. The source document remains immutable. Mutation occurs only inside a private PDF editor fork and is published only as existing immutable `extractpdf_output` snapshots.
+
+## Goals
+
+- Preserve all existing source/document/page/snapshot semantics.
+- Introduce an opaque isolated `extractpdf_pdf_edit` rather than making `extractpdf_document` mutable.
+- Allow ordinary annotation create/update/delete through session-local opaque value references.
+- Keep immutable enumeration indices non-persistent and unusable as mutation selectors.
+- Make each public create/update/delete call atomic through MuPDF journalling.
+- Produce non-consuming deterministic immutable output snapshots from an edit session.
+- Reuse the existing Fitz page-space coordinate model and `extractpdf_output` ownership model.
+- Fail closed for encrypted and already-signed PDFs in V1.
+- Never execute PDF JavaScript as a side effect of annotation editing.
+- Support only annotation types and fields whose semantics V1 can express correctly.
+
+## Non-goals
+
+V1 does not mutate the source `extractpdf_document`, expose PDF object numbers/generations or `/NM`, define persistent identity across save/reopen, expose public undo/redo, edit forms/widgets, edit links/popups, execute JavaScript, perform incremental save, preserve/rewrite encryption, preserve signatures through mutation, or model subtype-specific QuadPoints/vertices/ink/line geometry.
+
+V1 also does not promise that a session-local annotation ref remains meaningful after `extractpdf_drop_pdf_edit()` or in another edit session.
+
+## Architecture
+
+```text
+extractpdf_document                 read-only source
+        |
+        | extractpdf_pdf_edit_begin()
+        | validate PDF / encryption / signed-input policy
+        | materialize private full-document representation
+        v
+extractpdf_pdf_edit                 isolated mutable fork
+        |
+        |-- annotation discovery -> session-local annotation refs
+        |-- create/update/delete -> one atomic journal operation per API call
+        |-- annotation getters -> copies or value structs only
+        |
+        | extractpdf_pdf_edit_snapshot()
+        v
+extractpdf_output                   immutable owned bytes
+        |
+        | existing output_data / output_save_file / drop_output
+        v
+caller-controlled persistence
+```
+
+Once `extractpdf_pdf_edit_begin()` succeeds, the editor retains no public lifetime dependency on the source `extractpdf_document`; the caller may close the source immediately. Dropping the editor discards its private fork and invalidates the editor's ref namespace. Previously produced outputs remain valid.
+
+## Why the Source Document Stays Immutable
+
+The current `extractpdf_document` is a read/lifecycle wrapper around one `fz_context` and `fz_document`. Existing pages and immutable snapshots assume source state does not change underneath them. Making that object mutable would retroactively complicate page handles, render/text/image/link/outline/metadata snapshots, rollback semantics, and save semantics.
+
+Mutation therefore belongs in a separate editing layer. `extractpdf_pdf_edit_begin()` creates a private editable PDF representation. No mutation API accepts `extractpdf_document *` or `extractpdf_page *` as the mutation target after begin.
+
+The implementation may serialize/reopen, clone, graft, or otherwise materialize the private PDF as needed, but the public contract is independent of that mechanism. Begin must be atomic: on failure `*out_edit == NULL`, and the source remains usable with its pre-call observable semantics.
+
+## Public ABI
+
+Add the opaque editor and fixed-size session-local ref token:
+
+```c
+typedef struct extractpdf_pdf_edit extractpdf_pdf_edit;
+
+typedef struct extractpdf_annotation_ref {
+    uint64_t opaque[2];
+} extractpdf_annotation_ref;
+```
+
+Add one new status at the end of the stable status enum:
+
+```c
+EXTRACTPDF_ERROR_STATE = 8
+```
+
+Existing numeric status values do not change.
+
+Add update-field bits:
+
+```c
+typedef enum extractpdf_annotation_update_field {
+    EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS = 1u << 0,
+    EXTRACTPDF_ANNOTATION_UPDATE_FLAGS = 1u << 1,
+    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS = 1u << 2
+} extractpdf_annotation_update_field;
+```
+
+Create options:
+
+```c
+typedef struct extractpdf_annotation_create_options {
+    size_t struct_size;
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+} extractpdf_annotation_create_options;
+```
+
+Partial update:
+
+```c
+typedef struct extractpdf_annotation_update {
+    size_t struct_size;
+    uint32_t fields;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+} extractpdf_annotation_update;
+```
+
+Public functions:
+
+```c
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_begin(
+    extractpdf_document *source,
+    extractpdf_pdf_edit **out_edit);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_count(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t index,
+    extractpdf_annotation_ref *out_ref);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_get_info(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    extractpdf_annotation_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_contents(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_create(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    const extractpdf_annotation_create_options *options,
+    extractpdf_annotation_ref *out_ref);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_update(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    const extractpdf_annotation_update *update);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_delete(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_snapshot(
+    extractpdf_pdf_edit *edit,
+    extractpdf_output **out_output);
+
+EXTRACTPDF_API void extractpdf_drop_pdf_edit(
+    extractpdf_pdf_edit *edit);
+```
+
+No MuPDF type, PDF object identity, filename, or mutable source handle is added to the public mutation ABI.
+
+## Editor Begin Contract
+
+`extractpdf_pdf_edit_begin()` starts with:
+
+```text
+out_edit == NULL -> ARGUMENT
+otherwise        -> *out_edit = NULL before later validation/work
+```
+
+Then it validates and materializes the private editor.
+
+Required behavior:
+
+- null source -> `ARGUMENT`;
+- non-PDF source -> `UNSUPPORTED`;
+- encrypted PDF -> `UNSUPPORTED`;
+- PDF containing an already-signed signature widget -> `UNSUPPORTED`;
+- allocation failure -> `NOMEM`;
+- malformed PDF encountered while creating the private representation -> mapped existing error;
+- success -> non-NULL editor independent of source lifetime.
+
+An unsigned signature field does not by itself make the document unsupported. V1 rejects an already-signed signature value because full-rewrite mutation has no signature-preservation contract.
+
+The private PDF must have JavaScript disabled before any editing operation is exposed to the caller.
+
+## Annotation Discovery Contract
+
+Editor annotation discovery deliberately reuses the semantic boundary of immutable Annotation Enumeration V1.
+
+For a requested page, ordinary annotation discovery uses the same rules:
+
+- missing/non-array `/Annots` -> empty;
+- non-dictionary entries ignored;
+- Link ignored;
+- Popup ignored;
+- Widget ignored;
+- missing/non-name/unrecognized subtype -> `UNKNOWN`;
+- surviving annotations preserve original relative `/Annots` order;
+- surviving Rect/F/Contents materialization follows the same strict validation contract as immutable enumeration.
+
+This prevents the editor from creating a second incompatible definition of "ordinary annotation".
+
+`extractpdf_pdf_edit_annotation_count()` returns the count of current surviving ordinary annotations on the current edit state.
+
+`extractpdf_pdf_edit_annotation_ref_at(edit, page, index, &ref)` uses the current discovery index only to acquire a session-local ref. After a ref is issued, later update/delete/get operations use the ref, not the index.
+
+If discovery of a page encounters a malformed surviving annotation, the discovery call fails atomically with `FORMAT`; it does not publish new refs for an earlier valid prefix.
+
+`UNKNOWN` entries may receive refs and may be inspected with the common getters, but all mutation through such refs is `UNSUPPORTED`.
+
+## Session-local Annotation Identity
+
+`extractpdf_annotation_ref` is an opaque value capability, not a pointer. Callers may copy it by value but may not interpret `opaque[]`.
+
+Conceptually the private editor maintains a namespace equivalent to:
+
+```text
+session nonce
+registry slot
+generation / liveness
+        -> page
+        -> private annotation identity
+        -> live | tombstone
+```
+
+The exact encoding and registry representation are private.
+
+Required identity properties:
+
+```text
+same edit + live ref              valid
+additional create/reorder         existing live ref remains valid
+new create                         returns a new live ref
+delete success                     ref becomes tombstone
+same-session tombstone use         STATE
+wrong-session token                ARGUMENT
+malformed/forged token              ARGUMENT
+snapshot()                          refs remain valid
+drop edit                           entire ref namespace ends
+save/reopen output                  no ref continuity promise
+```
+
+Registry slots should not be recycled in a way that can make a deleted ref accidentally target a new annotation during the same edit session.
+
+PDF object number/generation or kept PDF objects may be used privately to resolve a registry entry, but none of that becomes public identity.
+
+## Status Semantics
+
+`EXTRACTPDF_ERROR_STATE` means the supplied public object was once meaningful in the current editor model but is no longer in a state where the requested operation is valid. The primary V1 case is a deleted/tombstoned annotation ref.
+
+Classification:
+
+```text
+null required pointer                 ARGUMENT
+bad page index                        ARGUMENT
+wrong-session ref                     ARGUMENT
+malformed/forged ref                  ARGUMENT
+tombstoned same-session ref           STATE
+UNKNOWN mutation                      UNSUPPORTED
+unsupported type-specific mutation    UNSUPPORTED
+non-PDF/encrypted/signed edit begin   UNSUPPORTED
+malformed surviving PDF data          FORMAT
+allocation/size overflow              NOMEM
+MuPDF exception                       existing status mapper
+```
+
+`extractpdf_status_string()` must gain a stable string for `EXTRACTPDF_ERROR_STATE`.
+
+## Common Annotation Data
+
+Mutation V1 uses the already-public `extractpdf_annotation_type` and `extractpdf_annotation_info` model:
+
+```text
+type
+bounds in Fitz page space
+flags
+Contents
+```
+
+No new author/name/date/color/opacity/border/intent/reply/appearance-state model is added in this slice.
+
+### Bounds Input
+
+Public mutation bounds are Fitz page-space rectangles, matching existing page/link/annotation geometry.
+
+Inputs must contain finite floats with `x0 <= x1` and `y0 <= y1`. Zero-width or zero-height rectangles are allowed unless MuPDF rejects the specific annotation type. Non-finite or reversed rectangles are `ARGUMENT`; V1 does not silently normalize mutation inputs.
+
+MuPDF's annotation setter performs the private inverse page transform required to store PDF-space geometry. The public caller never supplies PDF-space coordinates.
+
+### Flags
+
+Flags use the existing raw uint32 PDF `/F` bitmask representation. V1 does not define a second flag enum.
+
+### Contents
+
+Create semantics:
+
+```text
+contents_utf8 == NULL && contents_size == 0    absent /Contents
+contents_utf8 != NULL && contents_size == 0    present empty /Contents
+contents_utf8 != NULL && contents_size > 0     present UTF-8 contents
+contents_utf8 == NULL && contents_size > 0     ARGUMENT
+```
+
+Update semantics depend on the CONTENTS field bit:
+
+```text
+CONTENTS bit absent                             unchanged
+bit present + NULL/0                            remove /Contents
+bit present + non-NULL/0                        set present empty string
+bit present + non-NULL/nonzero                  set UTF-8 contents
+bit present + NULL/nonzero                      ARGUMENT
+```
+
+Present input must be valid UTF-8. Embedded NUL within the counted range is rejected as `ARGUMENT`, because the pinned MuPDF setter accepts a C string and V1 must not silently truncate caller data.
+
+Live-editor contents access returns an allocated ExtractPDF-owned copy:
+
+```c
+char *text = NULL;
+size_t size = 0;
+extractpdf_pdf_edit_annotation_contents(edit, &ref, &text, &size);
+...
+extractpdf_free(text);
+```
+
+It never returns a borrowed pointer into mutable MuPDF state. Missing Contents returns `OK + NULL + 0`; present-empty returns `OK + non-NULL + 0`.
+
+## Supported Type Matrix
+
+Enumeration capability does not imply creation capability.
+
+V1 create support is limited to types whose geometry and minimum useful representation can be correctly expressed by Rect plus common fields:
+
+| Type | Create | Bounds update | Flags update | Contents update | Delete |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| TEXT | yes | yes | yes | yes | yes |
+| FREE_TEXT | yes | yes | yes | yes | yes |
+| SQUARE | yes | yes | yes | yes | yes |
+| CIRCLE | yes | yes | yes | yes | yes |
+| LINE | no | no | yes | yes | yes |
+| POLYGON / POLY_LINE | no | no | yes | yes | yes |
+| HIGHLIGHT / UNDERLINE / SQUIGGLY / STRIKE_OUT | no | no | yes | yes | yes |
+| REDACT | no | no | yes | yes | yes |
+| STAMP / CARET / FILE_ATTACHMENT / SOUND / MOVIE / RICH_MEDIA / SCREEN / PRINTER_MARK / TRAP_NET / WATERMARK / 3D / PROJECTION | no | no | yes | yes | yes |
+| INK | no | no | yes | yes | yes |
+| UNKNOWN | no | no | no | no | no |
+
+Link, Popup, and Widget are not ordinary mutation targets in this API.
+
+Bounds update is intentionally narrower than generic field update. MuPDF distinguishes annotations whose design rectangle is directly manipulable from annotations whose rectangle is derived from QuadPoints, InkList, vertices, or other subtype geometry.
+
+A future geometry slice may extend existing refs with type-specific APIs without changing the identity model.
+
+## Create Contract
+
+`extractpdf_pdf_edit_annotation_create()`:
+
+- resets `out_ref` to all-zero before later validation/work when `out_ref` is supplied;
+- validates editor/page/options/struct_size/type/bounds/flags/contents before mutation;
+- only permits TEXT/FREE_TEXT/SQUARE/CIRCLE;
+- creates the annotation inside one outer journal operation;
+- applies bounds, flags, and optional Contents;
+- performs required annotation appearance update/resynthesis before successful operation completion;
+- publishes/registers the new ref only after the PDF mutation fully succeeds.
+
+Any failure abandons the outer operation, releases temporary MuPDF references, leaves the editor's observable state unchanged, and leaves `out_ref` zeroed.
+
+No partially created annotation or registry entry may survive a failed create.
+
+## Update Contract
+
+`extractpdf_pdf_edit_annotation_update()` validates the entire request before starting observable mutation wherever possible.
+
+Unknown field bits are `ARGUMENT`. A zero field mask is a successful no-op.
+
+Within one outer journal operation it applies requested fields in a fixed private order. Public semantics do not depend on that order because failure at any point abandons the whole operation.
+
+Bounds update is allowed only for TEXT/FREE_TEXT/SQUARE/CIRCLE. Generic flags/Contents update is allowed for recognized ordinary types. UNKNOWN mutation is `UNSUPPORTED`.
+
+Appearance regeneration/update required by any setter completes before the outer operation ends. If appearance update fails after one or more fields changed, the entire call is abandoned and all fields return to their pre-call state.
+
+## Delete Contract
+
+Delete is allowed for every recognized ordinary annotation type, including types whose geometry V1 cannot create or edit.
+
+Deletion occurs in one outer journal operation using MuPDF annotation deletion semantics. Associated Popup cleanup performed by MuPDF is part of that same operation. Link and Widget remain outside this API.
+
+Only after successful operation completion is the registry entry marked tombstoned. If deletion fails, the ref remains live and the annotation remains observable.
+
+Calling get/update/delete on a same-session tombstoned ref returns `EXTRACTPDF_ERROR_STATE`.
+
+## Atomic Mutation Operations
+
+The private PDF enables MuPDF journalling when the editor is constructed.
+
+Each public create/update/delete call establishes one outer operation:
+
+```text
+validate request/ref/type
+        |
+pdf_begin_operation
+        |
+perform one or more MuPDF annotation mutations
+        |
+perform required appearance update/resynthesis
+        |
+update private registry only when appropriate
+        |
+        +-- success -> pdf_end_operation -> publish outputs/ref state
+        |
+        +-- failure -> pdf_abandon_operation -> restore pre-call PDF state
+```
+
+Pinned MuPDF annotation setters may start nested annotation operations. Those are intentionally enclosed by the ExtractPDF outer operation so one public API call remains the atomic unit.
+
+No public undo/redo surface is introduced. Journalling is an implementation mechanism for per-call atomicity only.
+
+## Appearance Semantics
+
+A mutation is not considered successful if the stored annotation data changes but the appearance required for normal rendering cannot be updated consistently.
+
+After setters request synthesis/resynthesis, the target annotation is updated before the outer operation ends. V1 should prefer targeted `pdf_update_annot()` behavior and must not deliberately execute a whole JavaScript/form event pipeline as part of ordinary annotation CRUD.
+
+If pinned MuPDF requires a broader page update for a supported annotation subtype, that behavior must be demonstrated in RED/GREEN tests without enabling JavaScript. The public guarantee remains: successful mutation produces a renderable internally consistent annotation; failed appearance work rolls the API call back.
+
+## Snapshot Contract
+
+`extractpdf_pdf_edit_snapshot()` is deliberately not named commit. It is a non-consuming immutable snapshot operation.
+
+It starts with:
+
+```text
+out_output == NULL -> ARGUMENT
+otherwise          -> *out_output = NULL before later validation/work
+```
+
+Then it serializes the complete current private PDF using the deterministic full-document writer policy and deep-copies bytes into the existing `extractpdf_output` abstraction. Only complete success publishes the output.
+
+Required properties:
+
+1. Two snapshots from the same edit state with no intervening mutation are byte-identical.
+2. Snapshot A remains byte-identical and valid after later mutations to the editor.
+3. Snapshot B after later mutation reflects the later state.
+4. Snapshot does not consume/finalize the editor.
+5. Snapshot does not invalidate existing live refs.
+6. Output remains valid after the editor is dropped.
+7. Snapshot failure leaves the editor usable in its pre-snapshot observable state and returns NULL output.
+
+The implementation should reuse the existing deterministic PDF serialization policy (`reproducible = 1`, `dont_regenerate_id = 1`) and existing immutable output ownership model.
+
+If `pdf_write_document()` is found to mutate internal editor bookkeeping in a way that violates properties above, the implementation must snapshot through another private serialization clone. Public semantics do not change.
+
+## Encryption Policy
+
+V1 rejects every PDF whose trailer contains `/Encrypt`, even if `extractpdf_open()` successfully authenticated a password.
+
+This avoids accidentally choosing policy for:
+
+- owner/user password preservation,
+- algorithm preservation,
+- permission preservation,
+- metadata encryption,
+- re-encryption keys,
+- incremental versus full rewrite.
+
+Encrypted mutation belongs to the later rewrite/encryption architecture.
+
+## Signature Policy
+
+V1 permits unsigned signature fields to remain present but rejects a source containing any already-signed signature widget/value.
+
+The editor performs a full-document rewrite and does not define incremental-update signature preservation. Returning a rewritten PDF while implying an existing signature remains valid would be an unsafe API contract.
+
+Signed-PDF mutation therefore belongs to a separate incremental/signature architecture.
+
+## JavaScript Policy
+
+The private PDF editor disables JavaScript before callers can perform mutations.
+
+Annotation CRUD must not execute document OpenAction JavaScript, annotation actions, form validation/calculation scripts, or other PDF JavaScript as an implicit side effect.
+
+JavaScript execution remains out of scope for roadmap #2. A deterministic fixture must prove that a script capable of changing observable document state is not executed by editor begin, mutation, appearance update, or snapshot.
+
+## Forms, Widgets, Links, and Popups
+
+Widgets/forms are reserved for a separate Phase 5 architecture. The editor's ordinary annotation discovery filters Widget exactly as immutable enumeration does.
+
+Links remain owned by the existing link surface and are not represented by annotation refs in Mutation V1.
+
+Popup is not a standalone ordinary annotation target. MuPDF's automatic associated-Popup cleanup during deletion is allowed as internal consistency behavior, but there is no public Popup ref or Popup CRUD API.
+
+## Lifetime and Ownership
+
+`extractpdf_pdf_edit` owns all private MuPDF/PDF state required for mutation. It retains no public dependency on the source after begin succeeds.
+
+`extractpdf_annotation_ref` contains no pointer and requires no drop function. Its namespace exists only while the owning editor exists.
+
+Allocated strings returned by live-editor getters use `extractpdf_free()`.
+
+`extractpdf_output` snapshots use the existing output ownership rules and are independent of both source and editor lifetimes.
+
+`extractpdf_drop_pdf_edit(NULL)` is a no-op.
+
+## Error Atomicity and Output Reset
+
+All new functions follow the existing reset-before-later-validation convention wherever an output pointer exists.
+
+Examples:
+
+```text
+edit_begin:        *out_edit = NULL
+create:            *out_ref = zero token
+ref_at:            *out_ref = zero token
+count:             *out_count = 0
+get_info:          known fields reset after struct_size validation
+contents:          *out_utf8 = NULL; *out_size = 0
+snapshot:          *out_output = NULL
+```
+
+No API may publish a partially initialized editor, annotation ref, allocated string, or output after a later failure.
+
+## Deterministic RED Fixtures
+
+The implementation plan must define checked-in deterministic PDFs sufficient to prove the contracts below without depending on network resources or system fonts beyond the pinned MuPDF test environment.
+
+At minimum the RED suite must cover:
+
+### Editable ordinary annotations
+
+A PDF with multiple pages and an `/Annots` sequence that includes:
+
+- supported Rect-based ordinary annotations,
+- at least one QuadPoints annotation,
+- at least one Ink/vertex-style unsupported-geometry annotation,
+- Link,
+- Popup,
+- Widget,
+- UNKNOWN subtype.
+
+This fixture locks discovery filtering/order, supported-type matrix, and ref/index separation.
+
+### Source immutability and lifetime
+
+Begin an editor, close the source, continue discovery/mutation/snapshot successfully. Separately retain a source-side annotation snapshot before editing and prove it never changes after editor mutation.
+
+### Ref identity
+
+Acquire refs, create another annotation that changes discovery count/order, and prove existing refs still address the same logical annotations. A ref from edit A used in edit B must be rejected. Delete must tombstone the ref.
+
+### Atomic update failure
+
+Use one multi-field update where an earlier field can succeed but a later requested field deterministically fails. The call must fail and subsequent getters/snapshot must show every field unchanged.
+
+### Create failure
+
+Trigger a deterministic failure after MuPDF annotation creation has started but before publication. The page count/order and ref registry must remain unchanged and no ref may be published.
+
+### Snapshot isolation
+
+Generate snapshot A, mutate, generate snapshot B, and prove:
+
+- A bytes do not change;
+- B differs where expected;
+- reparse of A exposes the earlier annotation state;
+- reparse of B exposes the later state;
+- two snapshots without mutation are byte-identical.
+
+Reparsed public verification should reuse immutable annotation enumeration wherever possible rather than inspect raw PDF objects only.
+
+### Fail-closed inputs
+
+Checked-in encrypted and already-signed PDFs must make edit begin return `UNSUPPORTED + NULL`.
+
+### JavaScript disabled
+
+A fixture containing JavaScript with a deterministic observable mutation must prove no such change occurs through editor begin/CRUD/appearance update/snapshot.
+
+## TDD Boundary
+
+Implementation follows strict RED -> GREEN.
+
+Branch base:
+
+```text
+58525ce1b4b691ef53dfafc7c4e4d82753c966ba
+  -> feat/pdf-annotation-mutation
+```
+
+RED contains deterministic fixtures, the new mutation test target, and test/CMake registration only. It must not add mutation production declarations, `EXTRACTPDF_ERROR_STATE`, or implementation behavior before the RED failure is captured.
+
+A valid RED means:
+
+- the existing library and all pre-existing test targets build;
+- only the new mutation test target fails because the approved editor/ref/status/update ABI is absent;
+- no unrelated runtime/fixture failure masks the missing-ABI boundary.
+
+GREEN then adds the minimal production implementation required by the locked design.
+
+The exact production file split is chosen in the implementation plan, but scope must remain focused on the public header, private PDF editor/mutation implementation, deterministic serialization reuse where needed, CMake registration, and the new tests/fixtures. Unrelated render/text/image/link/outline/metadata/composition refactors are out of scope.
+
+## Cross-platform Acceptance
+
+Before integration, the final exact feature head must pass:
+
+- Linux strict static build + all CTests;
+- Linux ASan/UBSan build + all CTests;
+- macOS configure/build/test;
+- Windows DLL configure/build/test;
+- the new mutation CTest executed through the Windows DLL build.
+
+After merge, the integrated master merge SHA must pass the same push workflow before issue #37 is closed completed and roadmap #2 marks Annotation Mutation V1 integrated.
+
+## Explicit Future Extensions
+
+The following extensions intentionally build on the same editor/ref architecture rather than widening V1 prematurely:
+
+```text
+Markup geometry     -> QuadPoints APIs
+Line geometry       -> endpoints / line endings
+Polygon/PolyLine    -> vertex APIs
+Ink                 -> stroke-list APIs
+Forms/widgets       -> separate widget/field model
+Persistent identity -> separately designed cross-save identity
+Encrypted editing   -> rewrite/encryption policy
+Signed editing      -> incremental/signature policy
+Public undo/redo    -> separate editor-history API if ever required
+```
+
+None of these extensions may reinterpret immutable enumeration index as identity or expose raw MuPDF/PDF objects through the C ABI.

--- a/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md
+++ b/docs/superpowers/specs/2026-08-28-extractpdf-pdf-annotation-mutation-design.md
@@ -173,16 +173,28 @@ EXTRACTPDF_API void extractpdf_drop_pdf_edit(
 
 No MuPDF type, PDF object identity, filename, or mutable source handle is added to the public mutation ABI.
 
-## Editor Begin Contract
+## Struct-size and Output-reset Convention
 
-`extractpdf_pdf_edit_begin()` starts with:
+New option/update structs follow the existing ExtractPDF forward-compatible `struct_size` convention: a caller-provided struct must be at least large enough through the last field currently required by V1; larger structs are accepted and unknown trailing bytes are ignored. A too-small `struct_size` is `ARGUMENT`.
+
+`extractpdf_annotation_info` keeps its existing minimum-size behavior in the live editor getter.
+
+Every required output pointer follows reset-before-later-validation behavior wherever a non-NULL pointer can be reset safely:
 
 ```text
-out_edit == NULL -> ARGUMENT
-otherwise        -> *out_edit = NULL before later validation/work
+edit_begin:       out_edit == NULL -> ARGUMENT; otherwise *out_edit = NULL first
+count:            if out_count != NULL, *out_count = 0 first; NULL out_count -> ARGUMENT
+ref_at/create:    if out_ref != NULL, zero the whole token first; NULL out_ref -> ARGUMENT
+get_info:         NULL out_info -> ARGUMENT; validate minimum struct_size, then reset known fields
+contents:         reset each non-NULL output independently, then require both out_utf8 and out_size
+snapshot:         out_output == NULL -> ARGUMENT; otherwise *out_output = NULL first
 ```
 
-Then it validates and materializes the private editor.
+No later validation failure may leave stale caller-visible output values.
+
+## Editor Begin Contract
+
+`extractpdf_pdf_edit_begin()` validates and materializes the private editor after resetting `*out_edit`.
 
 Required behavior:
 
@@ -196,7 +208,7 @@ Required behavior:
 
 An unsigned signature field does not by itself make the document unsupported. V1 rejects an already-signed signature value because full-rewrite mutation has no signature-preservation contract.
 
-The private PDF must have JavaScript disabled before any editing operation is exposed to the caller.
+The private PDF must have JavaScript disabled before any editing operation is exposed to the caller. Editor begin itself must not execute document JavaScript or action code.
 
 ## Annotation Discovery Contract
 
@@ -215,11 +227,11 @@ For a requested page, ordinary annotation discovery uses the same rules:
 
 This prevents the editor from creating a second incompatible definition of "ordinary annotation".
 
-`extractpdf_pdf_edit_annotation_count()` returns the count of current surviving ordinary annotations on the current edit state.
+`extractpdf_pdf_edit_annotation_count()` returns the count of current surviving ordinary annotations on the current edit state. Invalid page index is `ARGUMENT`.
 
-`extractpdf_pdf_edit_annotation_ref_at(edit, page, index, &ref)` uses the current discovery index only to acquire a session-local ref. After a ref is issued, later update/delete/get operations use the ref, not the index.
+`extractpdf_pdf_edit_annotation_ref_at(edit, page, index, &ref)` uses the current discovery index only to acquire a session-local ref. Out-of-range index is `ARGUMENT`. After a ref is issued, later update/delete/get operations use the ref, not the index.
 
-If discovery of a page encounters a malformed surviving annotation, the discovery call fails atomically with `FORMAT`; it does not publish new refs for an earlier valid prefix.
+If discovery of a page encounters a malformed surviving annotation, the discovery call fails atomically with `FORMAT`; it does not publish/register new refs for an earlier valid prefix. Existing refs already issued by successful operations remain unchanged.
 
 `UNKNOWN` entries may receive refs and may be inspected with the common getters, but all mutation through such refs is `UNSUPPORTED`.
 
@@ -244,18 +256,18 @@ Required identity properties:
 
 ```text
 same edit + live ref              valid
-additional create/reorder         existing live ref remains valid
+create/delete shifts indices      unrelated existing live refs remain valid
 new create                         returns a new live ref
-delete success                     ref becomes tombstone
+delete success                     deleted ref becomes tombstone
 same-session tombstone use         STATE
 wrong-session token                ARGUMENT
-malformed/forged token              ARGUMENT
-snapshot()                          refs remain valid
-drop edit                           entire ref namespace ends
-save/reopen output                  no ref continuity promise
+malformed/forged token             ARGUMENT
+snapshot()                         refs remain valid
+drop edit                          entire ref namespace ends
+save/reopen output                 no ref continuity promise
 ```
 
-Registry slots should not be recycled in a way that can make a deleted ref accidentally target a new annotation during the same edit session.
+Registry slots must not be recycled in a way that can make a deleted ref accidentally target a new annotation during the same edit session.
 
 PDF object number/generation or kept PDF objects may be used privately to resolve a registry entry, but none of that becomes public identity.
 
@@ -267,7 +279,7 @@ Classification:
 
 ```text
 null required pointer                 ARGUMENT
-bad page index                        ARGUMENT
+bad page/index                        ARGUMENT
 wrong-session ref                     ARGUMENT
 malformed/forged ref                  ARGUMENT
 tombstoned same-session ref           STATE
@@ -300,11 +312,13 @@ Public mutation bounds are Fitz page-space rectangles, matching existing page/li
 
 Inputs must contain finite floats with `x0 <= x1` and `y0 <= y1`. Zero-width or zero-height rectangles are allowed unless MuPDF rejects the specific annotation type. Non-finite or reversed rectangles are `ARGUMENT`; V1 does not silently normalize mutation inputs.
 
-MuPDF's annotation setter performs the private inverse page transform required to store PDF-space geometry. The public caller never supplies PDF-space coordinates.
+MuPDF's annotation geometry path performs the private inverse page transform required to store PDF-space geometry. The public caller never supplies PDF-space coordinates.
 
 ### Flags
 
-Flags use the existing raw uint32 PDF `/F` bitmask representation. V1 does not define a second flag enum.
+Flags keep the existing raw `uint32_t` PDF `/F` bitmask contract. V1 accepts the full `uint32_t` range so a caller can round-trip an existing raw flag value without signed narrowing.
+
+Pinned MuPDF's convenience flag setter accepts `int`; implementation must therefore not cast a value greater than `INT_MAX` through that setter and emit a negative PDF integer. If the convenience setter cannot preserve the full public value, the implementation must perform an equivalent journalled PDF `/F` write using a non-narrowing integer representation and request the same dirty/resynthesis behavior. This is a private implementation detail; the public `uint32_t` contract does not narrow.
 
 ### Contents
 
@@ -327,7 +341,7 @@ bit present + non-NULL/nonzero                  set UTF-8 contents
 bit present + NULL/nonzero                      ARGUMENT
 ```
 
-Present input must be valid UTF-8. Embedded NUL within the counted range is rejected as `ARGUMENT`, because the pinned MuPDF setter accepts a C string and V1 must not silently truncate caller data.
+Present input is a counted byte range. It does not need a terminating NUL after `contents_size`; ExtractPDF copies the range into temporary storage and appends its own terminator before calling a C-string MuPDF API. The counted range must be valid UTF-8 and must not contain embedded NUL. Invalid UTF-8 or embedded NUL is `ARGUMENT`. Size arithmetic overflow is `NOMEM`.
 
 Live-editor contents access returns an allocated ExtractPDF-owned copy:
 
@@ -369,10 +383,12 @@ A future geometry slice may extend existing refs with type-specific APIs without
 
 ## Create Contract
 
-`extractpdf_pdf_edit_annotation_create()`:
+`extractpdf_pdf_edit_annotation_create()` requires non-NULL edit/options/out_ref, a valid page index, and a sufficiently large options `struct_size`.
 
-- resets `out_ref` to all-zero before later validation/work when `out_ref` is supplied;
-- validates editor/page/options/struct_size/type/bounds/flags/contents before mutation;
+It then:
+
+- zeroes `out_ref` before later validation/work;
+- validates type/bounds/flags/Contents before mutation;
 - only permits TEXT/FREE_TEXT/SQUARE/CIRCLE;
 - creates the annotation inside one outer journal operation;
 - applies bounds, flags, and optional Contents;
@@ -385,11 +401,13 @@ No partially created annotation or registry entry may survive a failed create.
 
 ## Update Contract
 
-`extractpdf_pdf_edit_annotation_update()` validates the entire request before starting observable mutation wherever possible.
+`extractpdf_pdf_edit_annotation_update()` requires non-NULL edit/ref/update and a sufficiently large update `struct_size`.
 
-Unknown field bits are `ARGUMENT`. A zero field mask is a successful no-op.
+It validates the editor and ref before treating a zero field mask as a successful no-op. Therefore a wrong-session ref still returns `ARGUMENT` and a tombstoned ref still returns `STATE` even when `fields == 0`.
 
-Within one outer journal operation it applies requested fields in a fixed private order. Public semantics do not depend on that order because failure at any point abandons the whole operation.
+Unknown field bits are `ARGUMENT`. For requested fields, all input validation that does not require mutation is completed before the outer operation begins.
+
+Within one outer journal operation the implementation applies requested fields in a fixed private order. Public semantics do not depend on that order because failure at any point abandons the whole operation.
 
 Bounds update is allowed only for TEXT/FREE_TEXT/SQUARE/CIRCLE. Generic flags/Contents update is allowed for recognized ordinary types. UNKNOWN mutation is `UNSUPPORTED`.
 
@@ -403,7 +421,7 @@ Deletion occurs in one outer journal operation using MuPDF annotation deletion s
 
 Only after successful operation completion is the registry entry marked tombstoned. If deletion fails, the ref remains live and the annotation remains observable.
 
-Calling get/update/delete on a same-session tombstoned ref returns `EXTRACTPDF_ERROR_STATE`.
+Calling get/update/delete/contents on a same-session tombstoned ref returns `EXTRACTPDF_ERROR_STATE`.
 
 ## Atomic Mutation Operations
 
@@ -420,14 +438,14 @@ perform one or more MuPDF annotation mutations
         |
 perform required appearance update/resynthesis
         |
-update private registry only when appropriate
-        |
-        +-- success -> pdf_end_operation -> publish outputs/ref state
+        +-- success -> pdf_end_operation -> update registry/publish ref state
         |
         +-- failure -> pdf_abandon_operation -> restore pre-call PDF state
 ```
 
 Pinned MuPDF annotation setters may start nested annotation operations. Those are intentionally enclosed by the ExtractPDF outer operation so one public API call remains the atomic unit.
+
+Registry changes that would expose a new ref or tombstone an existing ref occur only after the corresponding PDF operation has completed successfully. A failure to allocate registry state needed for create must be handled before publication and must not leave the new PDF annotation behind.
 
 No public undo/redo surface is introduced. Journalling is an implementation mechanism for per-call atomicity only.
 
@@ -443,14 +461,7 @@ If pinned MuPDF requires a broader page update for a supported annotation subtyp
 
 `extractpdf_pdf_edit_snapshot()` is deliberately not named commit. It is a non-consuming immutable snapshot operation.
 
-It starts with:
-
-```text
-out_output == NULL -> ARGUMENT
-otherwise          -> *out_output = NULL before later validation/work
-```
-
-Then it serializes the complete current private PDF using the deterministic full-document writer policy and deep-copies bytes into the existing `extractpdf_output` abstraction. Only complete success publishes the output.
+After resetting `*out_output`, it serializes the complete current private PDF using the deterministic full-document writer policy and deep-copies bytes into the existing `extractpdf_output` abstraction. Only complete success publishes the output.
 
 Required properties:
 
@@ -493,7 +504,7 @@ Signed-PDF mutation therefore belongs to a separate incremental/signature archit
 
 The private PDF editor disables JavaScript before callers can perform mutations.
 
-Annotation CRUD must not execute document OpenAction JavaScript, annotation actions, form validation/calculation scripts, or other PDF JavaScript as an implicit side effect.
+Annotation CRUD must not execute document OpenAction JavaScript, annotation actions, form validation/calculation scripts, or other PDF JavaScript as an implicit side effect. Editor begin and snapshot likewise must not execute document JavaScript.
 
 JavaScript execution remains out of scope for roadmap #2. A deterministic fixture must prove that a script capable of changing observable document state is not executed by editor begin, mutation, appearance update, or snapshot.
 
@@ -517,43 +528,15 @@ Allocated strings returned by live-editor getters use `extractpdf_free()`.
 
 `extractpdf_drop_pdf_edit(NULL)` is a no-op.
 
-## Error Atomicity and Output Reset
-
-All new functions follow the existing reset-before-later-validation convention wherever an output pointer exists.
-
-Examples:
-
-```text
-edit_begin:        *out_edit = NULL
-create:            *out_ref = zero token
-ref_at:            *out_ref = zero token
-count:             *out_count = 0
-get_info:          known fields reset after struct_size validation
-contents:          *out_utf8 = NULL; *out_size = 0
-snapshot:          *out_output = NULL
-```
-
-No API may publish a partially initialized editor, annotation ref, allocated string, or output after a later failure.
-
 ## Deterministic RED Fixtures
 
 The implementation plan must define checked-in deterministic PDFs sufficient to prove the contracts below without depending on network resources or system fonts beyond the pinned MuPDF test environment.
 
-At minimum the RED suite must cover:
-
 ### Editable ordinary annotations
 
-A PDF with multiple pages and an `/Annots` sequence that includes:
+A PDF with multiple pages and an `/Annots` sequence that includes supported Rect-based ordinary annotations, at least one QuadPoints annotation, at least one Ink/vertex-style unsupported-geometry annotation, Link, Popup, Widget, and UNKNOWN subtype.
 
-- supported Rect-based ordinary annotations,
-- at least one QuadPoints annotation,
-- at least one Ink/vertex-style unsupported-geometry annotation,
-- Link,
-- Popup,
-- Widget,
-- UNKNOWN subtype.
-
-This fixture locks discovery filtering/order, supported-type matrix, and ref/index separation.
+This fixture locks discovery filtering/order, strict survivor validation, supported-type matrix, and ref/index separation.
 
 ### Source immutability and lifetime
 
@@ -561,7 +544,7 @@ Begin an editor, close the source, continue discovery/mutation/snapshot successf
 
 ### Ref identity
 
-Acquire refs, create another annotation that changes discovery count/order, and prove existing refs still address the same logical annotations. A ref from edit A used in edit B must be rejected. Delete must tombstone the ref.
+Acquire refs to at least two annotations, delete an earlier annotation so later discovery indices shift, and prove the surviving later ref still addresses the same logical annotation. Also create a new annotation and prove existing refs remain stable. A ref from edit A used in edit B must be rejected. Delete must tombstone the deleted ref.
 
 ### Atomic update failure
 
@@ -569,23 +552,25 @@ Use one multi-field update where an earlier field can succeed but a later reques
 
 ### Create failure
 
-Trigger a deterministic failure after MuPDF annotation creation has started but before publication. The page count/order and ref registry must remain unchanged and no ref may be published.
+Trigger a deterministic failure after PDF annotation creation has started but before publication. The page count/order and ref registry must remain unchanged and no ref may be published.
+
+### Full uint32 flags
+
+A deterministic case must exercise a raw `/F` value above `INT_MAX`, prove immutable/editor getters preserve the same `uint32_t`, and prove an explicit flags update can round-trip that value without producing a negative PDF integer or failing subsequent strict enumeration.
+
+### Contents ownership and presence
+
+Prove absent, present-empty, and non-empty Contents remain distinct; counted input need not be NUL-terminated outside its declared size; invalid UTF-8 and embedded NUL are rejected; live getter strings survive subsequent editor mutation until caller frees them.
 
 ### Snapshot isolation
 
-Generate snapshot A, mutate, generate snapshot B, and prove:
-
-- A bytes do not change;
-- B differs where expected;
-- reparse of A exposes the earlier annotation state;
-- reparse of B exposes the later state;
-- two snapshots without mutation are byte-identical.
+Generate snapshot A, mutate, generate snapshot B, and prove A bytes do not change, B differs where expected, reparse of A exposes the earlier annotation state, reparse of B exposes the later state, and two snapshots without mutation are byte-identical.
 
 Reparsed public verification should reuse immutable annotation enumeration wherever possible rather than inspect raw PDF objects only.
 
 ### Fail-closed inputs
 
-Checked-in encrypted and already-signed PDFs must make edit begin return `UNSUPPORTED + NULL`.
+Checked-in encrypted and already-signed PDFs must make edit begin return `UNSUPPORTED + NULL`. An unsigned signature field remains acceptable.
 
 ### JavaScript disabled
 
@@ -616,13 +601,7 @@ The exact production file split is chosen in the implementation plan, but scope 
 
 ## Cross-platform Acceptance
 
-Before integration, the final exact feature head must pass:
-
-- Linux strict static build + all CTests;
-- Linux ASan/UBSan build + all CTests;
-- macOS configure/build/test;
-- Windows DLL configure/build/test;
-- the new mutation CTest executed through the Windows DLL build.
+Before integration, the final exact feature head must pass Linux strict static build + all CTests, Linux ASan/UBSan + all CTests, macOS configure/build/test, and Windows DLL configure/build/test with the new mutation CTest executed through the Windows DLL build.
 
 After merge, the integrated master merge SHA must pass the same push workflow before issue #37 is closed completed and roadmap #2 marks Annotation Mutation V1 integrated.
 

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -27,6 +27,7 @@ typedef struct extractpdf_link_page extractpdf_link_page;
 typedef struct extractpdf_output extractpdf_output;
 typedef struct extractpdf_outline extractpdf_outline;
 typedef struct extractpdf_annotation_page extractpdf_annotation_page;
+typedef struct extractpdf_pdf_edit extractpdf_pdf_edit;
 
 typedef struct extractpdf_point {
     float x;
@@ -163,6 +164,34 @@ typedef struct extractpdf_annotation_info {
     uint32_t flags;
 } extractpdf_annotation_info;
 
+typedef struct extractpdf_annotation_ref {
+    uint64_t opaque[2];
+} extractpdf_annotation_ref;
+
+typedef enum extractpdf_annotation_update_field {
+    EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS = 1u << 0,
+    EXTRACTPDF_ANNOTATION_UPDATE_FLAGS = 1u << 1,
+    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS = 1u << 2
+} extractpdf_annotation_update_field;
+
+typedef struct extractpdf_annotation_create_options {
+    size_t struct_size;
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+} extractpdf_annotation_create_options;
+
+typedef struct extractpdf_annotation_update {
+    size_t struct_size;
+    uint32_t fields;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+} extractpdf_annotation_update;
+
 typedef enum extractpdf_metadata_field {
     EXTRACTPDF_METADATA_TITLE = 1,
     EXTRACTPDF_METADATA_AUTHOR = 2,
@@ -182,7 +211,8 @@ typedef enum extractpdf_status {
     EXTRACTPDF_ERROR_FORMAT = 4,
     EXTRACTPDF_ERROR_UNSUPPORTED = 5,
     EXTRACTPDF_ERROR_NOMEM = 6,
-    EXTRACTPDF_ERROR_MUPDF = 7
+    EXTRACTPDF_ERROR_MUPDF = 7,
+    EXTRACTPDF_ERROR_STATE = 8
 } extractpdf_status;
 
 EXTRACTPDF_API extractpdf_status extractpdf_open(
@@ -250,6 +280,51 @@ EXTRACTPDF_API extractpdf_status extractpdf_output_data(
 EXTRACTPDF_API extractpdf_status extractpdf_output_save_file(
     const extractpdf_output *output,
     const char *filename);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_begin(
+    extractpdf_document *document,
+    extractpdf_pdf_edit **out_edit);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_count(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t *out_count);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t index,
+    extractpdf_annotation_ref *out_ref);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_get_info(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    extractpdf_annotation_info *out_info);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_contents(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    char **out_utf8,
+    size_t *out_size);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_create(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    const extractpdf_annotation_create_options *options,
+    extractpdf_annotation_ref *out_ref);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_update(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    const extractpdf_annotation_update *update);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_annotation_delete(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref);
+
+EXTRACTPDF_API extractpdf_status extractpdf_pdf_edit_snapshot(
+    extractpdf_pdf_edit *edit,
+    extractpdf_output **out_output);
 
 EXTRACTPDF_API extractpdf_status extractpdf_load_page(
     extractpdf_document *document,
@@ -413,6 +488,9 @@ EXTRACTPDF_API void extractpdf_free(
 
 EXTRACTPDF_API void extractpdf_drop_output(
     extractpdf_output *output);
+
+EXTRACTPDF_API void extractpdf_drop_pdf_edit(
+    extractpdf_pdf_edit *edit);
 
 EXTRACTPDF_API void extractpdf_drop_text_page(
     extractpdf_text_page *text);

--- a/src/pdf_annotation_common.c
+++ b/src/pdf_annotation_common.c
@@ -1,0 +1,232 @@
+#include "pdf_annotation_common.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+static int extractpdf_pdf_annotation_dict_find(
+    fz_context *ctx,
+    pdf_obj *dictionary,
+    pdf_obj *key,
+    pdf_obj **out_value)
+{
+    int count;
+    int index;
+
+    *out_value = NULL;
+    count = pdf_dict_len(ctx, dictionary);
+    for (index = 0; index < count; ++index) {
+        pdf_obj *candidate = pdf_dict_get_key(ctx, dictionary, index);
+        if (pdf_name_eq(ctx, candidate, key)) {
+            *out_value = pdf_dict_get_val(ctx, dictionary, index);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static extractpdf_annotation_type extractpdf_pdf_annotation_type_from_name(
+    const char *name)
+{
+    if (strcmp(name, "Text") == 0)
+        return EXTRACTPDF_ANNOTATION_TEXT;
+    if (strcmp(name, "FreeText") == 0)
+        return EXTRACTPDF_ANNOTATION_FREE_TEXT;
+    if (strcmp(name, "Line") == 0)
+        return EXTRACTPDF_ANNOTATION_LINE;
+    if (strcmp(name, "Square") == 0)
+        return EXTRACTPDF_ANNOTATION_SQUARE;
+    if (strcmp(name, "Circle") == 0)
+        return EXTRACTPDF_ANNOTATION_CIRCLE;
+    if (strcmp(name, "Polygon") == 0)
+        return EXTRACTPDF_ANNOTATION_POLYGON;
+    if (strcmp(name, "PolyLine") == 0)
+        return EXTRACTPDF_ANNOTATION_POLY_LINE;
+    if (strcmp(name, "Highlight") == 0)
+        return EXTRACTPDF_ANNOTATION_HIGHLIGHT;
+    if (strcmp(name, "Underline") == 0)
+        return EXTRACTPDF_ANNOTATION_UNDERLINE;
+    if (strcmp(name, "Squiggly") == 0)
+        return EXTRACTPDF_ANNOTATION_SQUIGGLY;
+    if (strcmp(name, "StrikeOut") == 0)
+        return EXTRACTPDF_ANNOTATION_STRIKE_OUT;
+    if (strcmp(name, "Redact") == 0)
+        return EXTRACTPDF_ANNOTATION_REDACT;
+    if (strcmp(name, "Stamp") == 0)
+        return EXTRACTPDF_ANNOTATION_STAMP;
+    if (strcmp(name, "Caret") == 0)
+        return EXTRACTPDF_ANNOTATION_CARET;
+    if (strcmp(name, "Ink") == 0)
+        return EXTRACTPDF_ANNOTATION_INK;
+    if (strcmp(name, "FileAttachment") == 0)
+        return EXTRACTPDF_ANNOTATION_FILE_ATTACHMENT;
+    if (strcmp(name, "Sound") == 0)
+        return EXTRACTPDF_ANNOTATION_SOUND;
+    if (strcmp(name, "Movie") == 0)
+        return EXTRACTPDF_ANNOTATION_MOVIE;
+    if (strcmp(name, "RichMedia") == 0)
+        return EXTRACTPDF_ANNOTATION_RICH_MEDIA;
+    if (strcmp(name, "Screen") == 0)
+        return EXTRACTPDF_ANNOTATION_SCREEN;
+    if (strcmp(name, "PrinterMark") == 0)
+        return EXTRACTPDF_ANNOTATION_PRINTER_MARK;
+    if (strcmp(name, "TrapNet") == 0)
+        return EXTRACTPDF_ANNOTATION_TRAP_NET;
+    if (strcmp(name, "Watermark") == 0)
+        return EXTRACTPDF_ANNOTATION_WATERMARK;
+    if (strcmp(name, "3D") == 0)
+        return EXTRACTPDF_ANNOTATION_3D;
+    if (strcmp(name, "Projection") == 0)
+        return EXTRACTPDF_ANNOTATION_PROJECTION;
+    return EXTRACTPDF_ANNOTATION_UNKNOWN;
+}
+
+int extractpdf_pdf_annotation_classify(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_type *out_type)
+{
+    pdf_obj *subtype = NULL;
+    const char *name;
+    int present;
+
+    *out_type = EXTRACTPDF_ANNOTATION_UNKNOWN;
+    present = extractpdf_pdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(Subtype), &subtype);
+    if (!present || !pdf_is_name(ctx, subtype))
+        return 1;
+
+    name = pdf_to_name(ctx, subtype);
+    if (strcmp(name, "Link") == 0 ||
+        strcmp(name, "Popup") == 0 ||
+        strcmp(name, "Widget") == 0)
+        return 0;
+
+    *out_type = extractpdf_pdf_annotation_type_from_name(name);
+    return 1;
+}
+
+static extractpdf_status extractpdf_pdf_annotation_read_bounds(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    fz_matrix page_ctm,
+    extractpdf_rect *out_bounds)
+{
+    pdf_obj *rect_obj = NULL;
+    float values[4];
+    fz_rect raw;
+    fz_rect transformed;
+    int present;
+    int index;
+
+    present = extractpdf_pdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(Rect), &rect_obj);
+    if (!present || !pdf_is_array(ctx, rect_obj) ||
+        pdf_array_len(ctx, rect_obj) != 4)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    for (index = 0; index < 4; ++index) {
+        pdf_obj *value = pdf_array_get(ctx, rect_obj, index);
+        if (!pdf_is_number(ctx, value))
+            return EXTRACTPDF_ERROR_FORMAT;
+        values[index] = pdf_to_real(ctx, value);
+        if (!isfinite(values[index]))
+            return EXTRACTPDF_ERROR_FORMAT;
+    }
+
+    raw.x0 = values[0] < values[2] ? values[0] : values[2];
+    raw.x1 = values[0] < values[2] ? values[2] : values[0];
+    raw.y0 = values[1] < values[3] ? values[1] : values[3];
+    raw.y1 = values[1] < values[3] ? values[3] : values[1];
+    transformed = fz_transform_rect(raw, page_ctm);
+
+    if (!isfinite(transformed.x0) || !isfinite(transformed.y0) ||
+        !isfinite(transformed.x1) || !isfinite(transformed.y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    out_bounds->x0 = transformed.x0 < transformed.x1 ?
+        transformed.x0 : transformed.x1;
+    out_bounds->x1 = transformed.x0 < transformed.x1 ?
+        transformed.x1 : transformed.x0;
+    out_bounds->y0 = transformed.y0 < transformed.y1 ?
+        transformed.y0 : transformed.y1;
+    out_bounds->y1 = transformed.y0 < transformed.y1 ?
+        transformed.y1 : transformed.y0;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_annotation_read_flags(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    uint32_t *out_flags)
+{
+    pdf_obj *flags_obj = NULL;
+    int64_t value;
+    int present;
+
+    *out_flags = 0;
+    present = extractpdf_pdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(F), &flags_obj);
+    if (!present)
+        return EXTRACTPDF_OK;
+    if (!pdf_is_int(ctx, flags_obj))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    value = pdf_to_int64(ctx, flags_obj);
+    if (value < 0 || (uint64_t)value > UINT32_MAX)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    *out_flags = (uint32_t)value;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_annotation_read_contents(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_pdf_annotation_view *out_view)
+{
+    pdf_obj *contents_obj = NULL;
+    const char *text;
+    int present;
+
+    present = extractpdf_pdf_annotation_dict_find(
+        ctx, annotation, PDF_NAME(Contents), &contents_obj);
+    if (!present)
+        return EXTRACTPDF_OK;
+    if (!pdf_is_string(ctx, contents_obj))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    text = pdf_to_text_string(ctx, contents_obj);
+    if (text == NULL)
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    out_view->has_contents = 1;
+    out_view->contents_utf8 = text;
+    out_view->contents_size = strlen(text);
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_pdf_annotation_read_view(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_type type,
+    fz_matrix page_ctm,
+    extractpdf_pdf_annotation_view *out_view)
+{
+    extractpdf_status status;
+
+    memset(out_view, 0, sizeof(*out_view));
+    out_view->type = type;
+
+    status = extractpdf_pdf_annotation_read_bounds(
+        ctx, annotation, page_ctm, &out_view->bounds);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    status = extractpdf_pdf_annotation_read_flags(
+        ctx, annotation, &out_view->flags);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    return extractpdf_pdf_annotation_read_contents(ctx, annotation, out_view);
+}

--- a/src/pdf_annotation_common.h
+++ b/src/pdf_annotation_common.h
@@ -1,0 +1,27 @@
+#ifndef EXTRACTPDF_PDF_ANNOTATION_COMMON_H
+#define EXTRACTPDF_PDF_ANNOTATION_COMMON_H
+
+#include "pdf_internal.h"
+
+typedef struct extractpdf_pdf_annotation_view {
+    extractpdf_annotation_type type;
+    extractpdf_rect bounds;
+    uint32_t flags;
+    const char *contents_utf8;
+    size_t contents_size;
+    int has_contents;
+} extractpdf_pdf_annotation_view;
+
+int extractpdf_pdf_annotation_classify(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_type *out_type);
+
+extractpdf_status extractpdf_pdf_annotation_read_view(
+    fz_context *ctx,
+    pdf_obj *annotation,
+    extractpdf_annotation_type type,
+    fz_matrix page_ctm,
+    extractpdf_pdf_annotation_view *out_view);
+
+#endif

--- a/src/pdf_annotations.c
+++ b/src/pdf_annotations.c
@@ -1,6 +1,5 @@
-#include "pdf_internal.h"
+#include "pdf_annotation_common.h"
 
-#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -111,238 +110,6 @@ static extractpdf_status extractpdf_annotation_append_string(
     return EXTRACTPDF_OK;
 }
 
-static int extractpdf_annotation_dict_find(
-    fz_context *ctx,
-    pdf_obj *dictionary,
-    pdf_obj *key,
-    pdf_obj **out_value)
-{
-    int count;
-    int index;
-
-    *out_value = NULL;
-    count = pdf_dict_len(ctx, dictionary);
-    for (index = 0; index < count; ++index) {
-        pdf_obj *candidate = pdf_dict_get_key(ctx, dictionary, index);
-        if (pdf_name_eq(ctx, candidate, key)) {
-            *out_value = pdf_dict_get_val(ctx, dictionary, index);
-            return 1;
-        }
-    }
-    return 0;
-}
-
-static extractpdf_annotation_type extractpdf_annotation_type_from_name(
-    const char *name)
-{
-    if (strcmp(name, "Text") == 0)
-        return EXTRACTPDF_ANNOTATION_TEXT;
-    if (strcmp(name, "FreeText") == 0)
-        return EXTRACTPDF_ANNOTATION_FREE_TEXT;
-    if (strcmp(name, "Line") == 0)
-        return EXTRACTPDF_ANNOTATION_LINE;
-    if (strcmp(name, "Square") == 0)
-        return EXTRACTPDF_ANNOTATION_SQUARE;
-    if (strcmp(name, "Circle") == 0)
-        return EXTRACTPDF_ANNOTATION_CIRCLE;
-    if (strcmp(name, "Polygon") == 0)
-        return EXTRACTPDF_ANNOTATION_POLYGON;
-    if (strcmp(name, "PolyLine") == 0)
-        return EXTRACTPDF_ANNOTATION_POLY_LINE;
-    if (strcmp(name, "Highlight") == 0)
-        return EXTRACTPDF_ANNOTATION_HIGHLIGHT;
-    if (strcmp(name, "Underline") == 0)
-        return EXTRACTPDF_ANNOTATION_UNDERLINE;
-    if (strcmp(name, "Squiggly") == 0)
-        return EXTRACTPDF_ANNOTATION_SQUIGGLY;
-    if (strcmp(name, "StrikeOut") == 0)
-        return EXTRACTPDF_ANNOTATION_STRIKE_OUT;
-    if (strcmp(name, "Redact") == 0)
-        return EXTRACTPDF_ANNOTATION_REDACT;
-    if (strcmp(name, "Stamp") == 0)
-        return EXTRACTPDF_ANNOTATION_STAMP;
-    if (strcmp(name, "Caret") == 0)
-        return EXTRACTPDF_ANNOTATION_CARET;
-    if (strcmp(name, "Ink") == 0)
-        return EXTRACTPDF_ANNOTATION_INK;
-    if (strcmp(name, "FileAttachment") == 0)
-        return EXTRACTPDF_ANNOTATION_FILE_ATTACHMENT;
-    if (strcmp(name, "Sound") == 0)
-        return EXTRACTPDF_ANNOTATION_SOUND;
-    if (strcmp(name, "Movie") == 0)
-        return EXTRACTPDF_ANNOTATION_MOVIE;
-    if (strcmp(name, "RichMedia") == 0)
-        return EXTRACTPDF_ANNOTATION_RICH_MEDIA;
-    if (strcmp(name, "Screen") == 0)
-        return EXTRACTPDF_ANNOTATION_SCREEN;
-    if (strcmp(name, "PrinterMark") == 0)
-        return EXTRACTPDF_ANNOTATION_PRINTER_MARK;
-    if (strcmp(name, "TrapNet") == 0)
-        return EXTRACTPDF_ANNOTATION_TRAP_NET;
-    if (strcmp(name, "Watermark") == 0)
-        return EXTRACTPDF_ANNOTATION_WATERMARK;
-    if (strcmp(name, "3D") == 0)
-        return EXTRACTPDF_ANNOTATION_3D;
-    if (strcmp(name, "Projection") == 0)
-        return EXTRACTPDF_ANNOTATION_PROJECTION;
-    return EXTRACTPDF_ANNOTATION_UNKNOWN;
-}
-
-static int extractpdf_annotation_classify(
-    fz_context *ctx,
-    pdf_obj *annotation,
-    extractpdf_annotation_type *out_type)
-{
-    pdf_obj *subtype = NULL;
-    const char *name;
-    int present;
-
-    *out_type = EXTRACTPDF_ANNOTATION_UNKNOWN;
-    present = extractpdf_annotation_dict_find(
-        ctx, annotation, PDF_NAME(Subtype), &subtype);
-    if (!present || !pdf_is_name(ctx, subtype))
-        return 1;
-
-    name = pdf_to_name(ctx, subtype);
-    if (strcmp(name, "Link") == 0 ||
-        strcmp(name, "Popup") == 0 ||
-        strcmp(name, "Widget") == 0)
-        return 0;
-
-    *out_type = extractpdf_annotation_type_from_name(name);
-    return 1;
-}
-
-static extractpdf_status extractpdf_annotation_read_bounds(
-    fz_context *ctx,
-    pdf_obj *annotation,
-    fz_matrix page_ctm,
-    extractpdf_rect *out_bounds)
-{
-    pdf_obj *rect_obj = NULL;
-    float values[4];
-    fz_rect raw;
-    fz_rect transformed;
-    int present;
-    int index;
-
-    present = extractpdf_annotation_dict_find(
-        ctx, annotation, PDF_NAME(Rect), &rect_obj);
-    if (!present || !pdf_is_array(ctx, rect_obj) ||
-        pdf_array_len(ctx, rect_obj) != 4)
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    for (index = 0; index < 4; ++index) {
-        pdf_obj *value = pdf_array_get(ctx, rect_obj, index);
-        if (!pdf_is_number(ctx, value))
-            return EXTRACTPDF_ERROR_FORMAT;
-        values[index] = pdf_to_real(ctx, value);
-        if (!isfinite(values[index]))
-            return EXTRACTPDF_ERROR_FORMAT;
-    }
-
-    raw.x0 = values[0] < values[2] ? values[0] : values[2];
-    raw.x1 = values[0] < values[2] ? values[2] : values[0];
-    raw.y0 = values[1] < values[3] ? values[1] : values[3];
-    raw.y1 = values[1] < values[3] ? values[3] : values[1];
-    transformed = fz_transform_rect(raw, page_ctm);
-
-    if (!isfinite(transformed.x0) || !isfinite(transformed.y0) ||
-        !isfinite(transformed.x1) || !isfinite(transformed.y1))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    out_bounds->x0 = transformed.x0 < transformed.x1 ?
-        transformed.x0 : transformed.x1;
-    out_bounds->x1 = transformed.x0 < transformed.x1 ?
-        transformed.x1 : transformed.x0;
-    out_bounds->y0 = transformed.y0 < transformed.y1 ?
-        transformed.y0 : transformed.y1;
-    out_bounds->y1 = transformed.y0 < transformed.y1 ?
-        transformed.y1 : transformed.y0;
-    return EXTRACTPDF_OK;
-}
-
-static extractpdf_status extractpdf_annotation_read_flags(
-    fz_context *ctx,
-    pdf_obj *annotation,
-    uint32_t *out_flags)
-{
-    pdf_obj *flags_obj = NULL;
-    int64_t value;
-    int present;
-
-    *out_flags = 0;
-    present = extractpdf_annotation_dict_find(
-        ctx, annotation, PDF_NAME(F), &flags_obj);
-    if (!present)
-        return EXTRACTPDF_OK;
-    if (!pdf_is_int(ctx, flags_obj))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    value = pdf_to_int64(ctx, flags_obj);
-    if (value < 0 || (uint64_t)value > UINT32_MAX)
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    *out_flags = (uint32_t)value;
-    return EXTRACTPDF_OK;
-}
-
-static extractpdf_status extractpdf_annotation_read_contents(
-    fz_context *ctx,
-    pdf_obj *annotation,
-    extractpdf_annotation_page *annotations,
-    extractpdf_annotation_internal *item)
-{
-    pdf_obj *contents_obj = NULL;
-    const char *text;
-    int present;
-
-    present = extractpdf_annotation_dict_find(
-        ctx, annotation, PDF_NAME(Contents), &contents_obj);
-    if (!present)
-        return EXTRACTPDF_OK;
-    if (!pdf_is_string(ctx, contents_obj))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    text = pdf_to_text_string(ctx, contents_obj);
-    if (text == NULL)
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    item->has_contents = 1;
-    return extractpdf_annotation_append_string(
-        annotations,
-        text,
-        &item->contents_offset,
-        &item->contents_size);
-}
-
-static extractpdf_status extractpdf_annotation_materialize(
-    fz_context *ctx,
-    pdf_obj *annotation,
-    fz_matrix page_ctm,
-    extractpdf_annotation_page *annotations,
-    size_t index,
-    extractpdf_annotation_type type)
-{
-    extractpdf_annotation_internal *item = &annotations->items[index];
-    extractpdf_status status;
-
-    item->type = type;
-
-    status = extractpdf_annotation_read_bounds(
-        ctx, annotation, page_ctm, &item->bounds);
-    if (status != EXTRACTPDF_OK)
-        return status;
-
-    status = extractpdf_annotation_read_flags(
-        ctx, annotation, &item->flags);
-    if (status != EXTRACTPDF_OK)
-        return status;
-
-    return extractpdf_annotation_read_contents(
-        ctx, annotation, annotations, item);
-}
-
 extractpdf_status extractpdf_extract_annotations(
     extractpdf_page *page,
     extractpdf_annotation_page **out_annotations)
@@ -387,7 +154,8 @@ extractpdf_status extractpdf_extract_annotations(
 
                 if (!pdf_is_dict(ctx, annotation))
                     continue;
-                if (!extractpdf_annotation_classify(ctx, annotation, &type))
+                if (!extractpdf_pdf_annotation_classify(
+                        ctx, annotation, &type))
                     continue;
                 if (count == SIZE_MAX) {
                     status = EXTRACTPDF_ERROR_NOMEM;
@@ -434,25 +202,38 @@ extractpdf_status extractpdf_extract_annotations(
         for (index = 0; index < annotation_count; ++index) {
             pdf_obj *annotation = pdf_array_get(ctx, annots, index);
             extractpdf_annotation_type type;
+            extractpdf_pdf_annotation_view view;
+            extractpdf_annotation_internal *item;
 
             if (!pdf_is_dict(ctx, annotation))
                 continue;
-            if (!extractpdf_annotation_classify(ctx, annotation, &type))
+            if (!extractpdf_pdf_annotation_classify(
+                    ctx, annotation, &type))
                 continue;
             if (output_index >= annotations->count) {
                 status = EXTRACTPDF_ERROR_FORMAT;
                 break;
             }
 
-            status = extractpdf_annotation_materialize(
-                ctx,
-                annotation,
-                page_ctm,
-                annotations,
-                output_index,
-                type);
+            status = extractpdf_pdf_annotation_read_view(
+                ctx, annotation, type, page_ctm, &view);
             if (status != EXTRACTPDF_OK)
                 break;
+
+            item = &annotations->items[output_index];
+            item->type = view.type;
+            item->bounds = view.bounds;
+            item->flags = view.flags;
+            if (view.has_contents) {
+                status = extractpdf_annotation_append_string(
+                    annotations,
+                    view.contents_utf8,
+                    &item->contents_offset,
+                    &item->contents_size);
+                if (status != EXTRACTPDF_OK)
+                    break;
+                item->has_contents = 1;
+            }
             ++output_index;
         }
     }

--- a/src/pdf_edit.c
+++ b/src/pdf_edit.c
@@ -1,0 +1,362 @@
+#include "pdf_edit_internal.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static void extractpdf_pdf_edit_discard_log(
+    void *user,
+    const char *message)
+{
+    (void)user;
+    (void)message;
+}
+
+static uint64_t extractpdf_pdf_edit_mix64(uint64_t x)
+{
+    x ^= x >> 30;
+    x *= UINT64_C(0xbf58476d1ce4e5b9);
+    x ^= x >> 27;
+    x *= UINT64_C(0x94d049bb133111eb);
+    x ^= x >> 31;
+    return x;
+}
+
+static int extractpdf_pdf_edit_dict_has_key(
+    fz_context *ctx,
+    pdf_obj *dictionary,
+    pdf_obj *key)
+{
+    int count;
+    int index;
+
+    count = pdf_dict_len(ctx, dictionary);
+    for (index = 0; index < count; ++index) {
+        if (pdf_name_eq(ctx, pdf_dict_get_key(ctx, dictionary, index), key))
+            return 1;
+    }
+    return 0;
+}
+
+typedef struct extractpdf_pdf_edit_signature_scan {
+    pdf_document *document;
+    int has_signed_field;
+} extractpdf_pdf_edit_signature_scan;
+
+static void extractpdf_pdf_edit_scan_signature_field(
+    fz_context *ctx,
+    pdf_obj *field,
+    void *data,
+    pdf_obj **ft)
+{
+    extractpdf_pdf_edit_signature_scan *scan =
+        (extractpdf_pdf_edit_signature_scan *)data;
+
+    if (scan->has_signed_field)
+        return;
+    if (!pdf_name_eq(ctx, *ft, PDF_NAME(Sig)))
+        return;
+    if (pdf_signature_is_signed(ctx, scan->document, field))
+        scan->has_signed_field = 1;
+}
+
+static int extractpdf_pdf_edit_has_signed_field(
+    fz_context *ctx,
+    pdf_document *document)
+{
+    static pdf_obj *field_type_names[2] = {PDF_NAME(FT), NULL};
+    extractpdf_pdf_edit_signature_scan scan;
+    pdf_obj *field_type = NULL;
+    pdf_obj *fields;
+
+    scan.document = document;
+    scan.has_signed_field = 0;
+    fields = pdf_dict_getp(
+        ctx, pdf_trailer(ctx, document), "Root/AcroForm/Fields");
+    pdf_walk_tree(
+        ctx,
+        fields,
+        PDF_NAME(Kids),
+        extractpdf_pdf_edit_scan_signature_field,
+        NULL,
+        &scan,
+        field_type_names,
+        &field_type);
+    return scan.has_signed_field;
+}
+
+static void extractpdf_dispose_pdf_edit(extractpdf_pdf_edit *edit)
+{
+    size_t index;
+
+    if (edit == NULL)
+        return;
+
+    if (edit->ctx != NULL) {
+        for (index = 0; index < edit->entry_count; ++index) {
+            if (edit->entries[index].object != NULL)
+                pdf_drop_obj(edit->ctx, edit->entries[index].object);
+        }
+        if (edit->document != NULL)
+            pdf_drop_document(edit->ctx, edit->document);
+    }
+
+    free(edit->entries);
+    if (edit->ctx != NULL)
+        fz_drop_context(edit->ctx);
+    extractpdf_drop_output(edit->seed_output);
+    free(edit);
+}
+
+static uint64_t extractpdf_pdf_edit_session_cookie(
+    extractpdf_pdf_edit *edit)
+{
+    uint64_t random_bits = 0;
+    uint64_t seed;
+
+    fz_memrnd(
+        edit->ctx,
+        (unsigned char *)&random_bits,
+        (int)sizeof(random_bits));
+
+    seed = (uint64_t)(uintptr_t)edit;
+    seed ^= extractpdf_pdf_edit_mix64((uint64_t)(uintptr_t)edit->ctx);
+    seed ^= extractpdf_pdf_edit_mix64((uint64_t)(uintptr_t)edit->document);
+    seed ^= extractpdf_pdf_edit_mix64((uint64_t)time(NULL));
+    seed ^= extractpdf_pdf_edit_mix64((uint64_t)clock());
+    seed ^= random_bits;
+    seed = extractpdf_pdf_edit_mix64(seed);
+    if (seed == 0)
+        seed = UINT64_C(0x9e3779b97f4a7c15);
+    return seed;
+}
+
+extractpdf_status extractpdf_pdf_edit_begin(
+    extractpdf_document *source,
+    extractpdf_pdf_edit **out_edit)
+{
+    pdf_document *source_pdf;
+    extractpdf_output *seed_output = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+    fz_stream *stream = NULL;
+    int encrypted = 0;
+    int signed_field = 0;
+    int caught_code = FZ_ERROR_NONE;
+    extractpdf_status status;
+
+    if (out_edit == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_edit = NULL;
+
+    if (source == NULL || source->ctx == NULL || source->doc == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    source_pdf = pdf_document_from_fz_document(source->ctx, source->doc);
+    if (source_pdf == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    fz_var(encrypted);
+    fz_var(signed_field);
+    fz_var(caught_code);
+
+    fz_try(source->ctx)
+    {
+        pdf_obj *trailer = pdf_trailer(source->ctx, source_pdf);
+        encrypted = extractpdf_pdf_edit_dict_has_key(
+            source->ctx, trailer, PDF_NAME(Encrypt));
+        if (!encrypted)
+            signed_field = extractpdf_pdf_edit_has_signed_field(
+                source->ctx, source_pdf);
+    }
+    fz_catch(source->ctx)
+    {
+        caught_code = fz_caught(source->ctx);
+        fz_report_error(source->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (encrypted || signed_field)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    status = extractpdf_serialize_pdf(
+        source->ctx, source_pdf, &seed_output);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    edit = (extractpdf_pdf_edit *)calloc(1, sizeof(*edit));
+    if (edit == NULL) {
+        extractpdf_drop_output(seed_output);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    edit->seed_output = seed_output;
+
+    edit->ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (edit->ctx == NULL) {
+        extractpdf_dispose_pdf_edit(edit);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    fz_set_error_callback(
+        edit->ctx, extractpdf_pdf_edit_discard_log, NULL);
+    fz_set_warning_callback(
+        edit->ctx, extractpdf_pdf_edit_discard_log, NULL);
+
+    caught_code = FZ_ERROR_NONE;
+    fz_var(stream);
+    fz_var(caught_code);
+
+    fz_try(edit->ctx)
+    {
+        stream = fz_open_memory(
+            edit->ctx,
+            edit->seed_output->data,
+            edit->seed_output->size);
+        edit->document = pdf_open_document_with_stream(edit->ctx, stream);
+        pdf_disable_js(edit->ctx, edit->document);
+        pdf_enable_journal(edit->ctx, edit->document);
+        edit->session_cookie = extractpdf_pdf_edit_session_cookie(edit);
+    }
+    fz_always(edit->ctx)
+    {
+        fz_drop_stream(edit->ctx, stream);
+        stream = NULL;
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        status = extractpdf_status_from_mupdf(caught_code);
+        extractpdf_dispose_pdf_edit(edit);
+        return status;
+    }
+
+    if (edit->document == NULL || edit->session_cookie == 0) {
+        extractpdf_dispose_pdf_edit(edit);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+
+    *out_edit = edit;
+    return EXTRACTPDF_OK;
+}
+
+static void extractpdf_pdf_edit_drop_snapshot_state(
+    fz_context *ctx,
+    fz_buffer *buffer,
+    fz_output *memory_output)
+{
+    if (memory_output != NULL)
+        fz_drop_output(ctx, memory_output);
+    if (buffer != NULL)
+        fz_drop_buffer(ctx, buffer);
+}
+
+static extractpdf_status extractpdf_pdf_edit_snapshot_pdf(
+    extractpdf_pdf_edit *edit,
+    extractpdf_output **out_output)
+{
+    fz_buffer *buffer = NULL;
+    fz_output *memory_output = NULL;
+    unsigned char *data = NULL;
+    size_t size = 0;
+    extractpdf_output *result = NULL;
+    int caught_code = FZ_ERROR_NONE;
+
+    *out_output = NULL;
+
+    fz_var(buffer);
+    fz_var(memory_output);
+    fz_var(data);
+    fz_var(size);
+    fz_var(caught_code);
+
+    fz_try(edit->ctx)
+    {
+        buffer = fz_new_buffer(edit->ctx, 0);
+        memory_output = fz_new_output_with_buffer(edit->ctx, buffer);
+        pdf_write_snapshot(edit->ctx, edit->document, memory_output);
+        fz_close_output(edit->ctx, memory_output);
+        size = fz_buffer_storage(edit->ctx, buffer, &data);
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        extractpdf_status status =
+            extractpdf_status_from_mupdf(caught_code);
+        extractpdf_pdf_edit_drop_snapshot_state(
+            edit->ctx, buffer, memory_output);
+        return status;
+    }
+
+    if (data == NULL || size == 0) {
+        extractpdf_pdf_edit_drop_snapshot_state(
+            edit->ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+
+    result = (extractpdf_output *)calloc(1, sizeof(*result));
+    if (result == NULL) {
+        extractpdf_pdf_edit_drop_snapshot_state(
+            edit->ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    result->data = (unsigned char *)malloc(size);
+    if (result->data == NULL) {
+        free(result);
+        extractpdf_pdf_edit_drop_snapshot_state(
+            edit->ctx, buffer, memory_output);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    memcpy(result->data, data, size);
+    result->size = size;
+    extractpdf_pdf_edit_drop_snapshot_state(
+        edit->ctx, buffer, memory_output);
+
+    *out_output = result;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_pdf_edit_snapshot(
+    extractpdf_pdf_edit *edit,
+    extractpdf_output **out_output)
+{
+    extractpdf_output *result = NULL;
+    extractpdf_status status;
+
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_pdf_edit_snapshot_pdf(edit, &result);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+#if defined(EXTRACTPDF_TESTING)
+    if (edit->test_fault ==
+        EXTRACTPDF_PDF_EDIT_TEST_FAULT_SNAPSHOT_BEFORE_PUBLISH) {
+        edit->test_fault = EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE;
+        extractpdf_drop_output(result);
+        return EXTRACTPDF_ERROR_MUPDF;
+    }
+#endif
+
+    *out_output = result;
+    return EXTRACTPDF_OK;
+}
+
+void extractpdf_drop_pdf_edit(extractpdf_pdf_edit *edit)
+{
+    extractpdf_dispose_pdf_edit(edit);
+}

--- a/src/pdf_edit_annotations.c
+++ b/src/pdf_edit_annotations.c
@@ -1,5 +1,7 @@
 #include "pdf_edit_internal.h"
 
+#include <limits.h>
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -16,6 +18,118 @@ static void extractpdf_pdf_edit_zero_rect(extractpdf_rect *rect)
     rect->y0 = 0.0f;
     rect->x1 = 0.0f;
     rect->y1 = 0.0f;
+}
+
+static int extractpdf_pdf_edit_bounds_valid(extractpdf_rect bounds)
+{
+    return isfinite(bounds.x0) && isfinite(bounds.y0) &&
+        isfinite(bounds.x1) && isfinite(bounds.y1) &&
+        bounds.x0 <= bounds.x1 && bounds.y0 <= bounds.y1;
+}
+
+static int extractpdf_pdf_edit_utf8_valid(
+    const unsigned char *text,
+    size_t size)
+{
+    size_t i = 0;
+
+    while (i < size) {
+        unsigned char a = text[i];
+
+        if (a == 0)
+            return 0;
+        if (a <= 0x7f) {
+            ++i;
+            continue;
+        }
+        if (a >= 0xc2 && a <= 0xdf) {
+            if (i + 1 >= size || text[i + 1] < 0x80 || text[i + 1] > 0xbf)
+                return 0;
+            i += 2;
+            continue;
+        }
+        if (a == 0xe0) {
+            if (i + 2 >= size || text[i + 1] < 0xa0 || text[i + 1] > 0xbf ||
+                text[i + 2] < 0x80 || text[i + 2] > 0xbf)
+                return 0;
+            i += 3;
+            continue;
+        }
+        if ((a >= 0xe1 && a <= 0xec) || (a >= 0xee && a <= 0xef)) {
+            if (i + 2 >= size || text[i + 1] < 0x80 || text[i + 1] > 0xbf ||
+                text[i + 2] < 0x80 || text[i + 2] > 0xbf)
+                return 0;
+            i += 3;
+            continue;
+        }
+        if (a == 0xed) {
+            if (i + 2 >= size || text[i + 1] < 0x80 || text[i + 1] > 0x9f ||
+                text[i + 2] < 0x80 || text[i + 2] > 0xbf)
+                return 0;
+            i += 3;
+            continue;
+        }
+        if (a == 0xf0) {
+            if (i + 3 >= size || text[i + 1] < 0x90 || text[i + 1] > 0xbf ||
+                text[i + 2] < 0x80 || text[i + 2] > 0xbf ||
+                text[i + 3] < 0x80 || text[i + 3] > 0xbf)
+                return 0;
+            i += 4;
+            continue;
+        }
+        if (a >= 0xf1 && a <= 0xf3) {
+            if (i + 3 >= size || text[i + 1] < 0x80 || text[i + 1] > 0xbf ||
+                text[i + 2] < 0x80 || text[i + 2] > 0xbf ||
+                text[i + 3] < 0x80 || text[i + 3] > 0xbf)
+                return 0;
+            i += 4;
+            continue;
+        }
+        if (a == 0xf4) {
+            if (i + 3 >= size || text[i + 1] < 0x80 || text[i + 1] > 0x8f ||
+                text[i + 2] < 0x80 || text[i + 2] > 0xbf ||
+                text[i + 3] < 0x80 || text[i + 3] > 0xbf)
+                return 0;
+            i += 4;
+            continue;
+        }
+        return 0;
+    }
+    return 1;
+}
+
+static extractpdf_status extractpdf_pdf_edit_prepare_contents(
+    const char *contents_utf8,
+    size_t contents_size,
+    int *out_present,
+    char **out_copy)
+{
+    char *copy;
+
+    *out_present = 0;
+    *out_copy = NULL;
+
+    if (contents_utf8 == NULL) {
+        if (contents_size != 0)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        return EXTRACTPDF_OK;
+    }
+
+    *out_present = 1;
+    if (!extractpdf_pdf_edit_utf8_valid(
+            (const unsigned char *)contents_utf8, contents_size))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (contents_size == SIZE_MAX)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    copy = (char *)malloc(contents_size + 1);
+    if (copy == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+    if (contents_size != 0)
+        memcpy(copy, contents_utf8, contents_size);
+    copy[contents_size] = '\0';
+    *out_copy = copy;
+    return EXTRACTPDF_OK;
 }
 
 static uint64_t extractpdf_pdf_edit_mix_token(uint64_t x)
@@ -42,7 +156,6 @@ static extractpdf_status extractpdf_pdf_edit_validate_page(
 
     fz_var(page_count);
     fz_var(caught_code);
-
     fz_try(edit->ctx)
     {
         page_count = pdf_count_pages(edit->ctx, edit->document);
@@ -86,8 +199,7 @@ static extractpdf_status extractpdf_pdf_edit_reserve_entries(
 
     if (needed <= edit->entry_capacity)
         return EXTRACTPDF_OK;
-    if (needed > maximum ||
-        needed > SIZE_MAX / sizeof(*edit->entries))
+    if (needed > maximum || needed > SIZE_MAX / sizeof(*edit->entries))
         return EXTRACTPDF_ERROR_NOMEM;
 
     capacity = edit->entry_capacity != 0 ? edit->entry_capacity : 8;
@@ -108,8 +220,7 @@ static extractpdf_status extractpdf_pdf_edit_reserve_entries(
         }
         capacity = next;
     }
-    if (capacity < needed ||
-        capacity > SIZE_MAX / sizeof(*edit->entries))
+    if (capacity < needed || capacity > SIZE_MAX / sizeof(*edit->entries))
         return EXTRACTPDF_ERROR_NOMEM;
 
     grown = (extractpdf_pdf_edit_annotation_entry *)realloc(
@@ -164,8 +275,7 @@ static extractpdf_status extractpdf_pdf_edit_resolve_ref(
 
     if (out_entry != NULL)
         *out_entry = NULL;
-    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
-        ref == NULL)
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL || ref == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
     if (ref->opaque[0] != edit->session_cookie)
         return EXTRACTPDF_ERROR_ARGUMENT;
@@ -205,8 +315,7 @@ static extractpdf_status extractpdf_pdf_edit_register_object(
 
         if (!entry->live || entry->object == NULL)
             continue;
-        if (extractpdf_pdf_edit_same_identity(
-                edit->ctx, entry->object, object)) {
+        if (extractpdf_pdf_edit_same_identity(edit->ctx, entry->object, object)) {
             pdf_drop_obj(edit->ctx, object);
             extractpdf_pdf_edit_make_token(edit, slot, out_ref);
             return EXTRACTPDF_OK;
@@ -217,9 +326,7 @@ static extractpdf_status extractpdf_pdf_edit_register_object(
         pdf_drop_obj(edit->ctx, object);
         return EXTRACTPDF_ERROR_NOMEM;
     }
-
-    status = extractpdf_pdf_edit_reserve_entries(
-        edit, edit->entry_count + 1);
+    status = extractpdf_pdf_edit_reserve_entries(edit, edit->entry_count + 1);
     if (status != EXTRACTPDF_OK) {
         pdf_drop_obj(edit->ctx, object);
         return status;
@@ -231,7 +338,6 @@ static extractpdf_status extractpdf_pdf_edit_register_object(
     edit->entries[slot].tag = extractpdf_pdf_edit_tag_for_slot(edit, slot);
     edit->entries[slot].live = 1;
     ++edit->entry_count;
-
     extractpdf_pdf_edit_make_token(edit, slot, out_ref);
     return EXTRACTPDF_OK;
 }
@@ -247,7 +353,7 @@ static extractpdf_status extractpdf_pdf_edit_scan_page(
     pdf_page *page = NULL;
     pdf_obj *kept = NULL;
     size_t count = 0;
-    extractpdf_status status;
+    extractpdf_status status = EXTRACTPDF_OK;
     int caught_code = FZ_ERROR_NONE;
 
     if (out_count != NULL)
@@ -264,8 +370,6 @@ static extractpdf_status extractpdf_pdf_edit_scan_page(
     fz_var(count);
     fz_var(status);
     fz_var(caught_code);
-
-    status = EXTRACTPDF_OK;
     fz_try(edit->ctx)
     {
         pdf_obj *annots;
@@ -286,8 +390,7 @@ static extractpdf_status extractpdf_pdf_edit_scan_page(
 
             if (!pdf_is_dict(edit->ctx, annotation))
                 continue;
-            if (!extractpdf_pdf_annotation_classify(
-                    edit->ctx, annotation, &type))
+            if (!extractpdf_pdf_annotation_classify(edit->ctx, annotation, &type))
                 continue;
 
             status = extractpdf_pdf_annotation_read_view(
@@ -353,11 +456,9 @@ static extractpdf_status extractpdf_pdf_edit_resolve_live_annot(
 
     *out_page = NULL;
     *out_annot = NULL;
-
     fz_var(page);
     fz_var(found);
     fz_var(caught_code);
-
     fz_try(edit->ctx)
     {
         pdf_annot *annotation;
@@ -367,9 +468,7 @@ static extractpdf_status extractpdf_pdf_edit_resolve_live_annot(
              annotation != NULL;
              annotation = pdf_next_annot(edit->ctx, annotation)) {
             if (extractpdf_pdf_edit_same_identity(
-                    edit->ctx,
-                    pdf_annot_obj(edit->ctx, annotation),
-                    entry->object)) {
+                    edit->ctx, pdf_annot_obj(edit->ctx, annotation), entry->object)) {
                 found = annotation;
                 break;
             }
@@ -420,12 +519,11 @@ static extractpdf_status extractpdf_pdf_edit_resolve_live_view(
     status = extractpdf_pdf_edit_resolve_ref(edit, ref, &entry);
     if (status != EXTRACTPDF_OK)
         return status;
-
-    status = extractpdf_pdf_edit_resolve_live_annot(
-        edit, entry, &page, &annotation);
+    status = extractpdf_pdf_edit_resolve_live_annot(edit, entry, &page, &annotation);
     if (status != EXTRACTPDF_OK)
         return status;
 
+    fz_var(status);
     fz_var(caught_code);
     fz_try(edit->ctx)
     {
@@ -433,8 +531,7 @@ static extractpdf_status extractpdf_pdf_edit_resolve_live_view(
         fz_matrix page_ctm;
         pdf_obj *object = pdf_annot_obj(edit->ctx, annotation);
 
-        if (!extractpdf_pdf_annotation_classify(
-                edit->ctx, object, &type)) {
+        if (!extractpdf_pdf_annotation_classify(edit->ctx, object, &type)) {
             status = EXTRACTPDF_ERROR_STATE;
         } else {
             pdf_page_transform(edit->ctx, page, NULL, &page_ctm);
@@ -464,6 +561,45 @@ static extractpdf_status extractpdf_pdf_edit_resolve_live_view(
     return EXTRACTPDF_OK;
 }
 
+static int extractpdf_pdf_edit_map_create_type(
+    extractpdf_annotation_type type,
+    enum pdf_annot_type *out_type)
+{
+    switch (type) {
+    case EXTRACTPDF_ANNOTATION_TEXT:
+        *out_type = PDF_ANNOT_TEXT;
+        return 1;
+    case EXTRACTPDF_ANNOTATION_FREE_TEXT:
+        *out_type = PDF_ANNOT_FREE_TEXT;
+        return 1;
+    case EXTRACTPDF_ANNOTATION_SQUARE:
+        *out_type = PDF_ANNOT_SQUARE;
+        return 1;
+    case EXTRACTPDF_ANNOTATION_CIRCLE:
+        *out_type = PDF_ANNOT_CIRCLE;
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static void extractpdf_pdf_edit_set_flags_u32(
+    fz_context *ctx,
+    pdf_annot *annotation,
+    uint32_t flags)
+{
+    if (flags <= (uint32_t)INT_MAX) {
+        pdf_set_annot_flags(ctx, annotation, (int)flags);
+    } else {
+        pdf_dict_put_int(
+            ctx,
+            pdf_annot_obj(ctx, annotation),
+            PDF_NAME(F),
+            (int64_t)(uint64_t)flags);
+        pdf_annot_request_resynthesis(ctx, annotation);
+    }
+}
+
 extractpdf_status extractpdf_pdf_edit_annotation_count(
     extractpdf_pdf_edit *edit,
     int page_index,
@@ -477,11 +613,9 @@ extractpdf_status extractpdf_pdf_edit_annotation_count(
     if (out_count == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    status = extractpdf_pdf_edit_scan_page(
-        edit, page_index, 0, 0, &count, NULL);
+    status = extractpdf_pdf_edit_scan_page(edit, page_index, 0, 0, &count, NULL);
     if (status != EXTRACTPDF_OK)
         return status;
-
     *out_count = count;
     return EXTRACTPDF_OK;
 }
@@ -505,9 +639,7 @@ extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
         edit, page_index, index, 1, &count, &object);
     if (status != EXTRACTPDF_OK)
         return status;
-
-    return extractpdf_pdf_edit_register_object(
-        edit, object, page_index, out_ref);
+    return extractpdf_pdf_edit_register_object(edit, object, page_index, out_ref);
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_get_info(
@@ -524,9 +656,7 @@ extractpdf_status extractpdf_pdf_edit_annotation_get_info(
 
     if (out_info == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
-
-    minimum_size = offsetof(extractpdf_annotation_info, flags) +
-        sizeof(out_info->flags);
+    minimum_size = offsetof(extractpdf_annotation_info, flags) + sizeof(out_info->flags);
     if (out_info->struct_size < minimum_size)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
@@ -592,7 +722,6 @@ extractpdf_status extractpdf_pdf_edit_annotation_contents(
     memcpy(copy, view.contents_utf8, view.contents_size);
     copy[view.contents_size] = '\0';
     fz_drop_page(edit->ctx, &page->super);
-
     *out_utf8 = copy;
     *out_size = view.contents_size;
     return EXTRACTPDF_OK;
@@ -604,8 +733,16 @@ extractpdf_status extractpdf_pdf_edit_annotation_create(
     const extractpdf_annotation_create_options *options,
     extractpdf_annotation_ref *out_ref)
 {
-    size_t minimum_size;
+    enum pdf_annot_type pdf_type = PDF_ANNOT_UNKNOWN;
+    pdf_page *page = NULL;
+    pdf_annot *annotation = NULL;
+    pdf_obj *object = NULL;
+    char *contents_copy = NULL;
+    int contents_present = 0;
+    int operation_open = 0;
+    int caught_code = FZ_ERROR_NONE;
     extractpdf_status status;
+    size_t minimum_size;
 
     if (out_ref != NULL)
         extractpdf_pdf_edit_zero_ref(out_ref);
@@ -620,7 +757,97 @@ extractpdf_status extractpdf_pdf_edit_annotation_create(
     status = extractpdf_pdf_edit_validate_page(edit, page_index);
     if (status != EXTRACTPDF_OK)
         return status;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    if (!extractpdf_pdf_edit_map_create_type(options->type, &pdf_type))
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    if (!extractpdf_pdf_edit_bounds_valid(options->bounds))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_pdf_edit_prepare_contents(
+        options->contents_utf8,
+        options->contents_size,
+        &contents_present,
+        &contents_copy);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    status = extractpdf_pdf_edit_reserve_entries(edit, edit->entry_count + 1);
+    if (status != EXTRACTPDF_OK) {
+        free(contents_copy);
+        return status;
+    }
+
+    fz_var(page);
+    fz_var(annotation);
+    fz_var(object);
+    fz_var(operation_open);
+    fz_var(caught_code);
+    fz_try(edit->ctx)
+    {
+        fz_rect bounds = fz_make_rect(
+            options->bounds.x0,
+            options->bounds.y0,
+            options->bounds.x1,
+            options->bounds.y1);
+
+        page = pdf_load_page(edit->ctx, edit->document, page_index);
+        pdf_begin_operation(
+            edit->ctx, edit->document, "ExtractPDF create annotation");
+        operation_open = 1;
+
+        annotation = pdf_create_annot(edit->ctx, page, pdf_type);
+        pdf_set_annot_rect(edit->ctx, annotation, bounds);
+        extractpdf_pdf_edit_set_flags_u32(
+            edit->ctx, annotation, options->flags);
+        if (contents_present)
+            pdf_set_annot_contents(edit->ctx, annotation, contents_copy);
+        (void)pdf_update_annot(edit->ctx, annotation);
+
+#if defined(EXTRACTPDF_TESTING)
+        if (edit->test_fault ==
+            EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_CREATE_MUTATION) {
+            edit->test_fault = EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE;
+            fz_throw(
+                edit->ctx,
+                FZ_ERROR_GENERIC,
+                "injected ExtractPDF create failure");
+        }
+#endif
+
+        pdf_end_operation(edit->ctx, edit->document);
+        operation_open = 0;
+        object = pdf_keep_obj(
+            edit->ctx, pdf_annot_obj(edit->ctx, annotation));
+    }
+    fz_always(edit->ctx)
+    {
+        if (annotation != NULL)
+            pdf_drop_annot(edit->ctx, annotation);
+        annotation = NULL;
+        if (page != NULL)
+            fz_drop_page(edit->ctx, &page->super);
+        page = NULL;
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        if (operation_open) {
+            pdf_abandon_operation(edit->ctx, edit->document);
+            operation_open = 0;
+        }
+        fz_report_error(edit->ctx);
+    }
+
+    free(contents_copy);
+    if (caught_code != FZ_ERROR_NONE) {
+        pdf_drop_obj(edit->ctx, object);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+    if (object == NULL)
+        return EXTRACTPDF_ERROR_MUPDF;
+
+    status = extractpdf_pdf_edit_register_object(
+        edit, object, page_index, out_ref);
+    return status;
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_update(
@@ -638,7 +865,6 @@ extractpdf_status extractpdf_pdf_edit_annotation_update(
 
     if (update == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
-
     minimum_size = offsetof(extractpdf_annotation_update, contents_size) +
         sizeof(update->contents_size);
     if (update->struct_size < minimum_size)
@@ -650,7 +876,6 @@ extractpdf_status extractpdf_pdf_edit_annotation_update(
     if (status != EXTRACTPDF_OK)
         return status;
     (void)entry;
-
     if (update->fields == 0)
         return EXTRACTPDF_OK;
     return EXTRACTPDF_ERROR_UNSUPPORTED;
@@ -661,8 +886,7 @@ extractpdf_status extractpdf_pdf_edit_annotation_delete(
     const extractpdf_annotation_ref *ref)
 {
     extractpdf_pdf_edit_annotation_entry *entry = NULL;
-    extractpdf_status status = extractpdf_pdf_edit_resolve_ref(
-        edit, ref, &entry);
+    extractpdf_status status = extractpdf_pdf_edit_resolve_ref(edit, ref, &entry);
 
     (void)entry;
     if (status != EXTRACTPDF_OK)

--- a/src/pdf_edit_annotations.c
+++ b/src/pdf_edit_annotations.c
@@ -1,6 +1,8 @@
 #include "pdf_edit_internal.h"
 
 #include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 static void extractpdf_pdf_edit_zero_ref(extractpdf_annotation_ref *ref)
@@ -16,6 +18,16 @@ static void extractpdf_pdf_edit_zero_rect(extractpdf_rect *rect)
     rect->y1 = 0.0f;
 }
 
+static uint64_t extractpdf_pdf_edit_mix_token(uint64_t x)
+{
+    x ^= x >> 30;
+    x *= UINT64_C(0xbf58476d1ce4e5b9);
+    x ^= x >> 27;
+    x *= UINT64_C(0x94d049bb133111eb);
+    x ^= x >> 31;
+    return x;
+}
+
 static extractpdf_status extractpdf_pdf_edit_validate_page(
     extractpdf_pdf_edit *edit,
     int page_index)
@@ -25,7 +37,6 @@ static extractpdf_status extractpdf_pdf_edit_validate_page(
 
     if (edit == NULL || edit->ctx == NULL || edit->document == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
-
     if (page_index < 0)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
@@ -49,11 +60,416 @@ static extractpdf_status extractpdf_pdf_edit_validate_page(
     return EXTRACTPDF_OK;
 }
 
+static int extractpdf_pdf_edit_same_identity(
+    fz_context *ctx,
+    pdf_obj *a,
+    pdf_obj *b)
+{
+    int ai = pdf_is_indirect(ctx, a);
+    int bi = pdf_is_indirect(ctx, b);
+
+    if (ai || bi) {
+        return ai && bi &&
+            pdf_to_num(ctx, a) == pdf_to_num(ctx, b) &&
+            pdf_to_gen(ctx, a) == pdf_to_gen(ctx, b);
+    }
+    return a == b;
+}
+
+static extractpdf_status extractpdf_pdf_edit_reserve_entries(
+    extractpdf_pdf_edit *edit,
+    size_t needed)
+{
+    extractpdf_pdf_edit_annotation_entry *grown;
+    size_t capacity;
+    size_t maximum = (size_t)UINT32_MAX - 1;
+
+    if (needed <= edit->entry_capacity)
+        return EXTRACTPDF_OK;
+    if (needed > maximum ||
+        needed > SIZE_MAX / sizeof(*edit->entries))
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    capacity = edit->entry_capacity != 0 ? edit->entry_capacity : 8;
+    while (capacity < needed) {
+        size_t next;
+
+        if (capacity >= maximum) {
+            capacity = maximum;
+            break;
+        }
+        if (capacity > maximum / 2)
+            next = maximum;
+        else
+            next = capacity * 2;
+        if (next <= capacity) {
+            capacity = maximum;
+            break;
+        }
+        capacity = next;
+    }
+    if (capacity < needed ||
+        capacity > SIZE_MAX / sizeof(*edit->entries))
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    grown = (extractpdf_pdf_edit_annotation_entry *)realloc(
+        edit->entries, capacity * sizeof(*edit->entries));
+    if (grown == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    memset(
+        grown + edit->entry_capacity,
+        0,
+        (capacity - edit->entry_capacity) * sizeof(*grown));
+    edit->entries = grown;
+    edit->entry_capacity = capacity;
+    return EXTRACTPDF_OK;
+}
+
+static uint32_t extractpdf_pdf_edit_tag_for_slot(
+    extractpdf_pdf_edit *edit,
+    size_t slot)
+{
+    uint64_t mixed = extractpdf_pdf_edit_mix_token(
+        edit->session_cookie ^ (uint64_t)(slot + 1));
+    uint32_t tag = (uint32_t)(mixed ^ (mixed >> 32));
+
+    if (tag == 0)
+        tag = 1;
+    return tag;
+}
+
+static void extractpdf_pdf_edit_make_token(
+    extractpdf_pdf_edit *edit,
+    size_t slot,
+    extractpdf_annotation_ref *out_ref)
+{
+    const extractpdf_pdf_edit_annotation_entry *entry = &edit->entries[slot];
+
+    out_ref->opaque[0] = edit->session_cookie;
+    out_ref->opaque[1] =
+        ((uint64_t)entry->tag << 32) | (uint64_t)(slot + 1);
+}
+
+static extractpdf_status extractpdf_pdf_edit_resolve_ref(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    extractpdf_pdf_edit_annotation_entry **out_entry)
+{
+    uint64_t encoded;
+    uint32_t slot_plus_one;
+    uint32_t tag;
+    size_t slot;
+    extractpdf_pdf_edit_annotation_entry *entry;
+
+    if (out_entry != NULL)
+        *out_entry = NULL;
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
+        ref == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (ref->opaque[0] != edit->session_cookie)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    encoded = ref->opaque[1];
+    slot_plus_one = (uint32_t)(encoded & UINT32_MAX);
+    tag = (uint32_t)(encoded >> 32);
+    if (slot_plus_one == 0 || tag == 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    slot = (size_t)slot_plus_one - 1;
+    if (slot >= edit->entry_count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    entry = &edit->entries[slot];
+    if (entry->tag != tag)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (!entry->live || entry->object == NULL)
+        return EXTRACTPDF_ERROR_STATE;
+
+    if (out_entry != NULL)
+        *out_entry = entry;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_edit_register_object(
+    extractpdf_pdf_edit *edit,
+    pdf_obj *object,
+    int page_index,
+    extractpdf_annotation_ref *out_ref)
+{
+    extractpdf_status status;
+    size_t slot;
+
+    for (slot = 0; slot < edit->entry_count; ++slot) {
+        extractpdf_pdf_edit_annotation_entry *entry = &edit->entries[slot];
+
+        if (!entry->live || entry->object == NULL)
+            continue;
+        if (extractpdf_pdf_edit_same_identity(
+                edit->ctx, entry->object, object)) {
+            pdf_drop_obj(edit->ctx, object);
+            extractpdf_pdf_edit_make_token(edit, slot, out_ref);
+            return EXTRACTPDF_OK;
+        }
+    }
+
+    if (edit->entry_count >= (size_t)UINT32_MAX - 1) {
+        pdf_drop_obj(edit->ctx, object);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    status = extractpdf_pdf_edit_reserve_entries(
+        edit, edit->entry_count + 1);
+    if (status != EXTRACTPDF_OK) {
+        pdf_drop_obj(edit->ctx, object);
+        return status;
+    }
+
+    slot = edit->entry_count;
+    edit->entries[slot].object = object;
+    edit->entries[slot].page_index = page_index;
+    edit->entries[slot].tag = extractpdf_pdf_edit_tag_for_slot(edit, slot);
+    edit->entries[slot].live = 1;
+    ++edit->entry_count;
+
+    extractpdf_pdf_edit_make_token(edit, slot, out_ref);
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_edit_scan_page(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t wanted_index,
+    int want_object,
+    size_t *out_count,
+    pdf_obj **out_object)
+{
+    pdf_page *page = NULL;
+    pdf_obj *kept = NULL;
+    size_t count = 0;
+    extractpdf_status status;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_count != NULL)
+        *out_count = 0;
+    if (out_object != NULL)
+        *out_object = NULL;
+
+    status = extractpdf_pdf_edit_validate_page(edit, page_index);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    fz_var(page);
+    fz_var(kept);
+    fz_var(count);
+    fz_var(status);
+    fz_var(caught_code);
+
+    status = EXTRACTPDF_OK;
+    fz_try(edit->ctx)
+    {
+        pdf_obj *annots;
+        pdf_obj *wanted = NULL;
+        fz_matrix page_ctm;
+        int raw_count;
+        int index;
+
+        page = pdf_load_page(edit->ctx, edit->document, page_index);
+        pdf_page_transform(edit->ctx, page, NULL, &page_ctm);
+        annots = pdf_dict_get(edit->ctx, page->obj, PDF_NAME(Annots));
+        raw_count = pdf_array_len(edit->ctx, annots);
+
+        for (index = 0; index < raw_count; ++index) {
+            pdf_obj *annotation = pdf_array_get(edit->ctx, annots, index);
+            extractpdf_annotation_type type;
+            extractpdf_pdf_annotation_view view;
+
+            if (!pdf_is_dict(edit->ctx, annotation))
+                continue;
+            if (!extractpdf_pdf_annotation_classify(
+                    edit->ctx, annotation, &type))
+                continue;
+
+            status = extractpdf_pdf_annotation_read_view(
+                edit->ctx, annotation, type, page_ctm, &view);
+            if (status != EXTRACTPDF_OK)
+                break;
+
+            if (want_object && count == wanted_index)
+                wanted = annotation;
+            if (count == SIZE_MAX) {
+                status = EXTRACTPDF_ERROR_NOMEM;
+                break;
+            }
+            ++count;
+        }
+
+        if (status == EXTRACTPDF_OK && want_object) {
+            if (wanted_index >= count || wanted == NULL)
+                status = EXTRACTPDF_ERROR_ARGUMENT;
+            else
+                kept = pdf_keep_obj(edit->ctx, wanted);
+        }
+    }
+    fz_always(edit->ctx)
+    {
+        if (page != NULL)
+            fz_drop_page(edit->ctx, &page->super);
+        page = NULL;
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        pdf_drop_obj(edit->ctx, kept);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+    if (status != EXTRACTPDF_OK) {
+        pdf_drop_obj(edit->ctx, kept);
+        return status;
+    }
+
+    if (out_count != NULL)
+        *out_count = count;
+    if (out_object != NULL)
+        *out_object = kept;
+    else
+        pdf_drop_obj(edit->ctx, kept);
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_edit_resolve_live_annot(
+    extractpdf_pdf_edit *edit,
+    extractpdf_pdf_edit_annotation_entry *entry,
+    pdf_page **out_page,
+    pdf_annot **out_annot)
+{
+    pdf_page *page = NULL;
+    pdf_annot *found = NULL;
+    int caught_code = FZ_ERROR_NONE;
+
+    *out_page = NULL;
+    *out_annot = NULL;
+
+    fz_var(page);
+    fz_var(found);
+    fz_var(caught_code);
+
+    fz_try(edit->ctx)
+    {
+        pdf_annot *annotation;
+
+        page = pdf_load_page(edit->ctx, edit->document, entry->page_index);
+        for (annotation = pdf_first_annot(edit->ctx, page);
+             annotation != NULL;
+             annotation = pdf_next_annot(edit->ctx, annotation)) {
+            if (extractpdf_pdf_edit_same_identity(
+                    edit->ctx,
+                    pdf_annot_obj(edit->ctx, annotation),
+                    entry->object)) {
+                found = annotation;
+                break;
+            }
+        }
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        if (page != NULL)
+            fz_drop_page(edit->ctx, &page->super);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+    if (found == NULL) {
+        if (page != NULL)
+            fz_drop_page(edit->ctx, &page->super);
+        return EXTRACTPDF_ERROR_STATE;
+    }
+
+    *out_page = page;
+    *out_annot = found;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_edit_resolve_live_view(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    extractpdf_pdf_edit_annotation_entry **out_entry,
+    pdf_page **out_page,
+    pdf_annot **out_annot,
+    extractpdf_pdf_annotation_view *out_view)
+{
+    extractpdf_pdf_edit_annotation_entry *entry = NULL;
+    pdf_page *page = NULL;
+    pdf_annot *annotation = NULL;
+    extractpdf_status status;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (out_entry != NULL)
+        *out_entry = NULL;
+    *out_page = NULL;
+    *out_annot = NULL;
+    memset(out_view, 0, sizeof(*out_view));
+
+    status = extractpdf_pdf_edit_resolve_ref(edit, ref, &entry);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    status = extractpdf_pdf_edit_resolve_live_annot(
+        edit, entry, &page, &annotation);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    fz_var(caught_code);
+    fz_try(edit->ctx)
+    {
+        extractpdf_annotation_type type;
+        fz_matrix page_ctm;
+        pdf_obj *object = pdf_annot_obj(edit->ctx, annotation);
+
+        if (!extractpdf_pdf_annotation_classify(
+                edit->ctx, object, &type)) {
+            status = EXTRACTPDF_ERROR_STATE;
+        } else {
+            pdf_page_transform(edit->ctx, page, NULL, &page_ctm);
+            status = extractpdf_pdf_annotation_read_view(
+                edit->ctx, object, type, page_ctm, out_view);
+        }
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        fz_drop_page(edit->ctx, &page->super);
+        return extractpdf_status_from_mupdf(caught_code);
+    }
+    if (status != EXTRACTPDF_OK) {
+        fz_drop_page(edit->ctx, &page->super);
+        return status;
+    }
+
+    if (out_entry != NULL)
+        *out_entry = entry;
+    *out_page = page;
+    *out_annot = annotation;
+    return EXTRACTPDF_OK;
+}
+
 extractpdf_status extractpdf_pdf_edit_annotation_count(
     extractpdf_pdf_edit *edit,
     int page_index,
     size_t *out_count)
 {
+    size_t count = 0;
     extractpdf_status status;
 
     if (out_count != NULL)
@@ -61,10 +477,13 @@ extractpdf_status extractpdf_pdf_edit_annotation_count(
     if (out_count == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    status = extractpdf_pdf_edit_validate_page(edit, page_index);
+    status = extractpdf_pdf_edit_scan_page(
+        edit, page_index, 0, 0, &count, NULL);
     if (status != EXTRACTPDF_OK)
         return status;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    *out_count = count;
+    return EXTRACTPDF_OK;
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
@@ -73,19 +492,22 @@ extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
     size_t index,
     extractpdf_annotation_ref *out_ref)
 {
+    pdf_obj *object = NULL;
+    size_t count = 0;
     extractpdf_status status;
-
-    (void)index;
 
     if (out_ref != NULL)
         extractpdf_pdf_edit_zero_ref(out_ref);
     if (out_ref == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    status = extractpdf_pdf_edit_validate_page(edit, page_index);
+    status = extractpdf_pdf_edit_scan_page(
+        edit, page_index, index, 1, &count, &object);
     if (status != EXTRACTPDF_OK)
         return status;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    return extractpdf_pdf_edit_register_object(
+        edit, object, page_index, out_ref);
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_get_info(
@@ -93,6 +515,11 @@ extractpdf_status extractpdf_pdf_edit_annotation_get_info(
     const extractpdf_annotation_ref *ref,
     extractpdf_annotation_info *out_info)
 {
+    extractpdf_pdf_edit_annotation_entry *entry = NULL;
+    pdf_page *page = NULL;
+    pdf_annot *annotation = NULL;
+    extractpdf_pdf_annotation_view view;
+    extractpdf_status status;
     size_t minimum_size;
 
     if (out_info == NULL)
@@ -107,11 +534,18 @@ extractpdf_status extractpdf_pdf_edit_annotation_get_info(
     extractpdf_pdf_edit_zero_rect(&out_info->bounds);
     out_info->flags = 0;
 
-    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
-        ref == NULL)
-        return EXTRACTPDF_ERROR_ARGUMENT;
+    status = extractpdf_pdf_edit_resolve_live_view(
+        edit, ref, &entry, &page, &annotation, &view);
+    if (status != EXTRACTPDF_OK)
+        return status;
 
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    (void)entry;
+    (void)annotation;
+    out_info->type = view.type;
+    out_info->bounds = view.bounds;
+    out_info->flags = view.flags;
+    fz_drop_page(edit->ctx, &page->super);
+    return EXTRACTPDF_OK;
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_contents(
@@ -120,16 +554,48 @@ extractpdf_status extractpdf_pdf_edit_annotation_contents(
     char **out_utf8,
     size_t *out_size)
 {
+    extractpdf_pdf_edit_annotation_entry *entry = NULL;
+    pdf_page *page = NULL;
+    pdf_annot *annotation = NULL;
+    extractpdf_pdf_annotation_view view;
+    extractpdf_status status;
+    char *copy;
+
     if (out_utf8 != NULL)
         *out_utf8 = NULL;
     if (out_size != NULL)
         *out_size = 0;
-
-    if (out_utf8 == NULL || out_size == NULL || edit == NULL ||
-        edit->ctx == NULL || edit->document == NULL || ref == NULL)
+    if (out_utf8 == NULL || out_size == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    status = extractpdf_pdf_edit_resolve_live_view(
+        edit, ref, &entry, &page, &annotation, &view);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    (void)entry;
+    (void)annotation;
+    if (!view.has_contents) {
+        fz_drop_page(edit->ctx, &page->super);
+        return EXTRACTPDF_OK;
+    }
+    if (view.contents_size == SIZE_MAX) {
+        fz_drop_page(edit->ctx, &page->super);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+
+    copy = (char *)malloc(view.contents_size + 1);
+    if (copy == NULL) {
+        fz_drop_page(edit->ctx, &page->super);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    memcpy(copy, view.contents_utf8, view.contents_size);
+    copy[view.contents_size] = '\0';
+    fz_drop_page(edit->ctx, &page->super);
+
+    *out_utf8 = copy;
+    *out_size = view.contents_size;
+    return EXTRACTPDF_OK;
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_create(
@@ -166,6 +632,8 @@ extractpdf_status extractpdf_pdf_edit_annotation_update(
         EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
         EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
         EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    extractpdf_pdf_edit_annotation_entry *entry = NULL;
+    extractpdf_status status;
     size_t minimum_size;
 
     if (update == NULL)
@@ -178,10 +646,13 @@ extractpdf_status extractpdf_pdf_edit_annotation_update(
     if ((update->fields & ~known_fields) != 0)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
-        ref == NULL)
-        return EXTRACTPDF_ERROR_ARGUMENT;
+    status = extractpdf_pdf_edit_resolve_ref(edit, ref, &entry);
+    if (status != EXTRACTPDF_OK)
+        return status;
+    (void)entry;
 
+    if (update->fields == 0)
+        return EXTRACTPDF_OK;
     return EXTRACTPDF_ERROR_UNSUPPORTED;
 }
 
@@ -189,8 +660,12 @@ extractpdf_status extractpdf_pdf_edit_annotation_delete(
     extractpdf_pdf_edit *edit,
     const extractpdf_annotation_ref *ref)
 {
-    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
-        ref == NULL)
-        return EXTRACTPDF_ERROR_ARGUMENT;
+    extractpdf_pdf_edit_annotation_entry *entry = NULL;
+    extractpdf_status status = extractpdf_pdf_edit_resolve_ref(
+        edit, ref, &entry);
+
+    (void)entry;
+    if (status != EXTRACTPDF_OK)
+        return status;
     return EXTRACTPDF_ERROR_UNSUPPORTED;
 }

--- a/src/pdf_edit_annotations.c
+++ b/src/pdf_edit_annotations.c
@@ -865,6 +865,13 @@ extractpdf_status extractpdf_pdf_edit_annotation_update(
         EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
         EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
     extractpdf_pdf_edit_annotation_entry *entry = NULL;
+    pdf_page *page = NULL;
+    pdf_annot *annotation = NULL;
+    extractpdf_pdf_annotation_view view;
+    char *contents_copy = NULL;
+    int contents_present = 0;
+    int operation_open = 0;
+    int caught_code = FZ_ERROR_NONE;
     extractpdf_status status;
     size_t minimum_size;
 
@@ -877,13 +884,135 @@ extractpdf_status extractpdf_pdf_edit_annotation_update(
     if ((update->fields & ~known_fields) != 0)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    status = extractpdf_pdf_edit_resolve_ref(edit, ref, &entry);
+    status = extractpdf_pdf_edit_resolve_live_view(
+        edit, ref, &entry, &page, &annotation, &view);
     if (status != EXTRACTPDF_OK)
         return status;
-    (void)entry;
-    if (update->fields == 0)
+
+    if (update->fields == 0) {
+        fz_drop_page(edit->ctx, &page->super);
         return EXTRACTPDF_OK;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    }
+    if (view.type == EXTRACTPDF_ANNOTATION_UNKNOWN) {
+        fz_drop_page(edit->ctx, &page->super);
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    }
+    if ((update->fields & EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS) != 0) {
+        enum pdf_annot_type ignored_type = PDF_ANNOT_UNKNOWN;
+
+        if (!extractpdf_pdf_edit_map_create_type(view.type, &ignored_type)) {
+            fz_drop_page(edit->ctx, &page->super);
+            return EXTRACTPDF_ERROR_UNSUPPORTED;
+        }
+        if (!extractpdf_pdf_edit_bounds_valid(update->bounds)) {
+            fz_drop_page(edit->ctx, &page->super);
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        }
+    }
+    if ((update->fields & EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS) != 0) {
+        status = extractpdf_pdf_edit_prepare_contents(
+            update->contents_utf8,
+            update->contents_size,
+            &contents_present,
+            &contents_copy);
+        if (status != EXTRACTPDF_OK) {
+            fz_drop_page(edit->ctx, &page->super);
+            return status;
+        }
+    }
+
+    fz_var(operation_open);
+    fz_var(caught_code);
+    fz_try(edit->ctx)
+    {
+        int applied_fields = 0;
+
+        pdf_begin_operation(
+            edit->ctx, edit->document, "ExtractPDF update annotation");
+        operation_open = 1;
+
+        if ((update->fields & EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS) != 0) {
+            fz_rect bounds = fz_make_rect(
+                update->bounds.x0,
+                update->bounds.y0,
+                update->bounds.x1,
+                update->bounds.y1);
+            pdf_set_annot_rect(edit->ctx, annotation, bounds);
+            ++applied_fields;
+#if defined(EXTRACTPDF_TESTING)
+            if (applied_fields == 1 && edit->test_fault ==
+                EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_FIRST_UPDATE_FIELD) {
+                edit->test_fault = EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE;
+                fz_throw(
+                    edit->ctx,
+                    FZ_ERROR_GENERIC,
+                    "injected ExtractPDF update failure");
+            }
+#endif
+        }
+
+        if ((update->fields & EXTRACTPDF_ANNOTATION_UPDATE_FLAGS) != 0) {
+            extractpdf_pdf_edit_set_flags_u32(
+                edit->ctx, annotation, update->flags);
+            ++applied_fields;
+#if defined(EXTRACTPDF_TESTING)
+            if (applied_fields == 1 && edit->test_fault ==
+                EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_FIRST_UPDATE_FIELD) {
+                edit->test_fault = EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE;
+                fz_throw(
+                    edit->ctx,
+                    FZ_ERROR_GENERIC,
+                    "injected ExtractPDF update failure");
+            }
+#endif
+        }
+
+        if ((update->fields & EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS) != 0) {
+            if (contents_present) {
+                pdf_set_annot_contents(edit->ctx, annotation, contents_copy);
+            } else {
+                pdf_dict_del(
+                    edit->ctx,
+                    pdf_annot_obj(edit->ctx, annotation),
+                    PDF_NAME(Contents));
+                pdf_annot_request_resynthesis(edit->ctx, annotation);
+            }
+            ++applied_fields;
+#if defined(EXTRACTPDF_TESTING)
+            if (applied_fields == 1 && edit->test_fault ==
+                EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_FIRST_UPDATE_FIELD) {
+                edit->test_fault = EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE;
+                fz_throw(
+                    edit->ctx,
+                    FZ_ERROR_GENERIC,
+                    "injected ExtractPDF update failure");
+            }
+#endif
+        }
+
+        (void)pdf_update_annot(edit->ctx, annotation);
+        pdf_end_operation(edit->ctx, edit->document);
+        operation_open = 0;
+    }
+    fz_always(edit->ctx)
+    {
+        fz_drop_page(edit->ctx, &page->super);
+        page = NULL;
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        if (operation_open) {
+            pdf_abandon_operation(edit->ctx, edit->document);
+            operation_open = 0;
+        }
+        fz_report_error(edit->ctx);
+    }
+
+    free(contents_copy);
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    return EXTRACTPDF_OK;
 }
 
 extractpdf_status extractpdf_pdf_edit_annotation_delete(
@@ -891,10 +1020,53 @@ extractpdf_status extractpdf_pdf_edit_annotation_delete(
     const extractpdf_annotation_ref *ref)
 {
     extractpdf_pdf_edit_annotation_entry *entry = NULL;
-    extractpdf_status status = extractpdf_pdf_edit_resolve_ref(edit, ref, &entry);
+    pdf_page *page = NULL;
+    pdf_annot *annotation = NULL;
+    extractpdf_pdf_annotation_view view;
+    int operation_open = 0;
+    int caught_code = FZ_ERROR_NONE;
+    extractpdf_status status;
 
-    (void)entry;
+    status = extractpdf_pdf_edit_resolve_live_view(
+        edit, ref, &entry, &page, &annotation, &view);
     if (status != EXTRACTPDF_OK)
         return status;
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    if (view.type == EXTRACTPDF_ANNOTATION_UNKNOWN) {
+        fz_drop_page(edit->ctx, &page->super);
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    }
+
+    fz_var(operation_open);
+    fz_var(caught_code);
+    fz_try(edit->ctx)
+    {
+        pdf_begin_operation(
+            edit->ctx, edit->document, "ExtractPDF delete annotation");
+        operation_open = 1;
+        pdf_delete_annot(edit->ctx, page, annotation);
+        pdf_end_operation(edit->ctx, edit->document);
+        operation_open = 0;
+    }
+    fz_always(edit->ctx)
+    {
+        fz_drop_page(edit->ctx, &page->super);
+        page = NULL;
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        if (operation_open) {
+            pdf_abandon_operation(edit->ctx, edit->document);
+            operation_open = 0;
+        }
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+
+    pdf_drop_obj(edit->ctx, entry->object);
+    entry->object = NULL;
+    entry->live = 0;
+    return EXTRACTPDF_OK;
 }

--- a/src/pdf_edit_annotations.c
+++ b/src/pdf_edit_annotations.c
@@ -1,0 +1,196 @@
+#include "pdf_edit_internal.h"
+
+#include <stddef.h>
+#include <string.h>
+
+static void extractpdf_pdf_edit_zero_ref(extractpdf_annotation_ref *ref)
+{
+    memset(ref, 0, sizeof(*ref));
+}
+
+static void extractpdf_pdf_edit_zero_rect(extractpdf_rect *rect)
+{
+    rect->x0 = 0.0f;
+    rect->y0 = 0.0f;
+    rect->x1 = 0.0f;
+    rect->y1 = 0.0f;
+}
+
+static extractpdf_status extractpdf_pdf_edit_validate_page(
+    extractpdf_pdf_edit *edit,
+    int page_index)
+{
+    int page_count = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    if (page_index < 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(page_count);
+    fz_var(caught_code);
+
+    fz_try(edit->ctx)
+    {
+        page_count = pdf_count_pages(edit->ctx, edit->document);
+    }
+    fz_catch(edit->ctx)
+    {
+        caught_code = fz_caught(edit->ctx);
+        fz_report_error(edit->ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (page_index >= page_count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_count(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t *out_count)
+{
+    extractpdf_status status;
+
+    if (out_count != NULL)
+        *out_count = 0;
+    if (out_count == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_pdf_edit_validate_page(edit, page_index);
+    if (status != EXTRACTPDF_OK)
+        return status;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_ref_at(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t index,
+    extractpdf_annotation_ref *out_ref)
+{
+    extractpdf_status status;
+
+    (void)index;
+
+    if (out_ref != NULL)
+        extractpdf_pdf_edit_zero_ref(out_ref);
+    if (out_ref == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_pdf_edit_validate_page(edit, page_index);
+    if (status != EXTRACTPDF_OK)
+        return status;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_get_info(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    extractpdf_annotation_info *out_info)
+{
+    size_t minimum_size;
+
+    if (out_info == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_annotation_info, flags) +
+        sizeof(out_info->flags);
+    if (out_info->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    out_info->type = EXTRACTPDF_ANNOTATION_UNKNOWN;
+    extractpdf_pdf_edit_zero_rect(&out_info->bounds);
+    out_info->flags = 0;
+
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
+        ref == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_contents(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    char **out_utf8,
+    size_t *out_size)
+{
+    if (out_utf8 != NULL)
+        *out_utf8 = NULL;
+    if (out_size != NULL)
+        *out_size = 0;
+
+    if (out_utf8 == NULL || out_size == NULL || edit == NULL ||
+        edit->ctx == NULL || edit->document == NULL || ref == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_create(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    const extractpdf_annotation_create_options *options,
+    extractpdf_annotation_ref *out_ref)
+{
+    size_t minimum_size;
+    extractpdf_status status;
+
+    if (out_ref != NULL)
+        extractpdf_pdf_edit_zero_ref(out_ref);
+    if (out_ref == NULL || options == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_annotation_create_options, contents_size) +
+        sizeof(options->contents_size);
+    if (options->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    status = extractpdf_pdf_edit_validate_page(edit, page_index);
+    if (status != EXTRACTPDF_OK)
+        return status;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_update(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    const extractpdf_annotation_update *update)
+{
+    const uint32_t known_fields =
+        EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
+        EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
+        EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    size_t minimum_size;
+
+    if (update == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    minimum_size = offsetof(extractpdf_annotation_update, contents_size) +
+        sizeof(update->contents_size);
+    if (update->struct_size < minimum_size)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    if ((update->fields & ~known_fields) != 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
+        ref == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+
+extractpdf_status extractpdf_pdf_edit_annotation_delete(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref)
+{
+    if (edit == NULL || edit->ctx == NULL || edit->document == NULL ||
+        ref == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}

--- a/src/pdf_edit_annotations.c
+++ b/src/pdf_edit_annotations.c
@@ -795,6 +795,11 @@ extractpdf_status extractpdf_pdf_edit_annotation_create(
         operation_open = 1;
 
         annotation = pdf_create_annot(edit->ctx, page, pdf_type);
+        if (pdf_type == PDF_ANNOT_SQUARE || pdf_type == PDF_ANNOT_CIRCLE)
+            pdf_dict_del(
+                edit->ctx,
+                pdf_annot_obj(edit->ctx, annotation),
+                PDF_NAME(RD));
         pdf_set_annot_rect(edit->ctx, annotation, bounds);
         extractpdf_pdf_edit_set_flags_u32(
             edit->ctx, annotation, options->flags);

--- a/src/pdf_edit_internal.h
+++ b/src/pdf_edit_internal.h
@@ -1,0 +1,35 @@
+#ifndef EXTRACTPDF_PDF_EDIT_INTERNAL_H
+#define EXTRACTPDF_PDF_EDIT_INTERNAL_H
+
+#include "pdf_annotation_common.h"
+
+typedef struct extractpdf_pdf_edit_annotation_entry {
+    pdf_obj *object;
+    int page_index;
+    uint32_t tag;
+    int live;
+} extractpdf_pdf_edit_annotation_entry;
+
+#if defined(EXTRACTPDF_TESTING)
+enum {
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_NONE = 0,
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_FIRST_UPDATE_FIELD = 1,
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_AFTER_CREATE_MUTATION = 2,
+    EXTRACTPDF_PDF_EDIT_TEST_FAULT_SNAPSHOT_BEFORE_PUBLISH = 3
+};
+#endif
+
+struct extractpdf_pdf_edit {
+    fz_context *ctx;
+    pdf_document *document;
+    extractpdf_output *seed_output;
+    uint64_t session_cookie;
+    extractpdf_pdf_edit_annotation_entry *entries;
+    size_t entry_count;
+    size_t entry_capacity;
+#if defined(EXTRACTPDF_TESTING)
+    int test_fault;
+#endif
+};
+
+#endif

--- a/src/status.c
+++ b/src/status.c
@@ -19,6 +19,8 @@ const char *extractpdf_status_string(extractpdf_status status)
         return "out of memory";
     case EXTRACTPDF_ERROR_MUPDF:
         return "MuPDF error";
+    case EXTRACTPDF_ERROR_STATE:
+        return "invalid state";
     default:
         return "unknown error";
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,28 @@ target_compile_definitions(extractpdf_test_pdf_annotations PRIVATE
 add_test(NAME extractpdf.pdf_annotations COMMAND extractpdf_test_pdf_annotations)
 set_tests_properties(extractpdf.pdf_annotations PROPERTIES TIMEOUT 30)
 
+set(MUTATION_OUTPUT_A "${CMAKE_CURRENT_BINARY_DIR}/annotation-mutation-a.pdf")
+set(MUTATION_OUTPUT_B "${CMAKE_CURRENT_BINARY_DIR}/annotation-mutation-b.pdf")
+set(MUTATION_OUTPUT_JS "${CMAKE_CURRENT_BINARY_DIR}/annotation-mutation-js-output.pdf")
+
+add_executable(extractpdf_test_pdf_annotation_mutation
+  test_pdf_annotation_mutation.c)
+target_link_libraries(extractpdf_test_pdf_annotation_mutation PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_annotation_mutation PRIVATE
+  MUTATION_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation.pdf"
+  SIGNED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-signed.pdf"
+  UNSIGNED_SIGNATURE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-unsigned-signature.pdf"
+  JS_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-js.pdf"
+  LATE_MALFORMED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-late-malformed.pdf"
+  ENCRYPTED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/encrypted-one-page.pdf"
+  NON_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/composition-non-pdf.txt"
+  OUTPUT_A_PDF="${MUTATION_OUTPUT_A}"
+  OUTPUT_B_PDF="${MUTATION_OUTPUT_B}"
+  OUTPUT_JS_PDF="${MUTATION_OUTPUT_JS}")
+add_test(NAME extractpdf.pdf_annotation_mutation
+  COMMAND extractpdf_test_pdf_annotation_mutation)
+set_tests_properties(extractpdf.pdf_annotation_mutation PROPERTIES TIMEOUT 60)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   foreach(test_target IN ITEMS
       extractpdf_test_status
@@ -193,7 +215,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       extractpdf_test_output_file
       extractpdf_test_pdf_metadata
       extractpdf_test_pdf_outline
-      extractpdf_test_pdf_annotations)
+      extractpdf_test_pdf_annotations
+      extractpdf_test_pdf_annotation_mutation)
     add_custom_command(TARGET ${test_target} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:extractpdf>

--- a/tests/fixtures/annotation-mutation-js.pdf
+++ b/tests/fixtures/annotation-mutation-js.pdf
@@ -1,0 +1,34 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /OpenAction 5 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [6 0 R] >>
+endobj
+4 0 obj
+<< /Title (SAFE) >>
+endobj
+5 0 obj
+<< /S /JavaScript /JS (this.title = \"EXECUTED\";) >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Text /Rect [10 10 30 30] /Contents (js-safe) >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+000000082 00000 n 
+0000000139 00000 n 
+0000000243 00000 n 
+0000000278 00000 n 
+0000000347 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R /Info 4 0 R >>
+startxref
+436
+%%EOF

--- a/tests/fixtures/annotation-mutation-signed.pdf
+++ b/tests/fixtures/annotation-mutation-signed.pdf
@@ -1,0 +1,34 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [5 0 R] >>
+endobj
+4 0 obj
+<< /Fields [5 0 R] /SigFlags 3 >>
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Sig /T (sig) /Rect [10 10 120 40] /P 3 0 R /V 6 0 R >>
+endobj
+6 0 obj
+<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached /ByteRange [0 0 0 0] /Contents <00> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000241 00000 n 
+0000000290 00000 n 
+0000000398 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R  >>
+startxref
+521
+%%EOF

--- a/tests/fixtures/annotation-mutation-unsigned-signature.pdf
+++ b/tests/fixtures/annotation-mutation-unsigned-signature.pdf
@@ -1,0 +1,34 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [5 0 R] >>
+endobj
+4 0 obj
+<< /Fields [5 0 R] /SigFlags 3 >>
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Sig /T (sig) /Rect [10 10 120 40] /P 3 0 R >>
+endobj
+6 0 obj
+<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached /ByteRange [0 0 0 0] /Contents <00> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000241 00000 n 
+0000000290 00000 n 
+0000000389 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R  >>
+startxref
+512
+%%EOF

--- a/tests/fixtures/annotation-mutation.pdf
+++ b/tests/fixtures/annotation-mutation.pdf
@@ -1,0 +1,66 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [5 0 R 17 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R] >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Annots [13 0 R 14 0 R] >>
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /F 2147483649 /Contents (text-a) /Popup 9 0 R >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Link /Rect [20 20 40 40] /A << /S /URI /URI (https://example.com/) >> >>
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /Square /Rect [40 50 70 80] /F 4 /Contents (square-b) >>
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /FutureThing /Rect [80 90 100 110] /F 64 /Contents (unknown-c) >>
+endobj
+9 0 obj
+<< /Type /Annot /Subtype /Popup /Rect [110 90 180 150] /Parent 5 0 R >>
+endobj
+10 0 obj
+<< /Type /Annot /Subtype /Widget /Rect [130 10 180 30] /FT /Tx /T (widget) >>
+endobj
+11 0 obj
+<< /Type /Annot /Subtype /Highlight /Rect [20 120 80 140] /QuadPoints [20 140 80 140 20 120 80 120] /Contents (highlight-d) >>
+endobj
+12 0 obj
+<< /Type /Annot /Subtype /Ink /Rect [90 120 150 160] /InkList [[90 120 120 140 150 160]] /Contents (ink-e) >>
+endobj
+13 0 obj
+<< /Type /Annot /Subtype /FreeText /Rect [10 10 80 40] /DA (/Helv 12 Tf 0 g) /Contents (free-f) >>
+endobj
+14 0 obj
+<< /Type /Annot /Subtype /Circle /Rect [100 20 150 70] /Contents (circle-g) >>
+endobj
+xref
+0 15
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000127 00000 n 
+0000000279 00000 n 
+0000000391 00000 n 
+0000000506 00000 n 
+0000000620 00000 n 
+0000000717 00000 n 
+0000000823 00000 n 
+0000000910 00000 n 
+0000001004 00000 n 
+0000001147 00000 n 
+0000001273 00000 n 
+0000001388 00000 n 
+trailer
+<< /Size 15 /Root 1 0 R  >>
+startxref
+1483
+%%EOF

--- a/tests/pdf_edit_fault_hook.c
+++ b/tests/pdf_edit_fault_hook.c
@@ -1,0 +1,15 @@
+#include "../src/pdf_edit_internal.h"
+#include "pdf_edit_test_api.h"
+
+void extractpdf_test_pdf_edit_set_fault(
+    extractpdf_pdf_edit *edit,
+    extractpdf_test_pdf_edit_fault fault)
+{
+#if defined(EXTRACTPDF_TESTING)
+    if (edit != NULL)
+        edit->test_fault = (int)fault;
+#else
+    (void)edit;
+    (void)fault;
+#endif
+}

--- a/tests/pdf_edit_test_api.h
+++ b/tests/pdf_edit_test_api.h
@@ -1,0 +1,17 @@
+#ifndef EXTRACTPDF_PDF_EDIT_TEST_API_H
+#define EXTRACTPDF_PDF_EDIT_TEST_API_H
+
+#include <extractpdf/extractpdf.h>
+
+typedef enum extractpdf_test_pdf_edit_fault {
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE = 0,
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_FIRST_UPDATE_FIELD = 1,
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_CREATE_MUTATION = 2,
+    EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH = 3
+} extractpdf_test_pdf_edit_fault;
+
+EXTRACTPDF_API void extractpdf_test_pdf_edit_set_fault(
+    extractpdf_pdf_edit *edit,
+    extractpdf_test_pdf_edit_fault fault);
+
+#endif

--- a/tests/test_pdf_annotation_mutation.c
+++ b/tests/test_pdf_annotation_mutation.c
@@ -1,0 +1,1034 @@
+#include <extractpdf/extractpdf.h>
+#include "pdf_edit_test_api.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float a, float b)
+{
+    float d = a - b;
+    return (d < 0.0f ? -d : d) < 0.01f;
+}
+
+static void zero_ref(extractpdf_annotation_ref *ref)
+{
+    ref->opaque[0] = 0;
+    ref->opaque[1] = 0;
+}
+
+static int ref_is_zero(const extractpdf_annotation_ref *ref)
+{
+    return ref->opaque[0] == 0 && ref->opaque[1] == 0;
+}
+
+static extractpdf_pdf_edit *begin_edit_path(const char *path, const char *password)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+
+    CHECK(extractpdf_open(path, password, &source) == EXTRACTPDF_OK);
+    CHECK(source != NULL);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(edit != NULL);
+    extractpdf_close(source);
+    return edit;
+}
+
+static extractpdf_annotation_ref get_ref(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    size_t index)
+{
+    extractpdf_annotation_ref ref = {{0, 0}};
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(
+              edit, page_index, index, &ref) == EXTRACTPDF_OK);
+    CHECK(!ref_is_zero(&ref));
+    return ref;
+}
+
+static extractpdf_annotation_info get_live_info(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref)
+{
+    extractpdf_annotation_info info = {0};
+
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              edit, ref, &info) == EXTRACTPDF_OK);
+    return info;
+}
+
+static void expect_live_info(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    extractpdf_annotation_type type,
+    extractpdf_rect bounds,
+    uint32_t flags)
+{
+    extractpdf_annotation_info info = get_live_info(edit, ref);
+
+    CHECK(info.type == type);
+    CHECK(close_float(info.bounds.x0, bounds.x0));
+    CHECK(close_float(info.bounds.y0, bounds.y0));
+    CHECK(close_float(info.bounds.x1, bounds.x1));
+    CHECK(close_float(info.bounds.y1, bounds.y1));
+    CHECK(info.flags == flags);
+}
+
+static void expect_live_contents(
+    extractpdf_pdf_edit *edit,
+    const extractpdf_annotation_ref *ref,
+    int present,
+    const char *expected,
+    size_t expected_size)
+{
+    char *text = (char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              edit, ref, &text, &size) == EXTRACTPDF_OK);
+
+    if (!present) {
+        CHECK(text == NULL);
+        CHECK(size == 0);
+        return;
+    }
+
+    CHECK(text != NULL);
+    CHECK(size == expected_size);
+    if (expected_size != 0)
+        CHECK(memcmp(text, expected, expected_size) == 0);
+    CHECK(text[size] == '\0');
+    extractpdf_free(text);
+}
+
+static void save_output(const extractpdf_output *output, const char *path)
+{
+    CHECK(extractpdf_output_save_file(output, path) == EXTRACTPDF_OK);
+}
+
+static void expect_snapshot_annotation(
+    const char *path,
+    int page_index,
+    size_t index,
+    extractpdf_annotation_type type,
+    extractpdf_rect bounds,
+    uint32_t flags,
+    int contents_present,
+    const char *contents,
+    size_t contents_size)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_page *page = NULL;
+    extractpdf_annotation_page *annotations = NULL;
+    extractpdf_annotation_info info = {0};
+    const char *text = (const char *)(uintptr_t)1;
+    size_t size = (size_t)-1;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_annotations(page, &annotations) == EXTRACTPDF_OK);
+
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_annotation_get_info(annotations, index, &info) ==
+          EXTRACTPDF_OK);
+    CHECK(info.type == type);
+    CHECK(close_float(info.bounds.x0, bounds.x0));
+    CHECK(close_float(info.bounds.y0, bounds.y0));
+    CHECK(close_float(info.bounds.x1, bounds.x1));
+    CHECK(close_float(info.bounds.y1, bounds.y1));
+    CHECK(info.flags == flags);
+
+    CHECK(extractpdf_annotation_contents(
+              annotations, index, &text, &size) == EXTRACTPDF_OK);
+    if (!contents_present) {
+        CHECK(text == NULL);
+        CHECK(size == 0);
+    } else {
+        CHECK(text != NULL);
+        CHECK(size == contents_size);
+        if (contents_size != 0)
+            CHECK(memcmp(text, contents, contents_size) == 0);
+        CHECK(text[size] == '\0');
+    }
+
+    extractpdf_drop_annotation_page(annotations);
+    extractpdf_drop_page(page);
+    extractpdf_close(document);
+}
+
+static void expect_metadata_title(const char *path, const char *expected)
+{
+    extractpdf_document *document = NULL;
+    char *text = NULL;
+    size_t size = 0;
+    size_t expected_size = strlen(expected);
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_metadata(
+              document, EXTRACTPDF_METADATA_TITLE, &text, &size) ==
+          EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(size == expected_size);
+    CHECK(memcmp(text, expected, size) == 0);
+    CHECK(text[size] == '\0');
+    extractpdf_free(text);
+    extractpdf_close(document);
+}
+
+static extractpdf_annotation_ref create_rect_annot(
+    extractpdf_pdf_edit *edit,
+    int page_index,
+    extractpdf_annotation_type type,
+    extractpdf_rect bounds,
+    uint32_t flags,
+    const char *contents,
+    size_t contents_size)
+{
+    extractpdf_annotation_create_options options = {0};
+    extractpdf_annotation_ref ref = {{0, 0}};
+
+    options.struct_size = sizeof(options);
+    options.type = type;
+    options.bounds = bounds;
+    options.flags = flags;
+    options.contents_utf8 = contents;
+    options.contents_size = contents_size;
+
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, page_index, &options, &ref) == EXTRACTPDF_OK);
+    CHECK(!ref_is_zero(&ref));
+    return ref;
+}
+
+static void test_arguments(void)
+{
+    int sentinel = 0;
+    extractpdf_pdf_edit *edit = (extractpdf_pdf_edit *)&sentinel;
+    extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
+    extractpdf_annotation_info info = {0};
+    extractpdf_output *output = (extractpdf_output *)&sentinel;
+    char *text = (char *)(uintptr_t)1;
+    size_t size = 99;
+    size_t count = 99;
+    extractpdf_document *source = NULL;
+    extractpdf_annotation_ref live_ref;
+    extractpdf_annotation_create_options create_small = {0};
+    extractpdf_annotation_update update_small = {0};
+    extractpdf_annotation_update bad_bits = {0};
+    struct create_larger {
+        extractpdf_annotation_create_options v1;
+        uint64_t future;
+    } create_big = {{0}, 0};
+    struct update_larger {
+        extractpdf_annotation_update v1;
+        uint64_t future;
+    } update_big = {{0}, 0};
+
+    CHECK(extractpdf_pdf_edit_begin(NULL, &edit) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(edit == NULL);
+    CHECK(extractpdf_pdf_edit_begin(NULL, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, &count) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    CHECK(extractpdf_pdf_edit_annotation_count(NULL, 0, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(NULL, 0, 0, &ref) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(NULL, 0, 0, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    info.struct_size = offsetof(extractpdf_annotation_info, flags);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(NULL, &ref, &info) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    text = (char *)(uintptr_t)1;
+    size = 99;
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              NULL, &ref, &text, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    text = (char *)(uintptr_t)1;
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              NULL, &ref, &text, NULL) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(text == NULL);
+
+    size = 99;
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              NULL, &ref, NULL, &size) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(size == 0);
+
+    output = (extractpdf_output *)&sentinel;
+    CHECK(extractpdf_pdf_edit_snapshot(NULL, &output) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(output == NULL);
+    CHECK(extractpdf_pdf_edit_snapshot(NULL, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+
+    extractpdf_drop_pdf_edit(NULL);
+    CHECK(strcmp(extractpdf_status_string(EXTRACTPDF_ERROR_STATE),
+                 "invalid state") == 0);
+
+    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    extractpdf_close(source);
+    source = NULL;
+    live_ref = get_ref(edit, 0, 1);
+
+    create_small.struct_size =
+        offsetof(extractpdf_annotation_create_options, contents_size);
+    zero_ref(&ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &create_small, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+
+    update_small.struct_size =
+        offsetof(extractpdf_annotation_update, contents_size);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &live_ref, &update_small) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    create_big.v1.struct_size = sizeof(create_big);
+    create_big.v1.type = EXTRACTPDF_ANNOTATION_TEXT;
+    create_big.v1.bounds = (extractpdf_rect){150, 150, 170, 170};
+    create_big.v1.flags = 0;
+    create_big.v1.contents_utf8 = NULL;
+    create_big.v1.contents_size = 0;
+    zero_ref(&ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &create_big.v1, &ref) == EXTRACTPDF_OK);
+    CHECK(!ref_is_zero(&ref));
+
+    update_big.v1.struct_size = sizeof(update_big);
+    update_big.v1.fields = 0;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &live_ref, &update_big.v1) == EXTRACTPDF_OK);
+
+    bad_bits.struct_size = sizeof(bad_bits);
+    bad_bits.fields = UINT32_C(0x80000000);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &live_ref, &bad_bits) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    count = 99;
+    CHECK(extractpdf_pdf_edit_annotation_count(edit, -1, &count) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+    count = 99;
+    CHECK(extractpdf_pdf_edit_annotation_count(edit, 2, &count) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(count == 0);
+
+    ref.opaque[0] = UINT64_MAX;
+    ref.opaque[1] = UINT64_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, -1, 0, &ref) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+    ref.opaque[0] = UINT64_MAX;
+    ref.opaque[1] = UINT64_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 99, &ref) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+
+    extractpdf_drop_pdf_edit(edit);
+}
+
+static void test_begin_lifetime_and_fail_closed(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+    extractpdf_output *output = NULL;
+
+    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(edit != NULL);
+    extractpdf_close(source);
+    source = NULL;
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &output) == EXTRACTPDF_OK);
+    CHECK(output != NULL);
+    extractpdf_drop_output(output);
+    extractpdf_drop_pdf_edit(edit);
+
+    CHECK(extractpdf_open(ENCRYPTED_PDF, "user-pass", &source) ==
+          EXTRACTPDF_OK);
+    edit = (extractpdf_pdf_edit *)(uintptr_t)1;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(edit == NULL);
+    extractpdf_close(source);
+
+    CHECK(extractpdf_open(SIGNED_PDF, NULL, &source) == EXTRACTPDF_OK);
+    edit = (extractpdf_pdf_edit *)(uintptr_t)1;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(edit == NULL);
+    extractpdf_close(source);
+
+    CHECK(extractpdf_open(UNSIGNED_SIGNATURE_PDF, NULL, &source) ==
+          EXTRACTPDF_OK);
+    edit = NULL;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(edit != NULL);
+    extractpdf_drop_pdf_edit(edit);
+    extractpdf_close(source);
+
+    CHECK(extractpdf_open(NON_PDF, NULL, &source) == EXTRACTPDF_OK);
+    edit = (extractpdf_pdf_edit *)(uintptr_t)1;
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(edit == NULL);
+    extractpdf_close(source);
+}
+
+static void test_discovery_and_refs(void)
+{
+    extractpdf_pdf_edit *a = begin_edit_path(MUTATION_PDF, NULL);
+    extractpdf_pdf_edit *b = begin_edit_path(MUTATION_PDF, NULL);
+    extractpdf_annotation_ref text_ref = {{0, 0}};
+    extractpdf_annotation_ref square_ref = {{0, 0}};
+    extractpdf_annotation_ref square_again = {{0, 0}};
+    extractpdf_annotation_ref invalid = {{UINT64_MAX, UINT64_MAX}};
+    extractpdf_annotation_info info = {0};
+    size_t count = 0;
+
+    CHECK(extractpdf_pdf_edit_annotation_count(a, 0, &count) ==
+          EXTRACTPDF_OK);
+    CHECK(count == 5);
+    CHECK(extractpdf_pdf_edit_annotation_count(a, 1, &count) ==
+          EXTRACTPDF_OK);
+    CHECK(count == 2);
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 0, &text_ref) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_ref) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 1, &square_again) ==
+          EXTRACTPDF_OK);
+    CHECK(memcmp(&square_ref, &square_again, sizeof(square_ref)) == 0);
+
+    expect_live_info(
+        a, &text_ref, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){10, 160, 30, 180}, UINT32_C(2147483649));
+    expect_live_contents(a, &text_ref, 1, "text-a", 6);
+    expect_live_info(
+        a, &square_ref, EXTRACTPDF_ANNOTATION_SQUARE,
+        (extractpdf_rect){40, 120, 70, 150}, 4);
+    expect_live_contents(a, &square_ref, 1, "square-b", 8);
+
+    info.struct_size = sizeof(info);
+    info.type = EXTRACTPDF_ANNOTATION_CIRCLE;
+    info.flags = UINT32_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              b, &square_ref, &info) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(info.type == EXTRACTPDF_ANNOTATION_UNKNOWN);
+    CHECK(info.flags == 0);
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, -1, 0, &invalid) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&invalid));
+    invalid.opaque[0] = UINT64_MAX;
+    invalid.opaque[1] = UINT64_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 2, 0, &invalid) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&invalid));
+    invalid.opaque[0] = UINT64_MAX;
+    invalid.opaque[1] = UINT64_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(a, 0, 99, &invalid) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&invalid));
+
+    extractpdf_drop_pdf_edit(a);
+    extractpdf_drop_pdf_edit(b);
+}
+
+static void test_malformed_discovery_is_atomic(void)
+{
+    extractpdf_pdf_edit *edit = begin_edit_path(LATE_MALFORMED_PDF, NULL);
+    extractpdf_annotation_ref ref = {{UINT64_MAX, UINT64_MAX}};
+    size_t count = 99;
+
+    CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &count) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(count == 0);
+
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 0, &ref) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(ref_is_zero(&ref));
+
+    ref.opaque[0] = UINT64_MAX;
+    ref.opaque[1] = UINT64_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_ref_at(edit, 0, 0, &ref) ==
+          EXTRACTPDF_ERROR_FORMAT);
+    CHECK(ref_is_zero(&ref));
+
+    extractpdf_drop_pdf_edit(edit);
+}
+
+static void test_create(void)
+{
+    extractpdf_pdf_edit *edit = begin_edit_path(MUTATION_PDF, NULL);
+    extractpdf_annotation_ref text;
+    extractpdf_annotation_ref free_text;
+    extractpdf_annotation_ref square;
+    extractpdf_annotation_ref circle;
+    extractpdf_annotation_ref ref = {{0, 0}};
+    extractpdf_annotation_create_options options = {0};
+    size_t count = 0;
+
+    text = create_rect_annot(
+        edit, 0, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){20, 20, 35, 35}, 1,
+        "new-text", sizeof("new-text") - 1);
+    free_text = create_rect_annot(
+        edit, 1, EXTRACTPDF_ANNOTATION_FREE_TEXT,
+        (extractpdf_rect){20, 20, 90, 55}, 4,
+        "new-free", sizeof("new-free") - 1);
+    square = create_rect_annot(
+        edit, 1, EXTRACTPDF_ANNOTATION_SQUARE,
+        (extractpdf_rect){100, 20, 150, 70}, 8,
+        NULL, 0);
+    circle = create_rect_annot(
+        edit, 1, EXTRACTPDF_ANNOTATION_CIRCLE,
+        (extractpdf_rect){20, 90, 70, 140}, 16,
+        "", 0);
+
+    expect_live_info(
+        edit, &text, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){20, 20, 35, 35}, 1);
+    expect_live_contents(edit, &text, 1, "new-text", 8);
+    expect_live_info(
+        edit, &free_text, EXTRACTPDF_ANNOTATION_FREE_TEXT,
+        (extractpdf_rect){20, 20, 90, 55}, 4);
+    expect_live_contents(edit, &free_text, 1, "new-free", 8);
+    expect_live_info(
+        edit, &square, EXTRACTPDF_ANNOTATION_SQUARE,
+        (extractpdf_rect){100, 20, 150, 70}, 8);
+    expect_live_contents(edit, &square, 0, NULL, 0);
+    expect_live_info(
+        edit, &circle, EXTRACTPDF_ANNOTATION_CIRCLE,
+        (extractpdf_rect){20, 90, 70, 140}, 16);
+    expect_live_contents(edit, &circle, 1, "", 0);
+
+    CHECK(extractpdf_pdf_edit_annotation_count(edit, 0, &count) ==
+          EXTRACTPDF_OK);
+    CHECK(count == 6);
+    CHECK(extractpdf_pdf_edit_annotation_count(edit, 1, &count) ==
+          EXTRACTPDF_OK);
+    CHECK(count == 5);
+
+    options.struct_size = sizeof(options);
+    options.type = EXTRACTPDF_ANNOTATION_HIGHLIGHT;
+    options.bounds = (extractpdf_rect){20, 20, 50, 50};
+    options.flags = 0;
+    options.contents_utf8 = NULL;
+    options.contents_size = 0;
+    zero_ref(&ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &options, &ref) == EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(ref_is_zero(&ref));
+
+    options.type = EXTRACTPDF_ANNOTATION_UNKNOWN;
+    zero_ref(&ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &options, &ref) == EXTRACTPDF_ERROR_UNSUPPORTED);
+    CHECK(ref_is_zero(&ref));
+
+    options.type = EXTRACTPDF_ANNOTATION_TEXT;
+    options.bounds = (extractpdf_rect){50, 50, 20, 20};
+    zero_ref(&ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &options, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+
+    options.bounds = (extractpdf_rect){20, 20, NAN, 50};
+    zero_ref(&ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &options, &ref) == EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(ref_is_zero(&ref));
+
+    extractpdf_drop_pdf_edit(edit);
+}
+
+static void test_update_delete(void)
+{
+    extractpdf_pdf_edit *edit = begin_edit_path(MUTATION_PDF, NULL);
+    extractpdf_pdf_edit *other = begin_edit_path(MUTATION_PDF, NULL);
+    extractpdf_annotation_ref text_ref = get_ref(edit, 0, 0);
+    extractpdf_annotation_ref square_ref = get_ref(edit, 0, 1);
+    extractpdf_annotation_ref current_square;
+    extractpdf_annotation_ref unknown_ref;
+    extractpdf_annotation_ref highlight_ref;
+    extractpdf_annotation_ref new_ref = {{0, 0}};
+    extractpdf_annotation_info before = {0};
+    extractpdf_annotation_info after = {0};
+    extractpdf_annotation_update update = {0};
+    extractpdf_annotation_update zero = {0};
+    extractpdf_annotation_create_options options = {0};
+    char *before_text = NULL;
+    char *after_text = NULL;
+    size_t before_size = 0;
+    size_t after_size = 0;
+    size_t before_count = 0;
+    size_t after_count = 0;
+
+    CHECK(extractpdf_pdf_edit_annotation_delete(edit, &text_ref) ==
+          EXTRACTPDF_OK);
+
+    before.struct_size = sizeof(before);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              edit, &text_ref, &before) == EXTRACTPDF_ERROR_STATE);
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              edit, &text_ref, &before_text, &before_size) ==
+          EXTRACTPDF_ERROR_STATE);
+    CHECK(before_text == NULL);
+    CHECK(before_size == 0);
+
+    zero.struct_size = sizeof(zero);
+    zero.fields = 0;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &zero) == EXTRACTPDF_ERROR_STATE);
+    CHECK(extractpdf_pdf_edit_annotation_delete(edit, &text_ref) ==
+          EXTRACTPDF_ERROR_STATE);
+
+    current_square = get_ref(edit, 0, 0);
+    CHECK(memcmp(&square_ref, &current_square, sizeof(square_ref)) == 0);
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
+                    EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
+                    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    update.bounds = (extractpdf_rect){45, 115, 90, 155};
+    update.flags = 33;
+    update.contents_utf8 = "square-updated";
+    update.contents_size = sizeof("square-updated") - 1;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &square_ref, &update) == EXTRACTPDF_OK);
+
+    expect_live_info(
+        edit, &square_ref, EXTRACTPDF_ANNOTATION_SQUARE,
+        (extractpdf_rect){45, 115, 90, 155}, 33);
+    expect_live_contents(
+        edit, &square_ref, 1, "square-updated",
+        sizeof("square-updated") - 1);
+
+    unknown_ref = get_ref(edit, 0, 1);
+    highlight_ref = get_ref(edit, 0, 2);
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS;
+    update.bounds = (extractpdf_rect){20, 20, 100, 100};
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &highlight_ref, &update) ==
+          EXTRACTPDF_ERROR_UNSUPPORTED);
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_FLAGS |
+                    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    update.flags = 77;
+    update.contents_utf8 = "highlight-updated";
+    update.contents_size = sizeof("highlight-updated") - 1;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &highlight_ref, &update) == EXTRACTPDF_OK);
+    expect_live_contents(
+        edit, &highlight_ref, 1, "highlight-updated",
+        sizeof("highlight-updated") - 1);
+
+    zero.struct_size = sizeof(zero);
+    zero.fields = 0;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &unknown_ref, &zero) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &zero) == EXTRACTPDF_ERROR_STATE);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              other, &square_ref, &zero) == EXTRACTPDF_ERROR_ARGUMENT);
+
+    before.struct_size = sizeof(before);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              edit, &square_ref, &before) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              edit, &square_ref, &before_text, &before_size) == EXTRACTPDF_OK);
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_BOUNDS |
+                    EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    update.bounds = (extractpdf_rect){20, 20, 90, 90};
+    update.contents_utf8 = "rollback-new";
+    update.contents_size = sizeof("rollback-new") - 1;
+    extractpdf_test_pdf_edit_set_fault(
+        edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_FIRST_UPDATE_FIELD);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &square_ref, &update) != EXTRACTPDF_OK);
+    extractpdf_test_pdf_edit_set_fault(
+        edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE);
+
+    after.struct_size = sizeof(after);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              edit, &square_ref, &after) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              edit, &square_ref, &after_text, &after_size) == EXTRACTPDF_OK);
+    CHECK(close_float(before.bounds.x0, after.bounds.x0));
+    CHECK(close_float(before.bounds.y0, after.bounds.y0));
+    CHECK(close_float(before.bounds.x1, after.bounds.x1));
+    CHECK(close_float(before.bounds.y1, after.bounds.y1));
+    CHECK(before.flags == after.flags);
+    CHECK(before_size == after_size);
+    CHECK(before_size == 0 ||
+          memcmp(before_text, after_text, before_size) == 0);
+    extractpdf_free(before_text);
+    extractpdf_free(after_text);
+    before_text = NULL;
+    after_text = NULL;
+
+    CHECK(extractpdf_pdf_edit_annotation_count(
+              edit, 0, &before_count) == EXTRACTPDF_OK);
+    options.struct_size = sizeof(options);
+    options.type = EXTRACTPDF_ANNOTATION_TEXT;
+    options.bounds = (extractpdf_rect){120, 120, 150, 150};
+    options.flags = 0;
+    options.contents_utf8 = "rollback-create";
+    options.contents_size = sizeof("rollback-create") - 1;
+
+    extractpdf_test_pdf_edit_set_fault(
+        edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_AFTER_CREATE_MUTATION);
+    zero_ref(&new_ref);
+    CHECK(extractpdf_pdf_edit_annotation_create(
+              edit, 0, &options, &new_ref) != EXTRACTPDF_OK);
+    extractpdf_test_pdf_edit_set_fault(
+        edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE);
+    CHECK(ref_is_zero(&new_ref));
+    CHECK(extractpdf_pdf_edit_annotation_count(
+              edit, 0, &after_count) == EXTRACTPDF_OK);
+    CHECK(after_count == before_count);
+
+    extractpdf_drop_pdf_edit(edit);
+    extractpdf_drop_pdf_edit(other);
+}
+
+static void test_contents_flags(void)
+{
+    static const char counted[3] = {'c', 'a', 't'};
+    static const char bad_utf8[2] = {(char)0xC0, (char)0xAF};
+    static const char embedded_nul[3] = {'a', '\0', 'b'};
+    extractpdf_pdf_edit *edit = begin_edit_path(MUTATION_PDF, NULL);
+    extractpdf_annotation_ref text_ref = get_ref(edit, 0, 0);
+    extractpdf_annotation_info info = {0};
+    extractpdf_annotation_update update = {0};
+    extractpdf_output *output = NULL;
+    char *old_copy = NULL;
+    char *text = NULL;
+    size_t old_size = 0;
+    size_t size = 0;
+
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              edit, &text_ref, &info) == EXTRACTPDF_OK);
+    CHECK(info.flags == UINT32_C(2147483649));
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_FLAGS;
+    update.flags = UINT32_MAX;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_pdf_edit_annotation_get_info(
+              edit, &text_ref, &info) == EXTRACTPDF_OK);
+    CHECK(info.flags == UINT32_MAX);
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    update.contents_utf8 = counted;
+    update.contents_size = sizeof(counted);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              edit, &text_ref, &old_copy, &old_size) == EXTRACTPDF_OK);
+    CHECK(old_copy != NULL);
+    CHECK(old_size == 3);
+    CHECK(memcmp(old_copy, "cat", 3) == 0);
+    CHECK(old_copy[3] == '\0');
+
+    update.contents_utf8 = "dog";
+    update.contents_size = 3;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+    CHECK(memcmp(old_copy, "cat", 3) == 0);
+    CHECK(old_copy[3] == '\0');
+    extractpdf_free(old_copy);
+    old_copy = NULL;
+
+    update.contents_utf8 = NULL;
+    update.contents_size = 0;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+    text = (char *)(uintptr_t)1;
+    size = 99;
+    CHECK(extractpdf_pdf_edit_annotation_contents(
+              edit, &text_ref, &text, &size) == EXTRACTPDF_OK);
+    CHECK(text == NULL);
+    CHECK(size == 0);
+
+    update.contents_utf8 = "";
+    update.contents_size = 0;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+    expect_live_contents(edit, &text_ref, 1, "", 0);
+
+    update.contents_utf8 = bad_utf8;
+    update.contents_size = sizeof(bad_utf8);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_ERROR_ARGUMENT);
+    expect_live_contents(edit, &text_ref, 1, "", 0);
+
+    update.contents_utf8 = embedded_nul;
+    update.contents_size = sizeof(embedded_nul);
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_ERROR_ARGUMENT);
+    expect_live_contents(edit, &text_ref, 1, "", 0);
+
+    update.contents_utf8 = NULL;
+    update.contents_size = 1;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_ERROR_ARGUMENT);
+    expect_live_contents(edit, &text_ref, 1, "", 0);
+
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &output) == EXTRACTPDF_OK);
+    save_output(output, OUTPUT_B_PDF);
+    expect_snapshot_annotation(
+        OUTPUT_B_PDF, 0, 0, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){10, 160, 30, 180}, UINT32_MAX,
+        1, "", 0);
+    extractpdf_drop_output(output);
+    extractpdf_drop_pdf_edit(edit);
+}
+
+static void test_snapshot_isolation(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_page *source_page = NULL;
+    extractpdf_annotation_page *source_annotations = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+    extractpdf_annotation_ref text_ref;
+    extractpdf_annotation_update update = {0};
+    extractpdf_output *a = NULL;
+    extractpdf_output *repeat = NULL;
+    extractpdf_output *b = NULL;
+    extractpdf_output *after_failed = NULL;
+    extractpdf_output *failed = (extractpdf_output *)(uintptr_t)1;
+    extractpdf_annotation_info source_info = {0};
+    const char *source_text = NULL;
+    size_t source_text_size = 0;
+    const unsigned char *a_data = NULL;
+    const unsigned char *repeat_data = NULL;
+    const unsigned char *b_data = NULL;
+    const unsigned char *after_failed_data = NULL;
+    size_t a_size = 0;
+    size_t repeat_size = 0;
+    size_t b_size = 0;
+    size_t after_failed_size = 0;
+    unsigned char *a_copy = NULL;
+
+    CHECK(extractpdf_open(MUTATION_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_load_page(source, 0, &source_page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_annotations(
+              source_page, &source_annotations) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    CHECK(edit != NULL);
+
+    extractpdf_drop_page(source_page);
+    source_page = NULL;
+    extractpdf_close(source);
+    source = NULL;
+
+    source_info.struct_size = sizeof(source_info);
+    CHECK(extractpdf_annotation_get_info(
+              source_annotations, 0, &source_info) == EXTRACTPDF_OK);
+    CHECK(source_info.type == EXTRACTPDF_ANNOTATION_TEXT);
+    CHECK(close_float(source_info.bounds.x0, 10));
+    CHECK(close_float(source_info.bounds.y0, 160));
+    CHECK(close_float(source_info.bounds.x1, 30));
+    CHECK(close_float(source_info.bounds.y1, 180));
+    CHECK(source_info.flags == UINT32_C(2147483649));
+    CHECK(extractpdf_annotation_contents(
+              source_annotations, 0, &source_text, &source_text_size) ==
+          EXTRACTPDF_OK);
+    CHECK(source_text != NULL);
+    CHECK(source_text_size == 6);
+    CHECK(memcmp(source_text, "text-a", 6) == 0);
+
+    text_ref = get_ref(edit, 0, 0);
+
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &a) == EXTRACTPDF_OK);
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &repeat) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(
+              repeat, &repeat_data, &repeat_size) == EXTRACTPDF_OK);
+    CHECK(a_size == repeat_size);
+    CHECK(memcmp(a_data, repeat_data, a_size) == 0);
+
+    a_copy = (unsigned char *)malloc(a_size);
+    CHECK(a_copy != NULL);
+    memcpy(a_copy, a_data, a_size);
+
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    update.contents_utf8 = "snapshot-b";
+    update.contents_size = sizeof("snapshot-b") - 1;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+
+    source_info.struct_size = sizeof(source_info);
+    CHECK(extractpdf_annotation_get_info(
+              source_annotations, 0, &source_info) == EXTRACTPDF_OK);
+    CHECK(source_info.flags == UINT32_C(2147483649));
+    CHECK(extractpdf_annotation_contents(
+              source_annotations, 0, &source_text, &source_text_size) ==
+          EXTRACTPDF_OK);
+    CHECK(source_text_size == 6);
+    CHECK(memcmp(source_text, "text-a", 6) == 0);
+
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &b) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
+    CHECK(memcmp(a_data, a_copy, a_size) == 0);
+    CHECK(extractpdf_output_data(b, &b_data, &b_size) == EXTRACTPDF_OK);
+
+    save_output(a, OUTPUT_A_PDF);
+    save_output(b, OUTPUT_B_PDF);
+    expect_snapshot_annotation(
+        OUTPUT_A_PDF, 0, 0, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){10, 160, 30, 180}, UINT32_C(2147483649),
+        1, "text-a", 6);
+    expect_snapshot_annotation(
+        OUTPUT_B_PDF, 0, 0, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){10, 160, 30, 180}, UINT32_C(2147483649),
+        1, "snapshot-b", sizeof("snapshot-b") - 1);
+
+    extractpdf_test_pdf_edit_set_fault(
+        edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_SNAPSHOT_BEFORE_PUBLISH);
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &failed) != EXTRACTPDF_OK);
+    CHECK(failed == NULL);
+    extractpdf_test_pdf_edit_set_fault(
+        edit, EXTRACTPDF_TEST_PDF_EDIT_FAULT_NONE);
+
+    update.contents_utf8 = "after-failed-snapshot";
+    update.contents_size = sizeof("after-failed-snapshot") - 1;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+    expect_live_contents(
+        edit, &text_ref, 1, "after-failed-snapshot",
+        sizeof("after-failed-snapshot") - 1);
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &after_failed) ==
+          EXTRACTPDF_OK);
+    save_output(after_failed, OUTPUT_B_PDF);
+    expect_snapshot_annotation(
+        OUTPUT_B_PDF, 0, 0, EXTRACTPDF_ANNOTATION_TEXT,
+        (extractpdf_rect){10, 160, 30, 180}, UINT32_C(2147483649),
+        1, "after-failed-snapshot", sizeof("after-failed-snapshot") - 1);
+
+    extractpdf_drop_pdf_edit(edit);
+    edit = NULL;
+
+    CHECK(extractpdf_output_data(a, &a_data, &a_size) == EXTRACTPDF_OK);
+    CHECK(memcmp(a_data, a_copy, a_size) == 0);
+    CHECK(extractpdf_output_data(b, &b_data, &b_size) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(
+              after_failed, &after_failed_data, &after_failed_size) ==
+          EXTRACTPDF_OK);
+    CHECK(b_size != 0);
+    CHECK(after_failed_size != 0);
+
+    free(a_copy);
+    extractpdf_drop_output(a);
+    extractpdf_drop_output(repeat);
+    extractpdf_drop_output(b);
+    extractpdf_drop_output(after_failed);
+    extractpdf_drop_annotation_page(source_annotations);
+}
+
+static void test_javascript_disabled(void)
+{
+    extractpdf_document *source = NULL;
+    extractpdf_pdf_edit *edit = NULL;
+    extractpdf_annotation_ref text_ref;
+    extractpdf_annotation_update update = {0};
+    extractpdf_output *output = NULL;
+    char *title = NULL;
+    size_t title_size = 0;
+
+    CHECK(extractpdf_open(JS_PDF, NULL, &source) == EXTRACTPDF_OK);
+    CHECK(extractpdf_document_metadata(
+              source, EXTRACTPDF_METADATA_TITLE, &title, &title_size) ==
+          EXTRACTPDF_OK);
+    CHECK(title != NULL);
+    CHECK(title_size == 4);
+    CHECK(memcmp(title, "SAFE", 4) == 0);
+    extractpdf_free(title);
+    title = NULL;
+
+    CHECK(extractpdf_pdf_edit_begin(source, &edit) == EXTRACTPDF_OK);
+    extractpdf_close(source);
+    source = NULL;
+
+    text_ref = get_ref(edit, 0, 0);
+    update.struct_size = sizeof(update);
+    update.fields = EXTRACTPDF_ANNOTATION_UPDATE_CONTENTS;
+    update.contents_utf8 = "js-mutated";
+    update.contents_size = sizeof("js-mutated") - 1;
+    CHECK(extractpdf_pdf_edit_annotation_update(
+              edit, &text_ref, &update) == EXTRACTPDF_OK);
+
+    CHECK(extractpdf_pdf_edit_snapshot(edit, &output) == EXTRACTPDF_OK);
+    save_output(output, OUTPUT_JS_PDF);
+    expect_metadata_title(OUTPUT_JS_PDF, "SAFE");
+
+    extractpdf_drop_output(output);
+    extractpdf_drop_pdf_edit(edit);
+}
+
+static int selected(int argc, char **argv, const char *name)
+{
+    return argc == 1 || (argc == 2 && strcmp(argv[1], name) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    CHECK(argc <= 2);
+
+    if (selected(argc, argv, "arguments"))
+        test_arguments();
+    if (selected(argc, argv, "begin"))
+        test_begin_lifetime_and_fail_closed();
+    if (selected(argc, argv, "discovery")) {
+        test_discovery_and_refs();
+        test_malformed_discovery_is_atomic();
+    }
+    if (selected(argc, argv, "create"))
+        test_create();
+    if (selected(argc, argv, "update-delete"))
+        test_update_delete();
+    if (selected(argc, argv, "contents-flags"))
+        test_contents_flags();
+    if (selected(argc, argv, "snapshot"))
+        test_snapshot_isolation();
+    if (selected(argc, argv, "javascript"))
+        test_javascript_disabled();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Integration carrier for Phase 5 Annotation Mutation V1 (#37 / #2), used because the GitHub connector's draft→ready GraphQL mutation for canonical PR #38 failed on an upstream schema-field mismatch.

This PR introduced **no new feature commit** and pointed to the exact already-proven feature SHA:

`0bd82a2ad9a927b7c492925f3fba679edd0570b7`

Canonical implementation/evidence PR: #38.

Pre-integration evidence on the exact same head against base `58525ce1b4b691ef53dfafc7c4e4d82753c966ba`:
- strict RED: `624d439ed9225af8f0c1c03de31fe4f1d11bba05`, workflow #181 (`33194853224`)
- Linux GREEN: workflow #190 (`33200695960`), 19/19 static + 19/19 ASan/UBSan
- same-head full-ci: workflow #191 (`33200839586`), Linux + ASan/UBSan + macOS + Windows DLL all success
- Windows built the editor sources and `extractpdf.dll`, built `extractpdf_test_pdf_annotation_mutation.exe`, and passed mutation test 19/19; all 19 CTests passed
- base→head scope: 12 commits, 19 approved paths, no unrelated subsystem changes
- no comments, submitted reviews, or inline review threads blocked integration

## Integration result

- Rechecked non-draft + mergeable with head `0bd82a2ad9a927b7c492925f3fba679edd0570b7` and expected base before merge.
- Merged with `expected_head_sha=0bd82a2ad9a927b7c492925f3fba679edd0570b7`, method `merge`.
- Merge commit: `0e4b769753215725797a557c4f18c4654e444e30`.
- Integrated master push workflow #198 (`33220037403`) completed/success on that exact merge SHA: Linux static + ASan/UBSan ✅, macOS ✅, Windows DLL ✅.
- Integrated Windows checked out `0e4b769...`, built the mutation/editor sources and DLL, ran `extractpdf.pdf_annotation_mutation` as test 19/19, and finished with 100% of 19 CTests passing.
- Canonical PR #38 is closed/merged at the same merge commit; issue #37 is closed completed; roadmap #2 marks Annotation Mutation V1 integrated.