### PR TITLE
feat: add immutable MediaBox physical trim transform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(extractpdf
   src/links.c
   src/pdf_crop.c
   src/pdf_crop_preflight.c
+  src/pdf_trim.c
   src/pdf_export.c
   src/pdf_output.c
   src/pdf_range.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,4 +87,11 @@ if(EXTRACTPDF_BUILD_TESTS)
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_main.c")
   target_link_libraries(extractpdf_test_pdf_trim PRIVATE
     unofficial::libmupdf::libmupdf)
+  if(WIN32 AND BUILD_SHARED_LIBS)
+    add_custom_command(TARGET extractpdf_test_pdf_trim POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:extractpdf>
+        $<TARGET_FILE_DIR:extractpdf_test_pdf_trim>
+      VERBATIM)
+  endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(EXTRACTPDF_BUILD_TESTS)
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_boxes.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_transforms.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_policy.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_batch.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_main.c")
   target_link_libraries(extractpdf_test_pdf_trim PRIVATE
     unofficial::libmupdf::libmupdf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,13 @@ if(EXTRACTPDF_BUILD_TESTS)
   add_subdirectory(tests)
   target_sources(extractpdf_test_pdf_form_mutation PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_form_rollback.c")
+  set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim.c"
+    TARGET_DIRECTORY extractpdf_test_pdf_trim
+    PROPERTY COMPILE_DEFINITIONS "main=extractpdf_pdf_trim_base_main")
   target_sources(extractpdf_test_pdf_trim PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_raw.c")
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_raw.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_transforms.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_main.c")
   target_link_libraries(extractpdf_test_pdf_trim PRIVATE
     unofficial::libmupdf::libmupdf)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if(EXTRACTPDF_BUILD_TESTS)
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_transforms.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_policy.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_batch.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_outside_crop.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_main.c")
   target_link_libraries(extractpdf_test_pdf_trim PRIVATE
     unofficial::libmupdf::libmupdf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,11 +87,4 @@ if(EXTRACTPDF_BUILD_TESTS)
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_main.c")
   target_link_libraries(extractpdf_test_pdf_trim PRIVATE
     unofficial::libmupdf::libmupdf)
-  if(WIN32 AND BUILD_SHARED_LIBS)
-    add_custom_command(TARGET extractpdf_test_pdf_trim POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        $<TARGET_FILE:extractpdf>
-        $<TARGET_FILE_DIR:extractpdf_test_pdf_trim>
-      VERBATIM)
-  endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(extractpdf
   src/images.c
   src/image_bitmap.c
   src/links.c
+  src/pdf_page_box_common.c
   src/pdf_crop.c
   src/pdf_crop_preflight.c
   src/pdf_trim.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,9 @@ if(EXTRACTPDF_BUILD_TESTS)
     PROPERTY COMPILE_DEFINITIONS "main=extractpdf_pdf_trim_base_main")
   target_sources(extractpdf_test_pdf_trim PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_raw.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_boxes.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_transforms.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_policy.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_main.c")
   target_link_libraries(extractpdf_test_pdf_trim PRIVATE
     unofficial::libmupdf::libmupdf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,4 +75,8 @@ if(EXTRACTPDF_BUILD_TESTS)
   add_subdirectory(tests)
   target_sources(extractpdf_test_pdf_form_mutation PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_form_rollback.c")
+  target_sources(extractpdf_test_pdf_trim PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pdf_trim_raw.c")
+  target_link_libraries(extractpdf_test_pdf_trim PRIVATE
+    unofficial::libmupdf::libmupdf)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(extractpdf
   src/pdf_crop.c
   src/pdf_crop_preflight.c
   src/pdf_trim.c
+  src/pdf_trim_preflight.c
   src/pdf_export.c
   src/pdf_output.c
   src/pdf_range.c

--- a/docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
+++ b/docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
@@ -4,11 +4,13 @@
 
 **Goal:** Add an immutable, batch, shrink-only MediaBox physical trim transform that preserves existing CropBox/interactive/document-root structures and extends the suite from 22 to 23 CTests.
 
-**Architecture:** Reuse CropBox V1's proven full-document isolation and deterministic serializer, but keep MediaBox trim as a separate public primitive and writer. Extract only strict page-box resolution/mapping into a small private `pdf_page_box_common.[ch]` helper so CropBox and MediaBox share one proven coordinate model without creating a generic transform framework.
+**Architecture:** Reuse CropBox V1's proven full-document isolation and deterministic serializer, but keep MediaBox trim as a separate public primitive and writer. Extract only strict page-box resolution/mapping into a small private `pdf_page_box_common.[ch]` helper so CropBox and MediaBox share one proven coordinate model without creating a generic transform framework. Frame-changing classification is based on the effective visible intersection before/after trim, per the committed MediaBox frame correction.
 
 **Tech Stack:** C11, MuPDF 1.28.2, CMake/CTest, GitHub Actions Linux + ASan/UBSan + macOS + Windows DLL.
 
 **Spec:** `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md`
+
+**Normative correction/evidence:** `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md`
 
 ## Global Constraints
 
@@ -16,8 +18,12 @@
 - Public request coordinates are current ExtractPDF/Fitz page space; callers never supply raw PDF coordinates.
 - MuPDF page matrix project invariant: PDF user space -> ExtractPDF/Fitz public page space; inverse maps public -> PDF.
 - V1 is shrink-only against current public MediaBox.
-- A real local/inherited CropBox remains structurally unchanged; output visible region is `intersection(new MediaBox, preserved CropBox)` and may have non-zero public origin.
-- If no CropBox exists through inheritance, CropBox falls back to new MediaBox and output page frame re-anchors to `(0,0)`.
+- A real local/inherited CropBox remains structurally unchanged.
+- Post-trim effective visible raw box is `requested_media_pdf` when no real CropBox exists, otherwise `intersection(requested_media_pdf, preserved_crop_pdf)`.
+- If post-trim effective visible raw box equals source effective visible raw box, the transform is physical-only: page frame and public visible/object geometry stay unchanged even though MediaBox changes.
+- If post-trim effective visible raw box differs, MuPDF re-anchors the page frame to that new effective visible box; deterministic unrotated/UserUnit=1 visible bounds restart at `(0,0)`.
+- Do not require a clipped preserved-CropBox output visible rectangle to retain its old non-zero origin. Instead test that the output MediaBox can be negative/non-zero relative to the newly re-anchored visible frame.
+- If no CropBox exists through inheritance, CropBox falls back to new MediaBox and output frame re-anchors to the new MediaBox.
 - BleedBox/TrimBox/ArtBox are opaque preservation state: do not write, materialize, normalize, repair, or trim-specific validate them.
 - Only changed pages receive page-local `/MediaBox` writes.
 - No page graft, content-stream transformation, per-object geometry rewrite, annotation/form mutation, appearance regeneration, JavaScript, form events, validation, formatting, calculation, or activation.
@@ -26,7 +32,7 @@
 - All requests preflight before private writes; private canonical reparse must re-resolve/revalidate every target before first write.
 - No MuPDF types in public headers; no mutable process-global/TLS PDF state; no MuPDF exception crosses the C ABI.
 - No `.github/workflows/ci.yml` changes are authorized.
-- Current suite is 22 CTests; this slice adds exactly one new CTest: `extractpdf.pdf_trim`, yielding 23 total.
+- Current suite is 22 CTests; this slice adds exactly one new CTest `extractpdf.pdf_trim`, yielding 23 total.
 - Do not start poster split, flatten, optimize/gc, image recompression, or security rewrite work in this branch.
 
 ---
@@ -34,29 +40,26 @@
 ## File Structure
 
 ### New production files
-
 - `src/pdf_page_box_common.h` — strict reusable page-box view and raw/public mapping declarations.
 - `src/pdf_page_box_common.c` — MediaBox/CropBox inheritance resolution, CropBox provenance, Rotate/UserUnit validation, effective-visible intersection, PDF/public mapping.
-- `src/pdf_trim_internal.h` — trim-only plan type and private declarations.
-- `src/pdf_trim_preflight.c` — MediaBox-specific request validation, no-op classification, post-trim CropBox-intersection validation.
+- `src/pdf_trim_internal.h` — trim-only plan type and declarations.
+- `src/pdf_trim_preflight.c` — MediaBox-specific request validation, no-op classification, post-trim visible intersection, frame-change classification.
 - `src/pdf_trim.c` — public orchestration, private full-document reopen, `/MediaBox` writer, deterministic publication.
 
 ### Existing production files modified
-
 - `include/extractpdf/extractpdf.h` — approved `extractpdf_page_trim` and `extractpdf_trim_pages()` ABI only.
 - `src/pdf_crop_internal.h` — retain crop-only plan declarations; consume common page-box view.
 - `src/pdf_crop_preflight.c` — delegate strict page-box resolution to common helper without semantic changes.
-- `src/pdf_crop.c` — include/name adjustment only if required by common extraction; no semantic change intended.
+- `src/pdf_crop.c` — include/name adjustment only if required; no semantic change intended.
 - `CMakeLists.txt` — add common and trim production sources.
 
 ### New tests/fixtures
-
-- `tests/test_pdf_trim.c` — ABI, argument/security/no-op/batch/source-lifetime tests and main runner.
-- `tests/test_pdf_trim_raw.c` — raw local MediaBox/CropBox/default-box/preservation checks.
-- `tests/test_pdf_trim_internal.h` — test-only declarations.
-- `tests/test_pdf_trim_transforms.c` — Rotate/UserUnit and preserved-CropBox coordinate cases.
-- `tests/fixtures/trim-interactive.pdf` — deterministic two-page no-CropBox interactive fixture.
-- `tests/fixtures/trim-preserved-crop.pdf` — inherited CropBox physical-only and clipped-visible cases.
+- `tests/test_pdf_trim.c`
+- `tests/test_pdf_trim_raw.c`
+- `tests/test_pdf_trim_internal.h`
+- `tests/test_pdf_trim_transforms.c`
+- `tests/fixtures/trim-interactive.pdf`
+- `tests/fixtures/trim-preserved-crop.pdf`
 - `tests/fixtures/trim-rotate-90.pdf`
 - `tests/fixtures/trim-userunit.pdf`
 - `tests/fixtures/trim-default-boxes.pdf`
@@ -65,69 +68,45 @@
 - `tests/fixtures/trim-malformed-userunit.pdf`
 
 ### Existing test file modified
-
-- `tests/CMakeLists.txt` — register exactly one new executable/CTest; private MuPDF link for raw helper; Windows DLL post-build copy as required.
+- `tests/CMakeLists.txt` — register exactly one new executable/CTest, private MuPDF link for raw helper, Windows DLL copy as required.
 
 ---
 
 ### Task 1: Lock the MediaBox ABI compile RED and open the draft PR
 
-**Files:**
-- Create: `tests/test_pdf_trim.c`
-- Create: `tests/fixtures/trim-interactive.pdf`
-- Modify: `tests/CMakeLists.txt`
-- Do not modify: public header, `src/`, root `CMakeLists.txt`, workflow files.
+**Files:** Create `tests/test_pdf_trim.c`, `tests/fixtures/trim-interactive.pdf`; modify `tests/CMakeLists.txt`. No public/header/src/root-CMake/workflow edits.
 
-**Interfaces:**
-- Consumes: integrated 22-test baseline.
-- Produces: one failing `extractpdf_test_pdf_trim` compile target referencing the approved-but-absent ABI.
+**Interfaces:** Produces one compile-RED target referencing absent approved ABI.
 
-- [ ] **Step 1: Create the deterministic two-page no-CropBox fixture**
-
-Construct `trim-interactive.pdf` with:
+- [ ] Create deterministic two-page fixture:
 
 ```text
-Page 1 raw MediaBox [0 0 400 300]
-Page 2 raw MediaBox [0 0 400 300]
-No local/inherited CropBox.
-
-Page 1:
-  text marker TRIM-TEXT
-  one image XObject occurrence
-  URI link https://example.com/trim
-  internal /XYZ link targeting page 2
-  Square annotation Contents=(TRIM-ANNOT)
-  Text Widget under a legal AcroForm hierarchy:
-      parent field /T (trim)
-      child Widget field /T (text)
-      public full field name = trim.text
-      value = TRIM-VALUE
-
-Page 2:
-  text marker TRIM-TARGET
-  outline internal destination
+Page 1/2 raw MediaBox [0 0 400 300]
+No real CropBox anywhere.
+Page 1: TRIM-TEXT, one image, URI https://example.com/trim,
+        internal /XYZ link -> page 2,
+        Square Contents=(TRIM-ANNOT),
+        Text Widget with legal hierarchy:
+          parent /T(trim), child Widget field /T(text)
+          public full field name trim.text, value TRIM-VALUE
+Page 2: TRIM-TARGET and outline internal destination.
 ```
 
-Do **not** encode `/T (trim.text)` as one partial field name; the existing strict AcroForm parser rejects dotted partial names. Use Parent/Kids hierarchy to produce the public full name `trim.text`.
+Do not encode `/T(trim.text)` as one partial name; existing strict AcroForm rejects dotted partial names.
 
-- [ ] **Step 2: Write the initial compile-RED test**
-
-Reference the absent ABI exactly:
+- [ ] Write initial absent-ABI test:
 
 ```c
-extractpdf_page_trim trim;
+extractpdf_page_trim trim = {0};
 extractpdf_output *output = NULL;
-
-memset(&trim, 0, sizeof(trim));
 trim.struct_size = sizeof(trim);
 trim.page_index = 0;
-trim.bounds = (extractpdf_rect){40.0f, 30.0f, 360.0f, 270.0f};
-
+trim.bounds = (extractpdf_rect){40,30,360,270};
 if (extractpdf_trim_pages(document, &trim, 1, &output) != EXTRACTPDF_OK)
     return fail("valid trim failed");
 ```
 
-- [ ] **Step 3: Register exactly one new CTest**
+- [ ] Register one new CTest:
 
 ```cmake
 add_executable(extractpdf_test_pdf_trim test_pdf_trim.c)
@@ -138,36 +117,15 @@ add_test(NAME extractpdf.pdf_trim COMMAND extractpdf_test_pdf_trim)
 set_tests_properties(extractpdf.pdf_trim PROPERTIES TIMEOUT 60)
 ```
 
-- [ ] **Step 4: Commit the strict RED surface**
-
-```bash
-git add tests/test_pdf_trim.c tests/fixtures/trim-interactive.pdf tests/CMakeLists.txt
-git commit -m "test: lock MediaBox trim contract"
-```
-
-- [ ] **Step 5: Create canonical draft PR**
-
-`feat/mediabox-trim` -> `master`, title `feat: add immutable MediaBox physical trim transform`, body tracks #51/#48/#2 and links the committed spec. State compile-RED checkpoint and explicit integration requirement.
-
-- [ ] **Step 6: Require attributable Linux compile RED**
-
-Expected:
-
-```text
-existing 22 targets build
-only extractpdf_test_pdf_trim fails for missing extractpdf_page_trim / extractpdf_trim_pages
-```
-
-Stop if any old target fails or RED is caused by fixture/CMake defects.
+- [ ] Commit `test: lock MediaBox trim contract`.
+- [ ] Create canonical **draft** PR `feat/mediabox-trim` -> `master`, tracking #51/#48/#2 and committed spec/correction.
+- [ ] Require Linux compile RED attributable only to missing `extractpdf_page_trim` / `extractpdf_trim_pages`; old 22 targets must still build. Stop otherwise.
 
 ---
 
 ### Task 2: Add the public ABI shell and move RED to runtime
 
-**Files:**
-- Modify: `include/extractpdf/extractpdf.h`
-- Create: `src/pdf_trim.c`
-- Modify: `CMakeLists.txt`
+**Files:** modify header/root CMake; create `src/pdf_trim.c`.
 
 **Interfaces:**
 
@@ -185,20 +143,14 @@ EXTRACTPDF_API extractpdf_status extractpdf_trim_pages(
     extractpdf_output **out_output);
 ```
 
-- [ ] **Step 1: Add exact approved ABI** beside CropBox types/function.
-- [ ] **Step 2: Add minimal shell**:
+- [ ] Add exact ABI beside CropBox ABI; no options/generic page-box rewrite API.
+- [ ] Add shell:
 
 ```c
 #include "internal.h"
-
-extractpdf_status extractpdf_trim_pages(
-    extractpdf_document *document,
-    const extractpdf_page_trim *trims,
-    size_t trim_count,
-    extractpdf_output **out_output)
+extractpdf_status extractpdf_trim_pages(...)
 {
-    if (out_output == NULL)
-        return EXTRACTPDF_ERROR_ARGUMENT;
+    if (out_output == NULL) return EXTRACTPDF_ERROR_ARGUMENT;
     *out_output = NULL;
     if (document == NULL || trims == NULL || trim_count == 0)
         return EXTRACTPDF_ERROR_ARGUMENT;
@@ -206,28 +158,15 @@ extractpdf_status extractpdf_trim_pages(
 }
 ```
 
-- [ ] **Step 3: Add only `src/pdf_trim.c` to root CMake.**
-- [ ] **Step 4: Run PR workflow.** Expected 23 executables compile; old 22 CTests pass; only `extractpdf.pdf_trim` fails `valid trim failed`.
-- [ ] **Step 5: Commit**:
-
-```bash
-git add include/extractpdf/extractpdf.h src/pdf_trim.c CMakeLists.txt
-git commit -m "feat: add MediaBox trim ABI shell"
-```
-
-Public ABI review gate: no MuPDF type, flags, generic box-rewrite API, or unrelated ABI.
+- [ ] Add only `src/pdf_trim.c` to root CMake.
+- [ ] Require workflow: 23 executables compile; old 22 CTests pass; only `extractpdf.pdf_trim` runtime REDs at changed trim.
+- [ ] Commit `feat: add MediaBox trim ABI shell`.
 
 ---
 
 ### Task 3: Extract strict page-box common helper without changing CropBox behavior
 
-**Files:**
-- Create: `src/pdf_page_box_common.h`
-- Create: `src/pdf_page_box_common.c`
-- Modify: `src/pdf_crop_internal.h`
-- Modify: `src/pdf_crop_preflight.c`
-- Modify: `src/pdf_crop.c` only if include/name adjustment is required
-- Modify: `CMakeLists.txt`
+**Files:** create `src/pdf_page_box_common.[ch]`; modify crop internal/preflight, root CMake, and `src/pdf_crop.c` only if include/name adjustment is necessary.
 
 **Interfaces:**
 
@@ -246,49 +185,25 @@ typedef struct extractpdf_pdf_page_box_view {
 } extractpdf_pdf_page_box_view;
 
 extractpdf_status extractpdf_pdf_page_box_resolve(
-    fz_context *ctx,
-    pdf_document *document,
-    int page_index,
+    fz_context *ctx, pdf_document *document, int page_index,
     extractpdf_pdf_page_box_view *out_view);
 ```
 
-- [ ] **Step 1: Characterize existing CropBox** with `ctest --test-dir build -R '^extractpdf\.pdf_crop$' --output-on-failure`; expect PASS before refactor.
-- [ ] **Step 2: Move only read-only consumed-state logic**: page dictionary; Parent cycle/depth; nearest MediaBox; nearest CropBox + presence provenance; strict four-number parsing; positive raw boxes; visible intersection; inherited Rotate; page-local UserUnit; `pdf_to_public`; `media_public`; `visible_public`.
-- [ ] **Step 3: Keep crop policy crop-specific**: struct_size, duplicate page, shrink-to-visible, changed/no-op, security, writer/orchestration.
-- [ ] **Step 4: Adapt crop plan mapping**:
+- [ ] Characterize `extractpdf.pdf_crop` before refactor; PASS required.
+- [ ] Move only read-only consumed-state logic: page dictionary; Parent cycle/depth; nearest MediaBox; nearest CropBox + provenance; strict finite boxes; visible intersection; inherited Rotate; page-local UserUnit; `pdf_to_public`; media/visible public rects.
+- [ ] Keep CropBox struct-size/duplicates/shrink-to-visible/no-op/security/writer/orchestration crop-specific.
+- [ ] Adapt crop plan mapping with `inverse(view.pdf_to_public)` and preserve exact integrated behavior.
+- [ ] Add common source to CMake; run static + sanitizer. Baseline 22 incl. crop PASS; trim remains runtime RED.
+- [ ] Audit common helper: no put/del/graft/serializer/JS/form runtime.
+- [ ] Commit `refactor: share strict PDF page-box resolution`.
 
-```c
-public_to_pdf = fz_invert_matrix(view.pdf_to_public);
-requested_pdf = normalize(transform(crops[index].bounds, public_to_pdf));
-validate requested_pdf inside view.visible_pdf;
-changed = requested_public != view.visible_public;
-```
-
-- [ ] **Step 5: Add common source to CMake and run static + sanitizer suites.** Expected baseline 22 pass; trim stays runtime RED.
-- [ ] **Step 6: Forbidden audit** common helper contains no `pdf_dict_put`, `pdf_dict_del`, graft, serializer, JS/form runtime.
-- [ ] **Step 7: Commit**:
-
-```bash
-git add src/pdf_page_box_common.h src/pdf_page_box_common.c \
-  src/pdf_crop_internal.h src/pdf_crop_preflight.c src/pdf_crop.c CMakeLists.txt
-git commit -m "refactor: share strict PDF page-box resolution"
-```
-
-Reject this task if any CropBox status, no-op, output semantics, tests, or public ABI changed.
+Reject this task if any CropBox status/no-op/output/test/public-ABI behavior changes.
 
 ---
 
-### Task 4: Lock strict trim preflight, security, and all-no-op behavior
+### Task 4: Lock strict trim preflight, security, no-op, and frame classification
 
-**Files:**
-- Create: `src/pdf_trim_internal.h`
-- Create: `src/pdf_trim_preflight.c`
-- Modify: `src/pdf_trim.c`
-- Create: `tests/fixtures/trim-malformed-box.pdf`
-- Create: `tests/fixtures/trim-malformed-rotate.pdf`
-- Create: `tests/fixtures/trim-malformed-userunit.pdf`
-- Modify: `tests/test_pdf_trim.c`
-- Modify: `tests/CMakeLists.txt`
+**Files:** create `src/pdf_trim_internal.h`, `src/pdf_trim_preflight.c`, three malformed fixtures; modify `src/pdf_trim.c`, trim test, tests CMake.
 
 **Interfaces:**
 
@@ -297,22 +212,22 @@ typedef struct extractpdf_pdf_trim_plan {
     int page_index;
     extractpdf_rect requested_public;
     fz_rect requested_media_pdf;
+    fz_rect output_visible_pdf;
     int changed;
+    int frame_changed;
 } extractpdf_pdf_trim_plan;
 
 extractpdf_status extractpdf_pdf_trim_build_plan(
-    fz_context *ctx,
-    pdf_document *document,
-    const extractpdf_page_trim *trims,
-    size_t trim_count,
-    extractpdf_pdf_trim_plan *plans,
-    int *out_any_changed);
+    fz_context *ctx, pdf_document *document,
+    const extractpdf_page_trim *trims, size_t trim_count,
+    extractpdf_pdf_trim_plan *plans, int *out_any_changed);
 ```
 
-- [ ] **Step 1: Add tests first** for null pointers, zero count, too-small struct, bad/duplicate index, NaN/inf, zero/inverted rect, request outside MediaBox, malformed consumed MediaBox/CropBox, invalid Rotate/UserUnit, non-PDF, encrypted, signed. Every failure initializes output to sentinel `(extractpdf_output *)(uintptr_t)1` and requires `output == NULL` afterward.
-- [ ] **Step 2: Add all-no-op test** by querying exact public MediaBox and submitting it unchanged. Require OK, source unchanged, repeated canonical outputs byte-identical.
-- [ ] **Step 3: Run test-first RED**; failure should now be missing validation/no-op behavior, not compile.
-- [ ] **Step 4: Implement trim plan**:
+- [ ] Test-first argument/error matrix: nulls, zero count, small struct, bad/duplicate index, NaN/inf, zero/inverted, outside MediaBox, malformed consumed MediaBox/CropBox, invalid Rotate/UserUnit, non-PDF, encrypted, signed. Reuse existing non-PDF/encrypted/signed fixtures read-only; do not modify them. Initialize output sentinel and require NULL after all failures.
+- [ ] `trim-malformed-box.pdf` must isolate both consumed-box failures without ambiguity: one target page with malformed MediaBox and another target page with valid MediaBox but malformed real CropBox; each selected independently.
+- [ ] Add all-no-op test by querying exact current public MediaBox. Require OK, source unchanged, repeated canonical outputs byte-identical.
+- [ ] Run new tests before production; expect validation/no-op RED.
+- [ ] Build each plan:
 
 ```c
 view = extractpdf_pdf_page_box_resolve(...);
@@ -320,158 +235,164 @@ validate request inside view.media_public;
 requested_media_pdf = normalize(transform(request, inverse(view.pdf_to_public)));
 validate requested_media_pdf inside view.media_pdf;
 changed = request != view.media_public;
-if (changed && view.has_explicit_crop)
-    require positive intersection(requested_media_pdf, view.crop_pdf);
+
+if (view.has_explicit_crop)
+    output_visible_pdf = intersection(requested_media_pdf, view.crop_pdf);
+else
+    output_visible_pdf = requested_media_pdf;
+
+require positive output_visible_pdf for changed request;
+frame_changed = !raw_rect_equal(output_visible_pdf, view.visible_pdf);
 ```
 
-Do not inspect BleedBox/TrimBox/ArtBox.
+A changed MediaBox with `frame_changed == 0` is a valid physical-only trim, not a no-op.
 
-- [ ] **Step 5: Implement fail-closed security and all-no-op orchestration**. Changed batch still returns `UNSUPPORTED`; all-no-op serializes source once with existing deterministic serializer.
-- [ ] **Step 6: Run static + sanitizer suites**. Expected all validation/no-op assertions pass, baseline 22 pass, trim test fails only at first changed request.
-- [ ] **Step 7: Commit** `feat: preflight immutable MediaBox trims`.
+- [ ] Implement fail-closed security + all-no-op canonical serialization; changed batch still `UNSUPPORTED`.
+- [ ] Static + sanitizer: all new validation/no-op assertions pass, old 22 pass, trim fails only at first changed request.
+- [ ] Commit `feat: preflight immutable MediaBox trims`.
 
 ---
 
-### Task 5: Implement isolated MediaBox-only writer and both page-frame modes
+### Task 5: Implement isolated MediaBox-only writer and both frame modes
 
-**Files:**
-- Modify: `src/pdf_trim.c`
-- Create: `tests/test_pdf_trim_internal.h`
-- Create: `tests/test_pdf_trim_raw.c`
-- Create: `tests/fixtures/trim-preserved-crop.pdf`
-- Modify: `tests/test_pdf_trim.c`
-- Modify: `tests/CMakeLists.txt`
+**Files:** modify `src/pdf_trim.c`; create trim raw helper/header, `trim-preserved-crop.pdf`; modify trim test/CMake.
 
-**Test-only interfaces:**
+**Raw helper interfaces:**
 
 ```c
 int trim_raw_expect_local_mediabox(
     const unsigned char *data, size_t size, int page_index,
     int expect_present, const float expected[4]);
-
-int trim_raw_expect_preserved_cropbox(
-    const unsigned char *before, size_t before_size,
-    const unsigned char *after, size_t after_size,
-    int page_index);
-
-int trim_raw_expect_preserved_graph(
-    const unsigned char *before, size_t before_size,
-    const unsigned char *after, size_t after_size);
+int trim_raw_expect_preserved_cropbox(...);
+int trim_raw_expect_preserved_graph(...);
 ```
 
-- [ ] **Step 1: Add inherited-CropBox fixture** with MediaBox `[0 0 400 300]`, CropBox `[50 40 350 260]`, child pages without local boxes. One page is trimmed physically while still containing all CropBox; another clips CropBox but leaves positive intersection.
-- [ ] **Step 2: Derive public trim requests from actual public MediaBox observations/mapping**, never assume its public origin is `(0,0)` when CropBox exists.
-- [ ] **Step 3: Add raw helper** and privately link MuPDF only to trim test. Prove changed inherited MediaBox becomes local, no-op inherited MediaBox remains inherited, CropBox raw object/value unchanged, and Contents/Resources/Annots/root AcroForm/root Outlines are semantically preserved without object-number identity assumptions.
-- [ ] **Step 4: Add public assertions before production**:
+- [ ] Fixture: inherited MediaBox `[0 0 400 300]`, inherited CropBox `[50 40 350 260]`, child pages no local boxes. Include:
+  - physical-only trim whose `requested_media_pdf ∩ crop_pdf == source visible_pdf`;
+  - clipping trim whose intersection is positive but differs from source visible.
+- [ ] Derive public requests from actual source public MediaBox observations/mapping; never assume source MediaBox origin `(0,0)` when CropBox exists.
+- [ ] Raw helper proves changed inherited MediaBox becomes local; no-op remains inherited; raw CropBox unchanged; core graph semantically preserved without indirect-object-number identity assumptions.
+- [ ] Public tests first:
 
 ```text
-no CropBox fallback:
-  output MediaBox/CropBox/visible origin -> (0,0)
-  dimensions == requested physical dimensions
-  existing geometry follows re-anchored transform
+no real CropBox:
+  changed trim -> new effective visible = new MediaBox
+  output frame re-anchors
+  deterministic unrotated/UserUnit=1 visible bounds [0,0,w,h]
 
-preserved CropBox physical-only:
+real CropBox physical-only:
   MediaBox changes
-  visible/CropBox observation unchanged
+  output_visible_pdf == source_visible_pdf
+  frame unchanged
+  visible/object public geometry unchanged
 
-preserved CropBox clipped:
+real CropBox clipping:
   raw CropBox unchanged
-  visible == intersection(new MediaBox, CropBox)
-  visible public x0/y0 may be non-zero
-  no per-object rewrite
+  output_visible_pdf = new MediaBox ∩ CropBox
+  output_visible_pdf != source_visible_pdf
+  page frame re-anchors to new effective visible intersection
+  deterministic unrotated/UserUnit=1 visible bounds restart at [0,0,w,h]
+  output MediaBox public rect may be negative/non-zero relative to that new visible frame
+  object PDF geometry unchanged; public geometry follows new page transform
 ```
 
-Expected still RED on changed trim.
+Do not assert clipped visible public origin remains non-zero.
 
-- [ ] **Step 5: Implement private changed flow**: canonical source serialize -> fresh context -> open bytes -> disable JS -> security recheck -> rebuild all private plans -> resolve all target pages -> verify private semantics before first write -> local `/MediaBox` writes only -> deterministic serialize -> cleanup.
-- [ ] **Step 6: Narrow writer** uses `pdf_new_array(ctx, private_document, 4)` and exactly one `pdf_dict_put(..., PDF_NAME(MediaBox), array)` semantic key. No journal/graft/runtime mutation.
-- [ ] **Step 7: Require static + ASan/UBSan 23/23** at this checkpoint.
-- [ ] **Step 8: Commit** `feat: apply isolated MediaBox trims`.
+- [ ] Implement changed flow: source canonical serialize -> fresh private context -> open -> disable JS -> security recheck -> rebuild complete private plans -> resolve every target -> compare private plan semantics including `output_visible_pdf` and `frame_changed` before first write -> local MediaBox writes only -> deterministic serialize.
+- [ ] Writer uses `pdf_new_array(ctx, private_document, 4)` and exactly one semantic `pdf_dict_put(... PDF_NAME(MediaBox) ...)` key.
+- [ ] Static + ASan/UBSan 23/23.
+- [ ] Commit `feat: apply isolated MediaBox trims`.
 
 ---
 
 ### Task 6: Lock Rotate/UserUnit and opaque Bleed/Trim/Art preservation
 
-**Files:**
-- Create: `tests/test_pdf_trim_transforms.c`
-- Create: `tests/fixtures/trim-rotate-90.pdf`
-- Create: `tests/fixtures/trim-userunit.pdf`
-- Create: `tests/fixtures/trim-default-boxes.pdf`
-- Modify: `tests/test_pdf_trim_internal.h`
-- Modify: `tests/test_pdf_trim_raw.c`
-- Modify: `tests/CMakeLists.txt`
-- Production correction only if a real defect appears: `src/pdf_page_box_common.c`, `src/pdf_trim_preflight.c`, `src/pdf_trim.c`.
+**Files:** create transformed/default-box tests/fixtures; modify trim raw/header/CMake. Production only for a real defect in common/trim mapping files.
 
-- [ ] **Step 1: Add Rotate 90 test first**. Query public MediaBox, construct a valid public inset, trim, verify raw MediaBox equals inverse-mapped request and public behavior follows CropBox provenance.
-- [ ] **Step 2: Add page-local UserUnit 2 test** with same methodology.
-- [ ] **Step 3: Add default-box fixture**:
+- [ ] Rotate 90: query source public MediaBox, create valid inset, trim, verify raw MediaBox via inverse source mapping and post-trim frame behavior via effective intersection.
+- [ ] UserUnit 2: same methodology.
+- [ ] Default-box fixture:
 
 ```text
-page A: BleedBox/TrimBox/ArtBox absent
-page B: all explicit, with at least one raw box extending beyond future new MediaBox
+page A: Bleed/Trim/Art absent
+page B: explicit values, at least one extends beyond future new MediaBox
 ```
 
-Require absent keys remain absent; explicit raw arrays unchanged; trim succeeds even when a production box's effective intersection becomes reduced or empty.
-
-- [ ] **Step 4: Run characterization**. If mapping already passes, do not edit production. If not, fix only common/trim mapping; never add rotation switch tables or extra box writes.
-- [ ] **Step 5: Run full static + sanitizer 23/23.**
-- [ ] **Step 6: Commit** `test: lock transformed MediaBox trim semantics`; stage production only if it actually changed.
+Require absent keys remain absent; explicit raw values semantically unchanged; trim succeeds even if effective production box becomes reduced/empty. Do not add trim-specific malformed-production-box rejection.
+- [ ] Run characterization first. If already PASS, no production edit. If RED, correction only in common/trim mapping; no rotation switch tables/extra writes.
+- [ ] Static + sanitizer 23/23.
+- [ ] Commit `test: lock transformed MediaBox trim semantics`, staging production only if changed.
 
 ---
 
 ### Task 7: Lock batch determinism, failure atomicity, and lifetime preservation
 
-**Files:**
-- Modify: `tests/test_pdf_trim.c`
-- Modify: `tests/test_pdf_trim_transforms.c`
-- Modify: `tests/test_pdf_trim_raw.c` only if needed for one extra observation.
-- Production correction only for real contract defect: `src/pdf_trim.c`, `src/pdf_trim_preflight.c`.
+**Files:** modify trim public/transforms/raw tests; production only for real defect in trim orchestration/preflight.
 
-- [ ] **Step 1: Two-page all-no-op batch**: both current public MediaBoxes; require no local materialization and repeated canonical outputs byte-identical; do not compare to original file bytes.
-- [ ] **Step 2: Mixed no-op + changed**: no-op page structurally untouched, changed page local MediaBox.
-- [ ] **Step 3: Two changed pages**: identical batch twice -> same size + `memcmp == 0`.
-- [ ] **Step 4: Failure atomicity**: request 0 valid changed; request 1 invalid because it leaves empty preserved-CropBox intersection. Require `ARGUMENT`, output NULL, both source pages unchanged.
-- [ ] **Step 5: Source/output lifetime**: successful transform leaves source public observations unchanged; close source; output remains reopenable/fully usable; structurally enumerated objects outside new medium remain present.
-- [ ] **Step 6: Run tests before production edits**. Expected PASS if implementation already matches spec; failures are real contract defects unless test contradicts committed spec.
-- [ ] **Step 7: Minimal correction only if required**, no public ABI/general framework.
-- [ ] **Step 8: Run static + sanitizer 23/23 and commit** `test: lock MediaBox trim batch determinism`.
+- [ ] Two-page all-no-op: no local materialization; repeated canonical outputs byte-identical; never require original input byte equality.
+- [ ] Mixed no-op + changed: untouched no-op page, local MediaBox on changed page.
+- [ ] Two changed pages: identical batch twice -> equal size + `memcmp == 0`.
+- [ ] Failure atomicity: request 0 valid changed; request 1 leaves empty post-trim effective visible intersection -> `ARGUMENT`, output NULL, source unchanged.
+- [ ] Source/output lifetime: source original observations remain; close source; output remains fully usable; structurally enumerable objects outside medium remain present.
+- [ ] Run tests before production changes; expected PASS if implementation matches spec/correction. Treat failures as contract defects.
+- [ ] Minimal correction only if required; no ABI/general framework.
+- [ ] Static + sanitizer 23/23; commit `test: lock MediaBox trim batch determinism`.
 
 ---
 
 ### Task 8: Freeze exact head, same-SHA cross-platform proof, review, and STOP
 
-**Files:**
-- No intended source/test changes.
-- PR/issue metadata/comments only.
+**Files:** no intended source/test changes; metadata/comments only.
 
-- [ ] **Step 1: Freeze exact candidate SHA**. Any file change invalidates proof; no amend/rebase/force-push.
-- [ ] **Step 2: Audit net paths**. Expected only spec/plan, trim/common production, crop adaptation, trim tests/fixtures, CMake/header. Reused fixtures and workflow YAML untouched.
-- [ ] **Step 3: Forbidden audit**:
+- [ ] Freeze exact candidate SHA; any file change invalidates proof; no amend/rebase/force-push.
+- [ ] Audit net paths: only MediaBox spec + frame correction + plan, approved header/CMake, page-box common + crop adaptation, trim production/tests/fixtures. Reused fixtures/workflow YAML untouched.
+- [ ] Forbidden audit:
 
 ```text
 pdf_page_box_common.c: no put/del/graft/serializer/runtime mutation
 pdf_trim_preflight.c: no writes/graft; no Bleed/Trim/Art parsing
 pdf_trim.c: sole semantic key write PDF_NAME(MediaBox); no graft/content/annot/form/widget/appearance/JS/event mutation
-crop path: CropBox regression unchanged and sole crop write remains PDF_NAME(CropBox)
-public header: no MuPDF type
+crop path: CropBox regression unchanged; sole crop semantic key PDF_NAME(CropBox)
+public header: no MuPDF types
 ```
 
-- [ ] **Step 4: Fresh exact-head Linux PR proof**: static 23/23 + ASan/UBSan 23/23.
-- [ ] **Step 5: Add existing `full-ci` label to draft PR only**; workflow YAML unchanged. Require same frozen head SHA and Linux static/sanitizer 23/23, macOS 23/23, Windows DLL 23/23. Windows logs must show `extractpdf.dll`, `extractpdf_test_pdf_trim.exe`, `extractpdf.pdf_trim` as test 23/23, and 100% of 23 tests.
-- [ ] **Step 6: Final Critical/Important review** against: current-Fitz MediaBox inputs; shrink-only; source immutable; all preflight before writes; full-document isolation; private re-resolution; no source MuPDF pointer crossing; no-op inheritance preservation; fallback re-anchor; preserved-CropBox non-zero visible origin; physical-only trim != no-op; Rotate/UserUnit via common matrix; opaque Bleed/Trim/Art; structural preservation; fail-closed security; output reset; deterministic output; CropBox #22 regression; new #23 coverage.
-- [ ] **Step 7: Fetch reviews/threads**; require no unresolved Critical/Important blocker.
-- [ ] **Step 8: Post checkpoint to #51 + draft PR and STOP**. Do not mark ready, merge, close #51, checkpoint #48/#2 as integrated, delete branch, or start poster split without explicit integration authorization.
+- [ ] Fresh exact-head Linux PR: static 23/23 + ASan/UBSan 23/23.
+- [ ] Add existing `full-ci` label to draft PR only; workflow unchanged. Require same frozen SHA, Linux static/sanitizer 23/23, macOS 23/23, Windows DLL 23/23. Windows log explicitly shows `extractpdf.dll`, `extractpdf_test_pdf_trim.exe`, `extractpdf.pdf_trim` as test 23/23, 100% of 23 tests.
+- [ ] Final Critical/Important review verifies:
+
+```text
+current-source-Fitz MediaBox input
+shrink-only MediaBox
+source immutable / private reparse before writes
+no source MuPDF pointer crosses contexts
+only changed local MediaBox writes
+no-op inherited MediaBox stays inherited
+no-CropBox fallback re-anchors frame
+physical-only trim => effective visible intersection unchanged => frame unchanged
+clipping trim => effective visible intersection changed => frame re-anchored
+clipped visible public origin is not incorrectly required to preserve old non-zero origin
+output MediaBox may be negative/non-zero relative to visible frame
+Rotate/UserUnit use common matrix
+Bleed/Trim/Art opaque preservation
+interactive/document-root structural preservation
+encrypted/signed fail closed
+output reset and deterministic outputs
+CropBox #22 regression GREEN
+trim #23 adds coverage without weakening prior tests
+```
+
+- [ ] Fetch reviews/threads; no unresolved Critical/Important blocker.
+- [ ] Post exact SHA/workflow IDs/23-of-23/scope/review checkpoint to #51 + draft PR and STOP. Do not mark ready, merge, close #51, checkpoint #48/#2 as integrated, delete branch, or start poster split without explicit integration authorization.
 
 ---
 
 ### Task 9: Integrate only after explicit authorization
 
-**Files:**
-- No intended feature-tree changes.
+**Files:** no intended feature-tree changes.
 
-- [ ] **Step 1: Re-read frozen head, current master, reviews, and exact-head CI**. If feature moved, repeat Task 8; if master moved, inspect rather than silently rebasing.
-- [ ] **Step 2: Prefer normal expected-head merge commit**.
-- [ ] **Step 3: If draft->ready connector GraphQL is still broken**, use only the already-approved fallback after explicit integration authorization:
+- [ ] Re-read frozen feature head, current master, reviews, exact-head CI. If feature moved repeat Task 8; if master moved inspect, do not silently rebase.
+- [ ] Prefer normal expected-head merge commit.
+- [ ] If draft->ready connector GraphQL is still broken, only after explicit integration authorization use proven fallback:
 
 ```text
 create two-parent merge commit
@@ -479,11 +400,10 @@ create two-parent merge commit
   parent1 = current verified master
   parent2 = frozen feature SHA
 update master force=false
-verify PR is associated/merged
+verify GitHub associates PR as merged
 ```
 
 Never force-update master.
-
-- [ ] **Step 4: Require integrated-master push proof on exact merge SHA**: Linux static 23/23 + ASan/UBSan 23/23 + macOS 23/23 + Windows DLL 23/23, including `extractpdf_test_pdf_trim.exe`.
-- [ ] **Step 5: Only after proof** close #51 as completed and checkpoint #48/#2.
-- [ ] **Step 6: Do not auto-start poster split.**
+- [ ] Require integrated-master exact merge SHA proof: Linux static 23/23, ASan/UBSan 23/23, macOS 23/23, Windows DLL 23/23 including `extractpdf_test_pdf_trim.exe`.
+- [ ] Only after integrated proof close #51 completed and checkpoint #48/#2.
+- [ ] Do not auto-start poster split.

--- a/docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
+++ b/docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
@@ -1,0 +1,1050 @@
+# ExtractPDF Immutable MediaBox Physical Trim V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an immutable, batch, shrink-only MediaBox physical trim transform that preserves existing CropBox/interactive/document-root structures and extends the suite from 22 to 23 CTests.
+
+**Architecture:** Reuse CropBox V1's proven full-document isolation and deterministic serializer, but keep MediaBox trim as a separate public primitive and writer. Extract only strict page-box resolution/mapping into a small private `pdf_page_box_common.[ch]` helper so CropBox and MediaBox share one proven coordinate model without creating a generic transform framework.
+
+**Tech Stack:** C11, MuPDF 1.28.2, CMake/CTest, GitHub Actions Linux + ASan/UBSan + macOS + Windows DLL.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md`
+
+## Global Constraints
+
+- Baseline master is `3fc48b5fb0f7a07926f7942fc4a4a3fb5e93a753`, tree `594499cfea3071f210b5b8781d73e942ba94a94d`.
+- Public request coordinates are current ExtractPDF/Fitz page space; callers never supply raw PDF coordinates.
+- MuPDF page matrix project invariant: PDF user space -> ExtractPDF/Fitz public page space; inverse maps public -> PDF.
+- V1 is shrink-only against current public MediaBox.
+- A real local/inherited CropBox remains structurally unchanged; output visible region is `intersection(new MediaBox, preserved CropBox)` and may have non-zero public origin.
+- If no CropBox exists through inheritance, CropBox falls back to new MediaBox and output page frame re-anchors to `(0,0)`.
+- BleedBox/TrimBox/ArtBox are opaque preservation state: do not write, materialize, normalize, repair, or trim-specific validate them.
+- Only changed pages receive page-local `/MediaBox` writes.
+- No page graft, content-stream transformation, per-object geometry rewrite, annotation/form mutation, appearance regeneration, JavaScript, form events, validation, formatting, calculation, or activation.
+- Source document remains immutable; output owns independent bytes and survives source close.
+- Encrypted and already-signed PDF inputs fail closed with `EXTRACTPDF_ERROR_UNSUPPORTED`.
+- All requests preflight before private writes; private canonical reparse must re-resolve/revalidate every target before first write.
+- No MuPDF types in public headers; no mutable process-global/TLS PDF state; no MuPDF exception crosses the C ABI.
+- No `.github/workflows/ci.yml` changes are authorized.
+- Current suite is 22 CTests; this slice adds exactly one new CTest: `extractpdf.pdf_trim`, yielding 23 total.
+- Do not start poster split, flatten, optimize/gc, image recompression, or security rewrite work in this branch.
+
+---
+
+## File Structure
+
+### New production files
+
+- `src/pdf_page_box_common.h` — strict reusable page-box view and security-independent raw/public mapping helpers only.
+- `src/pdf_page_box_common.c` — MediaBox/CropBox inheritance resolution, provenance, Rotate/UserUnit validation, effective-visible intersection, PDF/public mapping.
+- `src/pdf_trim_internal.h` — trim-only plan type and private function declarations.
+- `src/pdf_trim_preflight.c` — MediaBox-specific request validation, no-op classification, post-trim CropBox-intersection validation, private-plan consistency.
+- `src/pdf_trim.c` — public orchestration, private full-document reopen, `/MediaBox` writer, deterministic publication.
+
+### Existing production files modified
+
+- `include/extractpdf/extractpdf.h` — approved `extractpdf_page_trim` and `extractpdf_trim_pages()` ABI only.
+- `src/pdf_crop_internal.h` — remove page-box view ownership after common extraction; retain crop-only plan declarations.
+- `src/pdf_crop_preflight.c` — delegate strict page-box resolution to common helper without changing CropBox policy/results.
+- `src/pdf_crop.c` — no semantic change intended; only include/function-name adjustments if common helper naming requires them.
+- `CMakeLists.txt` — add common and trim production sources.
+
+### New tests/fixtures
+
+- `tests/test_pdf_trim.c` — public ABI, argument/security/no-op/batch/source-lifetime tests and main runner.
+- `tests/test_pdf_trim_raw.c` — raw local MediaBox/CropBox/default-box/preservation observations using MuPDF privately.
+- `tests/test_pdf_trim_internal.h` — test-only helper declarations.
+- `tests/test_pdf_trim_transforms.c` — Rotate/UserUnit + preserved-CropBox public coordinate cases.
+- `tests/fixtures/trim-interactive.pdf` — deterministic two-page no-CropBox interactive fixture.
+- `tests/fixtures/trim-preserved-crop.pdf` — explicit/inherited CropBox cases including physical-only and clipped-visible cases.
+- `tests/fixtures/trim-rotate-90.pdf` — Rotate 90 fixture.
+- `tests/fixtures/trim-userunit.pdf` — page-local UserUnit fixture.
+- `tests/fixtures/trim-default-boxes.pdf` — absent/present Bleed/Trim/Art raw preservation fixture.
+- `tests/fixtures/trim-malformed-box.pdf` — malformed consumed MediaBox/CropBox fixture.
+- `tests/fixtures/trim-malformed-rotate.pdf` — invalid inherited Rotate fixture.
+- `tests/fixtures/trim-malformed-userunit.pdf` — invalid page-local UserUnit fixture.
+
+### Existing test file modified
+
+- `tests/CMakeLists.txt` — register exactly one new executable/CTest, link private MuPDF for raw helper, copy `extractpdf.dll` post-build on Windows as needed.
+
+---
+
+### Task 1: Lock the MediaBox ABI compile RED and open the draft PR
+
+**Files:**
+- Create: `tests/test_pdf_trim.c`
+- Create: `tests/fixtures/trim-interactive.pdf`
+- Modify: `tests/CMakeLists.txt`
+- Do not modify: public header, `src/`, root `CMakeLists.txt`, workflow files.
+
+**Interfaces:**
+- Consumes: current 22-test integrated baseline.
+- Produces: one failing `extractpdf_test_pdf_trim` compile target referencing the approved-but-absent ABI.
+
+- [ ] **Step 1: Create the deterministic two-page no-CropBox fixture**
+
+Construct `trim-interactive.pdf` as a small hand-authored deterministic PDF with:
+
+```text
+Page 1 raw MediaBox [0 0 400 300]
+Page 2 raw MediaBox [0 0 400 300]
+No local/inherited CropBox anywhere.
+No BleedBox/TrimBox/ArtBox unless a later dedicated fixture needs them.
+
+Page 1:
+  text marker: TRIM-TEXT
+  one image XObject occurrence
+  URI link: https://example.com/trim
+  internal /XYZ link targeting page 2
+  Square annotation, Contents=(TRIM-ANNOT)
+  Text Widget attached to AcroForm field trim.text with value TRIM-VALUE
+
+Page 2:
+  text marker: TRIM-TARGET
+  outline destination target
+```
+
+Keep all object numbers stable inside the fixture but never make production behavior depend on them.
+
+- [ ] **Step 2: Write the initial compile-RED test**
+
+In `tests/test_pdf_trim.c`, include `extractpdf/extractpdf.h` and reference the absent approved ABI exactly:
+
+```c
+extractpdf_page_trim trim;
+extractpdf_output *output = NULL;
+
+memset(&trim, 0, sizeof(trim));
+trim.struct_size = sizeof(trim);
+trim.page_index = 0;
+trim.bounds.x0 = 40.0f;
+trim.bounds.y0 = 30.0f;
+trim.bounds.x1 = 360.0f;
+trim.bounds.y1 = 270.0f;
+
+if (extractpdf_trim_pages(document, &trim, 1, &output) != EXTRACTPDF_OK)
+    return fail("valid trim failed");
+```
+
+The test must not contain fallback declarations that would let it compile before the public ABI exists.
+
+- [ ] **Step 3: Register exactly one new CTest**
+
+Append to `tests/CMakeLists.txt`:
+
+```cmake
+add_executable(extractpdf_test_pdf_trim test_pdf_trim.c)
+target_link_libraries(extractpdf_test_pdf_trim PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_trim PRIVATE
+  TRIM_INTERACTIVE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/trim-interactive.pdf")
+add_test(NAME extractpdf.pdf_trim COMMAND extractpdf_test_pdf_trim)
+set_tests_properties(extractpdf.pdf_trim PROPERTIES TIMEOUT 60)
+```
+
+No existing CTest is renamed or removed.
+
+- [ ] **Step 4: Commit the strict RED surface**
+
+```bash
+git add tests/test_pdf_trim.c tests/fixtures/trim-interactive.pdf tests/CMakeLists.txt
+git commit -m "test: lock MediaBox trim contract"
+```
+
+- [ ] **Step 5: Create a canonical draft PR**
+
+Create draft PR from `feat/mediabox-trim` to `master`:
+
+```text
+Title: feat: add immutable MediaBox physical trim transform
+Body: Tracks #51. Child of #48 / #2. Links committed spec. State that current checkpoint is strict compile RED and integration requires explicit authorization.
+```
+
+- [ ] **Step 6: Require attributable Linux compile RED**
+
+Expected latest PR workflow result:
+
+```text
+existing 22 targets build
+new extractpdf_test_pdf_trim fails compilation only because:
+  extractpdf_page_trim is unknown and/or
+  extractpdf_trim_pages is undeclared
+```
+
+Do not proceed if any old target fails or the new failure is fixture/CMake related.
+
+---
+
+### Task 2: Add the public ABI shell and move RED from compile-time to runtime
+
+**Files:**
+- Modify: `include/extractpdf/extractpdf.h`
+- Create: `src/pdf_trim.c`
+- Modify: `CMakeLists.txt`
+- Test: `tests/test_pdf_trim.c`
+
+**Interfaces:**
+- Produces public ABI:
+
+```c
+typedef struct extractpdf_page_trim {
+    size_t struct_size;
+    int page_index;
+    extractpdf_rect bounds;
+} extractpdf_page_trim;
+
+EXTRACTPDF_API extractpdf_status extractpdf_trim_pages(
+    extractpdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_output **out_output);
+```
+
+- [ ] **Step 1: Add the exact approved ABI**
+
+Place `extractpdf_page_trim` beside `extractpdf_page_crop`; place `extractpdf_trim_pages()` beside `extractpdf_crop_pages()`.
+
+No flags/options/general page-box enum are added.
+
+- [ ] **Step 2: Add the minimal shell**
+
+Create `src/pdf_trim.c`:
+
+```c
+#include "internal.h"
+
+extractpdf_status extractpdf_trim_pages(
+    extractpdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_output **out_output)
+{
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+    if (document == NULL || trims == NULL || trim_count == 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}
+```
+
+- [ ] **Step 3: Add only `src/pdf_trim.c` to root CMake**
+
+Do not add common helpers yet.
+
+- [ ] **Step 4: Run the latest PR workflow**
+
+Expected:
+
+```text
+all 23 executables compile
+CTest #1-#22 pass
+extractpdf.pdf_trim fails at runtime with "valid trim failed"
+```
+
+- [ ] **Step 5: Commit the ABI shell**
+
+```bash
+git add include/extractpdf/extractpdf.h src/pdf_trim.c CMakeLists.txt
+git commit -m "feat: add MediaBox trim ABI shell"
+```
+
+Review gate: public header exposes no MuPDF type and no API beyond the approved structure/function.
+
+---
+
+### Task 3: Extract the strict page-box common helper without changing CropBox behavior
+
+**Files:**
+- Create: `src/pdf_page_box_common.h`
+- Create: `src/pdf_page_box_common.c`
+- Modify: `src/pdf_crop_internal.h`
+- Modify: `src/pdf_crop_preflight.c`
+- Modify: `src/pdf_crop.c` only if include/name adjustment is required
+- Modify: `CMakeLists.txt`
+- Existing regression test: `extractpdf.pdf_crop`
+
+**Interfaces:**
+
+Create common view:
+
+```c
+typedef struct extractpdf_pdf_page_box_view {
+    pdf_obj *page_obj;
+    fz_rect media_pdf;
+    fz_rect crop_pdf;
+    fz_rect visible_pdf;
+    fz_matrix pdf_to_public;
+    extractpdf_rect media_public;
+    extractpdf_rect visible_public;
+    int has_explicit_crop;
+    int rotate_degrees;
+    float user_unit;
+} extractpdf_pdf_page_box_view;
+```
+
+Create helper:
+
+```c
+extractpdf_status extractpdf_pdf_page_box_resolve(
+    fz_context *ctx,
+    pdf_document *document,
+    int page_index,
+    extractpdf_pdf_page_box_view *out_view);
+```
+
+- [ ] **Step 1: Characterize CropBox before extraction**
+
+Run only existing CropBox test on current Task-2 head:
+
+```bash
+ctest --test-dir build -R '^extractpdf\.pdf_crop$' --output-on-failure
+```
+
+Expected PASS. Record this as the before-extraction behavior.
+
+- [ ] **Step 2: Move only strict consumed-state logic into common helper**
+
+Move from crop preflight into `pdf_page_box_common.c`:
+
+```text
+page dictionary validation
+Parent traversal + cycle/depth protection
+nearest MediaBox lookup
+nearest CropBox lookup + explicit provenance
+strict four-finite-number parse
+normalized positive raw boxes
+visible intersection
+Rotate inherited validation
+page-local UserUnit validation
+pdf_to_public retrieval
+media_public derivation
+visible_public derivation
+```
+
+Do **not** move:
+
+```text
+crop request struct_size checks
+duplicate page checks
+crop shrink-only-to-visible policy
+crop changed/no-op classification
+crop security policy
+crop writer/orchestration
+```
+
+- [ ] **Step 3: Adapt CropBox plan builder to the common view**
+
+`extractpdf_pdf_crop_build_plan()` should consume `extractpdf_pdf_page_box_view` and preserve the exact integrated contract:
+
+```c
+public_to_pdf = fz_invert_matrix(view.pdf_to_public);
+requested_pdf = normalize(transform(crops[index].bounds, public_to_pdf));
+validate requested_pdf inside view.visible_pdf;
+changed = requested_public != view.visible_public;
+```
+
+Keep `extractpdf_pdf_crop_plan` crop-specific.
+
+- [ ] **Step 4: Add common source to CMake and run CropBox regression**
+
+Expected:
+
+```text
+extractpdf.pdf_crop PASS
+all existing 22 baseline CTests PASS
+new trim test still runtime RED because shell returns UNSUPPORTED
+```
+
+Run both static and sanitizer suites before committing extraction.
+
+- [ ] **Step 5: Audit forbidden accidental behavior**
+
+`pdf_page_box_common.c` must contain no:
+
+```text
+pdf_dict_put
+pdf_dict_del
+pdf_graft_mapped_page
+serializer call
+JavaScript/form API
+```
+
+It is a read-only resolver only.
+
+- [ ] **Step 6: Commit the extraction**
+
+```bash
+git add src/pdf_page_box_common.h src/pdf_page_box_common.c \
+  src/pdf_crop_internal.h src/pdf_crop_preflight.c src/pdf_crop.c CMakeLists.txt
+git commit -m "refactor: share strict PDF page-box resolution"
+```
+
+Reviewer gate: reject the task if CropBox behavior, statuses, no-op semantics, fixture expectations, or public ABI changed.
+
+---
+
+### Task 4: Lock strict MediaBox preflight, security, and no-op semantics
+
+**Files:**
+- Create: `src/pdf_trim_internal.h`
+- Create: `src/pdf_trim_preflight.c`
+- Modify: `src/pdf_trim.c`
+- Create: `tests/fixtures/trim-malformed-box.pdf`
+- Create: `tests/fixtures/trim-malformed-rotate.pdf`
+- Create: `tests/fixtures/trim-malformed-userunit.pdf`
+- Modify: `tests/test_pdf_trim.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+
+Trim plan:
+
+```c
+typedef struct extractpdf_pdf_trim_plan {
+    int page_index;
+    extractpdf_rect requested_public;
+    fz_rect requested_media_pdf;
+    int changed;
+} extractpdf_pdf_trim_plan;
+```
+
+Preflight:
+
+```c
+extractpdf_status extractpdf_pdf_trim_build_plan(
+    fz_context *ctx,
+    pdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_pdf_trim_plan *plans,
+    int *out_any_changed);
+```
+
+Security may initially call a shared-or-copied fail-closed helper, but do not refactor Phase 5 unrelated code.
+
+- [ ] **Step 1: Extend tests first with argument and malformed cases**
+
+Add helper requiring output reset:
+
+```c
+static int expect_trim_error(..., extractpdf_status expected)
+{
+    extractpdf_output *output = (extractpdf_output *)(uintptr_t)1;
+    extractpdf_status status = extractpdf_trim_pages(..., &output);
+    return status == expected && output == NULL;
+}
+```
+
+Lock at least:
+
+```text
+NULL document/trims/out_output
+trim_count == 0
+small struct_size
+out-of-range page
+negative page
+NaN/infinity
+zero/inverted rectangle
+duplicate page index
+request outside public MediaBox
+malformed MediaBox/CropBox -> FORMAT
+invalid inherited Rotate -> FORMAT
+invalid page-local UserUnit -> FORMAT
+non-PDF -> UNSUPPORTED
+encrypted -> UNSUPPORTED
+signed -> UNSUPPORTED
+```
+
+- [ ] **Step 2: Add an all-no-op test before implementation**
+
+Query public MediaBox via existing API and pass that exact rectangle as trim request.
+
+Require:
+
+```text
+OK
+output != NULL
+source remains unchanged
+repeated all-no-op calls produce byte-identical canonical bytes
+```
+
+Raw non-materialization is added in Task 5.
+
+- [ ] **Step 3: Run test to verify new RED**
+
+Expected first failure should be a missing validation/no-op behavior in the shell, not a compile error.
+
+- [ ] **Step 4: Implement trim-only plan building**
+
+For each request:
+
+```c
+view = extractpdf_pdf_page_box_resolve(...);
+validate request inside view.media_public;
+public_to_pdf = fz_invert_matrix(view.pdf_to_public);
+requested_media_pdf = normalize(transform(request, public_to_pdf));
+validate requested_media_pdf inside view.media_pdf;
+changed = request != view.media_public;
+
+if (changed && view.has_explicit_crop) {
+    visible_after = intersect(requested_media_pdf, view.crop_pdf);
+    if (empty(visible_after))
+        return EXTRACTPDF_ERROR_ARGUMENT;
+}
+```
+
+Do not parse BleedBox/TrimBox/ArtBox.
+
+- [ ] **Step 5: Implement source security + all-no-op path**
+
+`extractpdf_trim_pages()` must:
+
+```text
+reset out_output
+reject non-PDF/encrypted/signed
+allocate plans safely
+build complete source plan
+if all no-op:
+  serialize source once using existing deterministic serializer
+else:
+  return UNSUPPORTED for now
+```
+
+Changed trim remains RED until Task 5.
+
+- [ ] **Step 6: Run static and sanitizer suites**
+
+Expected:
+
+```text
+all validation/no-op assertions pass
+all baseline 22 CTests pass
+extractpdf.pdf_trim fails only at first valid changed trim
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pdf_trim_internal.h src/pdf_trim_preflight.c src/pdf_trim.c \
+  tests/test_pdf_trim.c tests/CMakeLists.txt tests/fixtures/trim-malformed-*.pdf
+git commit -m "feat: preflight immutable MediaBox trims"
+```
+
+---
+
+### Task 5: Implement isolated MediaBox-only writer and both page-frame modes
+
+**Files:**
+- Modify: `src/pdf_trim.c`
+- Create: `tests/test_pdf_trim_internal.h`
+- Create: `tests/test_pdf_trim_raw.c`
+- Create: `tests/fixtures/trim-preserved-crop.pdf`
+- Modify: `tests/test_pdf_trim.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- `extractpdf_trim_pages()` becomes functional for unrotated/default-UserUnit pages.
+- Raw helper API:
+
+```c
+int trim_raw_expect_local_mediabox(
+    const unsigned char *data, size_t size, int page_index,
+    int expect_present, const float expected[4]);
+
+int trim_raw_expect_preserved_cropbox(
+    const unsigned char *before, size_t before_size,
+    const unsigned char *after, size_t after_size,
+    int page_index);
+
+int trim_raw_expect_preserved_graph(
+    const unsigned char *before, size_t before_size,
+    const unsigned char *after, size_t after_size);
+```
+
+- [ ] **Step 1: Add preserved-CropBox fixture**
+
+Create deterministic pages covering:
+
+```text
+Page A:
+  inherited MediaBox [0 0 400 300]
+  inherited CropBox [50 40 350 260]
+  no local MediaBox/CropBox
+
+Page B:
+  inherited MediaBox [0 0 400 300]
+  inherited CropBox [50 40 350 260]
+```
+
+Use Page A for physical-only trim that still contains CropBox, e.g. public MediaBox request corresponding to raw `[20 10 380 290]`.
+Use Page B for trim clipping CropBox but retaining positive intersection, e.g. raw `[100 80 380 290]`.
+
+The exact public request rectangles must be derived/locked from `extractpdf_page_box_bounds(...MEDIA...)` and the common mapping, not guessed from a `(0,0)` assumption.
+
+- [ ] **Step 2: Add raw test helper**
+
+Link only this test executable privately to MuPDF. Verify:
+
+```text
+changed inherited MediaBox becomes local
+no-op inherited MediaBox remains inherited
+raw CropBox object/value remains unchanged
+Contents/Resources/Annots/root AcroForm/root Outlines remain semantically unchanged
+```
+
+Do not compare indirect object numbers as identity.
+
+- [ ] **Step 3: Add public page-frame assertions first**
+
+No-CropBox fallback page:
+
+```text
+source request uses source MediaBox public subrect
+output MediaBox/CropBox/visible origin == (0,0)
+output dimensions equal request width/height
+text/image/link/annotation/widget/destination geometry follows re-anchored page transform
+```
+
+Preserved-CropBox physical-only page:
+
+```text
+MediaBox changes
+visible page bounds unchanged
+CropBox public observation unchanged
+```
+
+Preserved-CropBox clipped page:
+
+```text
+MediaBox changes
+raw CropBox unchanged
+visible = intersection(new MediaBox, CropBox)
+visible public x0/y0 may be non-zero
+object geometry is not individually rewritten
+```
+
+Run now; expected changed trim RED remains `UNSUPPORTED`.
+
+- [ ] **Step 4: Implement private changed transform flow**
+
+Mirror CropBox isolation without sharing writer/orchestration:
+
+```text
+canonical source serialization
+fresh private context
+open memory stream
+pdf_disable_js
+security recheck
+allocate private plans/views
+rebuild complete trim plan in private graph
+resolve every target page before write
+verify private plan classification/semantics
+write only changed local /MediaBox arrays
+serialize private PDF
+cleanup all private state
+```
+
+Writer must be narrow:
+
+```c
+static void extractpdf_pdf_trim_put_mediabox(
+    fz_context *ctx,
+    pdf_document *document,
+    pdf_obj *page_obj,
+    fz_rect box)
+{
+    pdf_obj *array = NULL;
+    fz_var(array);
+    fz_try(ctx) {
+        array = pdf_new_array(ctx, document, 4);
+        pdf_array_push_real(ctx, array, box.x0);
+        pdf_array_push_real(ctx, array, box.y0);
+        pdf_array_push_real(ctx, array, box.x1);
+        pdf_array_push_real(ctx, array, box.y1);
+        pdf_dict_put(ctx, page_obj, PDF_NAME(MediaBox), array);
+    }
+    fz_always(ctx) { pdf_drop_obj(ctx, array); }
+    fz_catch(ctx) { fz_rethrow(ctx); }
+}
+```
+
+No other semantic dictionary key may be written.
+
+- [ ] **Step 5: Require static + ASan/UBSan 23/23**
+
+At this checkpoint unrotated/default-UserUnit fallback and preserved-CropBox cases must be GREEN.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pdf_trim.c tests/test_pdf_trim.c tests/test_pdf_trim_raw.c \
+  tests/test_pdf_trim_internal.h tests/fixtures/trim-preserved-crop.pdf tests/CMakeLists.txt
+git commit -m "feat: apply isolated MediaBox trims"
+```
+
+Review gate: only `/MediaBox` writer, no graft, no per-object mutation, no default-box materialization.
+
+---
+
+### Task 6: Add Rotate/UserUnit and opaque Bleed/Trim/Art preservation
+
+**Files:**
+- Create: `tests/test_pdf_trim_transforms.c`
+- Create: `tests/fixtures/trim-rotate-90.pdf`
+- Create: `tests/fixtures/trim-userunit.pdf`
+- Create: `tests/fixtures/trim-default-boxes.pdf`
+- Modify: `tests/test_pdf_trim_internal.h`
+- Modify: `tests/test_pdf_trim_raw.c`
+- Modify: `tests/CMakeLists.txt`
+- Production changes only if a real common-mapping defect appears: `src/pdf_page_box_common.c`, `src/pdf_trim_preflight.c`, or `src/pdf_trim.c`.
+
+**Interfaces:**
+- Reuses common `pdf_to_public`; no per-rotation formula API.
+
+- [ ] **Step 1: Add transformed fixtures and tests first**
+
+Rotate fixture: valid `/Rotate 90`, changed MediaBox trim.
+
+UserUnit fixture: valid page-local `/UserUnit 2`, changed MediaBox trim.
+
+For each:
+
+```text
+query current public MediaBox
+construct a strict inset in public space
+trim
+verify output raw MediaBox equals inverse-mapped request
+verify public MediaBox/visible behavior according to CropBox provenance
+```
+
+- [ ] **Step 2: Add opaque default-box preservation fixture**
+
+Use pages with:
+
+```text
+one page: BleedBox/TrimBox/ArtBox all absent
+one page: explicit BleedBox/TrimBox/ArtBox values, including values extending beyond future new MediaBox
+```
+
+Require after trim:
+
+```text
+absent keys remain absent
+explicit raw arrays remain semantically unchanged
+trim succeeds even if an effective production box becomes reduced/empty
+```
+
+Do not add trim-specific malformed-production-box rejection tests; spec explicitly excludes those keys from consumed-state validation.
+
+- [ ] **Step 3: Run test-first RED/characterization**
+
+If Task 5 already handles Rotate/UserUnit through common matrix correctly, these tests may PASS immediately. That is acceptable characterization, not a reason to edit production.
+
+- [ ] **Step 4: Make only minimal production correction if tests expose a spec defect**
+
+Allowed correction surface is restricted to the three trim/common mapping files above. Do not introduce rotation switch/case tables or write extra boxes.
+
+- [ ] **Step 5: Run full static + sanitizer suites**
+
+Expected 23/23 in both configurations.
+
+- [ ] **Step 6: Commit tests and any required minimal correction**
+
+```bash
+git add tests/test_pdf_trim_transforms.c tests/test_pdf_trim_raw.c \
+  tests/test_pdf_trim_internal.h tests/fixtures/trim-rotate-90.pdf \
+  tests/fixtures/trim-userunit.pdf tests/fixtures/trim-default-boxes.pdf tests/CMakeLists.txt
+git add src/pdf_page_box_common.c src/pdf_trim_preflight.c src/pdf_trim.c
+git commit -m "test: lock transformed MediaBox trim semantics"
+```
+
+If production files did not change, do not stage them.
+
+---
+
+### Task 7: Lock batch determinism, failure atomicity, and final public preservation
+
+**Files:**
+- Modify: `tests/test_pdf_trim.c`
+- Modify: `tests/test_pdf_trim_transforms.c`
+- Modify: `tests/test_pdf_trim_raw.c` only if an existing helper needs one additional observation.
+- Production changes only for a real contract defect: `src/pdf_trim.c`, `src/pdf_trim_preflight.c`.
+
+- [ ] **Step 1: Add all-no-op two-page determinism**
+
+Build two requests equal to each page's current public MediaBox.
+
+Require:
+
+```text
+OK
+no local MediaBox materialized merely because page was requested
+repeated outputs have same size and byte-identical data
+no assertion that canonical output equals original input bytes
+```
+
+- [ ] **Step 2: Add mixed no-op + changed batch**
+
+Require:
+
+```text
+no-op page remains structurally untouched
+changed page receives local MediaBox
+both output pages reopen correctly
+```
+
+- [ ] **Step 3: Add two-changed-page deterministic batch**
+
+Call identical changed batch twice on unchanged source:
+
+```c
+size_a == size_b
+memcmp(data_a, data_b, size_a) == 0
+```
+
+- [ ] **Step 4: Add failure-atomic ordering case**
+
+Batch:
+
+```text
+request 0 valid changed trim
+request 1 invalid/disjoint-with-preserved-CropBox trim
+```
+
+Require:
+
+```text
+EXTRACTPDF_ERROR_ARGUMENT
+output == NULL
+source page 0 unchanged
+source page 1 unchanged
+```
+
+- [ ] **Step 5: Add source-lifetime/public preservation checks**
+
+On a successful changed output:
+
+```text
+source still exposes original MediaBox/CropBox/text/link/annotation/form/outline observations
+close source
+reopen/use output successfully afterward
+objects outside new medium remain structurally enumerable where existing APIs enumerate by structure
+```
+
+- [ ] **Step 6: Run tests before production edits**
+
+Expected PASS if Tasks 4-6 fully implement the spec. Any failure is a contract defect; do not weaken tests unless they contradict the committed spec.
+
+- [ ] **Step 7: Make minimal correction only if required**
+
+No public ABI changes and no new transform framework.
+
+- [ ] **Step 8: Run full static + sanitizer 23/23 and commit**
+
+```bash
+git add tests/test_pdf_trim.c tests/test_pdf_trim_transforms.c tests/test_pdf_trim_raw.c
+git add src/pdf_trim.c src/pdf_trim_preflight.c
+git commit -m "test: lock MediaBox trim batch determinism"
+```
+
+If production files did not change, do not stage them.
+
+---
+
+### Task 8: Freeze exact head, run same-SHA cross-platform proof, review, and STOP
+
+**Files:**
+- No intended source/test changes.
+- PR/issue metadata/comments only.
+
+**Interfaces:**
+- Consumes: final feature head from Task 7.
+- Produces: frozen exact-SHA Linux + sanitizer + macOS + Windows proof and integration authorization gate.
+
+- [ ] **Step 1: Freeze exact candidate SHA**
+
+After this point any source/test/spec change invalidates proof and requires a fresh run. Do not amend/rebase/force-push the proven head.
+
+- [ ] **Step 2: Audit net feature scope against baseline**
+
+Expected paths are limited to:
+
+```text
+docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
+docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
+include/extractpdf/extractpdf.h
+CMakeLists.txt
+src/pdf_page_box_common.h
+src/pdf_page_box_common.c
+src/pdf_crop_internal.h
+src/pdf_crop_preflight.c
+src/pdf_crop.c              # only if common-helper adaptation required
+src/pdf_trim_internal.h
+src/pdf_trim_preflight.c
+src/pdf_trim.c
+tests/CMakeLists.txt
+tests/test_pdf_trim.c
+tests/test_pdf_trim_raw.c
+tests/test_pdf_trim_internal.h
+tests/test_pdf_trim_transforms.c
+tests/fixtures/trim-interactive.pdf
+tests/fixtures/trim-preserved-crop.pdf
+tests/fixtures/trim-rotate-90.pdf
+tests/fixtures/trim-userunit.pdf
+tests/fixtures/trim-default-boxes.pdf
+tests/fixtures/trim-malformed-box.pdf
+tests/fixtures/trim-malformed-rotate.pdf
+tests/fixtures/trim-malformed-userunit.pdf
+```
+
+Reused fixtures and workflow files must not be modified.
+
+- [ ] **Step 3: Perform forbidden-surface audit**
+
+Require:
+
+```text
+pdf_page_box_common.c:
+  no put/del/graft/serializer/runtime mutation
+
+pdf_trim_preflight.c:
+  no put/del/graft
+  no Bleed/Trim/Art strict parsing
+
+pdf_trim.c:
+  no page graft
+  no content rewrite
+  no annotation/form/widget mutation
+  no appearance regeneration
+  no JS/event execution
+  sole semantic dictionary write key = PDF_NAME(MediaBox)
+
+crop regression:
+  CropBox writer remains sole PDF_NAME(CropBox) write for crop path
+  extractpdf.pdf_crop remains GREEN
+
+public header:
+  no MuPDF types
+```
+
+- [ ] **Step 4: Require fresh exact-head Linux PR GREEN**
+
+Same candidate SHA:
+
+```text
+static configure/build/test -> 23/23
+ASan/UBSan configure/build/test -> 23/23
+```
+
+- [ ] **Step 5: Trigger existing `full-ci` label on the draft PR**
+
+Do not edit workflow YAML. Require new workflow head SHA equals frozen candidate.
+
+Require:
+
+```text
+Linux static 23/23
+Linux ASan/UBSan 23/23
+macOS 23/23
+Windows DLL configure/build/test 23/23
+```
+
+Windows log must explicitly show:
+
+```text
+extractpdf.dll
+extractpdf_test_pdf_trim.exe
+extractpdf.pdf_trim as test 23/23
+100% tests passed out of 23
+```
+
+- [ ] **Step 6: Final Critical/Important review**
+
+Review exact source/tests against all invariants:
+
+```text
+public trim inputs are current Fitz page-space MediaBox coordinates
+MediaBox shrink-only
+source immutable
+all requests preflight before writes
+full-document copy, not graft
+private context re-resolves every page
+no source MuPDF pointer crosses contexts
+only changed pages receive local MediaBox
+no-op inherited MediaBox remains inherited
+no-CropBox fallback re-anchors output page frame
+preserved CropBox stays raw-unchanged and may yield non-zero visible origin
+physical-only trim is not mistaken for no-op
+Rotate/UserUnit use common page transform, no manual rotation geometry
+Bleed/Trim/Art absent/present raw state remains untouched and is not trim-validated
+links/annotations/Widgets/AcroForm/outline/destinations structurally preserved
+objects outside medium remain structurally present
+encrypted/signed fail closed
+output reset on failure
+canonical deterministic outputs
+CropBox #22 regression remains GREEN
+new trim #23 adds coverage without weakening old tests
+```
+
+Fetch submitted reviews and inline threads; no unresolved Critical/Important blocker may remain.
+
+- [ ] **Step 7: Record checkpoint and STOP**
+
+Post frozen SHA, workflow IDs, 23/23 evidence, scope audit, CropBox regression result, and review conclusion to #51 and draft PR.
+
+Do **not** mark ready, merge, close #51, update #48/#2 as integrated, delete branch, or begin poster split without explicit integration authorization.
+
+---
+
+### Task 9: Integrate only after explicit authorization
+
+**Files:**
+- No intended feature-tree changes.
+- Git/PR/issue metadata only.
+
+- [ ] **Step 1: Re-read exact frozen head/base/reviews/CI**
+
+If feature head moved, repeat Task 8. If master moved, inspect the new base and do not silently rebase the proven feature.
+
+- [ ] **Step 2: Prefer normal expected-head PR merge**
+
+Use merge commit semantics with expected frozen head guard.
+
+If draft->ready connector GraphQL remains broken, the already-approved fallback pattern is allowed only after this explicit integration authorization:
+
+```text
+create exact two-parent merge commit
+  tree = frozen feature tree
+  parent 1 = current verified master
+  parent 2 = exact frozen feature SHA
+update master with force=false
+verify GitHub associates PR as merged
+```
+
+Never force-update master.
+
+- [ ] **Step 3: Require integrated-master push proof**
+
+On exact merge SHA require:
+
+```text
+Linux static 23/23
+Linux ASan/UBSan 23/23
+macOS 23/23
+Windows DLL 23/23
+```
+
+Windows must explicitly build `extractpdf.dll` and `extractpdf_test_pdf_trim.exe`.
+
+- [ ] **Step 4: Close and checkpoint only after integrated proof**
+
+Only then:
+
+```text
+close #51 as completed
+record PR/merge SHA/integrated workflow in #51
+add checkpoint comments to #48 and #2
+```
+
+Do not auto-start poster split.

--- a/docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
+++ b/docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
@@ -35,38 +35,38 @@
 
 ### New production files
 
-- `src/pdf_page_box_common.h` — strict reusable page-box view and security-independent raw/public mapping helpers only.
-- `src/pdf_page_box_common.c` — MediaBox/CropBox inheritance resolution, provenance, Rotate/UserUnit validation, effective-visible intersection, PDF/public mapping.
-- `src/pdf_trim_internal.h` — trim-only plan type and private function declarations.
-- `src/pdf_trim_preflight.c` — MediaBox-specific request validation, no-op classification, post-trim CropBox-intersection validation, private-plan consistency.
+- `src/pdf_page_box_common.h` — strict reusable page-box view and raw/public mapping declarations.
+- `src/pdf_page_box_common.c` — MediaBox/CropBox inheritance resolution, CropBox provenance, Rotate/UserUnit validation, effective-visible intersection, PDF/public mapping.
+- `src/pdf_trim_internal.h` — trim-only plan type and private declarations.
+- `src/pdf_trim_preflight.c` — MediaBox-specific request validation, no-op classification, post-trim CropBox-intersection validation.
 - `src/pdf_trim.c` — public orchestration, private full-document reopen, `/MediaBox` writer, deterministic publication.
 
 ### Existing production files modified
 
 - `include/extractpdf/extractpdf.h` — approved `extractpdf_page_trim` and `extractpdf_trim_pages()` ABI only.
-- `src/pdf_crop_internal.h` — remove page-box view ownership after common extraction; retain crop-only plan declarations.
-- `src/pdf_crop_preflight.c` — delegate strict page-box resolution to common helper without changing CropBox policy/results.
-- `src/pdf_crop.c` — no semantic change intended; only include/function-name adjustments if common helper naming requires them.
+- `src/pdf_crop_internal.h` — retain crop-only plan declarations; consume common page-box view.
+- `src/pdf_crop_preflight.c` — delegate strict page-box resolution to common helper without semantic changes.
+- `src/pdf_crop.c` — include/name adjustment only if required by common extraction; no semantic change intended.
 - `CMakeLists.txt` — add common and trim production sources.
 
 ### New tests/fixtures
 
-- `tests/test_pdf_trim.c` — public ABI, argument/security/no-op/batch/source-lifetime tests and main runner.
-- `tests/test_pdf_trim_raw.c` — raw local MediaBox/CropBox/default-box/preservation observations using MuPDF privately.
-- `tests/test_pdf_trim_internal.h` — test-only helper declarations.
-- `tests/test_pdf_trim_transforms.c` — Rotate/UserUnit + preserved-CropBox public coordinate cases.
+- `tests/test_pdf_trim.c` — ABI, argument/security/no-op/batch/source-lifetime tests and main runner.
+- `tests/test_pdf_trim_raw.c` — raw local MediaBox/CropBox/default-box/preservation checks.
+- `tests/test_pdf_trim_internal.h` — test-only declarations.
+- `tests/test_pdf_trim_transforms.c` — Rotate/UserUnit and preserved-CropBox coordinate cases.
 - `tests/fixtures/trim-interactive.pdf` — deterministic two-page no-CropBox interactive fixture.
-- `tests/fixtures/trim-preserved-crop.pdf` — explicit/inherited CropBox cases including physical-only and clipped-visible cases.
-- `tests/fixtures/trim-rotate-90.pdf` — Rotate 90 fixture.
-- `tests/fixtures/trim-userunit.pdf` — page-local UserUnit fixture.
-- `tests/fixtures/trim-default-boxes.pdf` — absent/present Bleed/Trim/Art raw preservation fixture.
-- `tests/fixtures/trim-malformed-box.pdf` — malformed consumed MediaBox/CropBox fixture.
-- `tests/fixtures/trim-malformed-rotate.pdf` — invalid inherited Rotate fixture.
-- `tests/fixtures/trim-malformed-userunit.pdf` — invalid page-local UserUnit fixture.
+- `tests/fixtures/trim-preserved-crop.pdf` — inherited CropBox physical-only and clipped-visible cases.
+- `tests/fixtures/trim-rotate-90.pdf`
+- `tests/fixtures/trim-userunit.pdf`
+- `tests/fixtures/trim-default-boxes.pdf`
+- `tests/fixtures/trim-malformed-box.pdf`
+- `tests/fixtures/trim-malformed-rotate.pdf`
+- `tests/fixtures/trim-malformed-userunit.pdf`
 
 ### Existing test file modified
 
-- `tests/CMakeLists.txt` — register exactly one new executable/CTest, link private MuPDF for raw helper, copy `extractpdf.dll` post-build on Windows as needed.
+- `tests/CMakeLists.txt` — register exactly one new executable/CTest; private MuPDF link for raw helper; Windows DLL post-build copy as required.
 
 ---
 
@@ -79,37 +79,40 @@
 - Do not modify: public header, `src/`, root `CMakeLists.txt`, workflow files.
 
 **Interfaces:**
-- Consumes: current 22-test integrated baseline.
+- Consumes: integrated 22-test baseline.
 - Produces: one failing `extractpdf_test_pdf_trim` compile target referencing the approved-but-absent ABI.
 
 - [ ] **Step 1: Create the deterministic two-page no-CropBox fixture**
 
-Construct `trim-interactive.pdf` as a small hand-authored deterministic PDF with:
+Construct `trim-interactive.pdf` with:
 
 ```text
 Page 1 raw MediaBox [0 0 400 300]
 Page 2 raw MediaBox [0 0 400 300]
-No local/inherited CropBox anywhere.
-No BleedBox/TrimBox/ArtBox unless a later dedicated fixture needs them.
+No local/inherited CropBox.
 
 Page 1:
-  text marker: TRIM-TEXT
+  text marker TRIM-TEXT
   one image XObject occurrence
-  URI link: https://example.com/trim
+  URI link https://example.com/trim
   internal /XYZ link targeting page 2
-  Square annotation, Contents=(TRIM-ANNOT)
-  Text Widget attached to AcroForm field trim.text with value TRIM-VALUE
+  Square annotation Contents=(TRIM-ANNOT)
+  Text Widget under a legal AcroForm hierarchy:
+      parent field /T (trim)
+      child Widget field /T (text)
+      public full field name = trim.text
+      value = TRIM-VALUE
 
 Page 2:
-  text marker: TRIM-TARGET
-  outline destination target
+  text marker TRIM-TARGET
+  outline internal destination
 ```
 
-Keep all object numbers stable inside the fixture but never make production behavior depend on them.
+Do **not** encode `/T (trim.text)` as one partial field name; the existing strict AcroForm parser rejects dotted partial names. Use Parent/Kids hierarchy to produce the public full name `trim.text`.
 
 - [ ] **Step 2: Write the initial compile-RED test**
 
-In `tests/test_pdf_trim.c`, include `extractpdf/extractpdf.h` and reference the absent approved ABI exactly:
+Reference the absent ABI exactly:
 
 ```c
 extractpdf_page_trim trim;
@@ -118,20 +121,13 @@ extractpdf_output *output = NULL;
 memset(&trim, 0, sizeof(trim));
 trim.struct_size = sizeof(trim);
 trim.page_index = 0;
-trim.bounds.x0 = 40.0f;
-trim.bounds.y0 = 30.0f;
-trim.bounds.x1 = 360.0f;
-trim.bounds.y1 = 270.0f;
+trim.bounds = (extractpdf_rect){40.0f, 30.0f, 360.0f, 270.0f};
 
 if (extractpdf_trim_pages(document, &trim, 1, &output) != EXTRACTPDF_OK)
     return fail("valid trim failed");
 ```
 
-The test must not contain fallback declarations that would let it compile before the public ABI exists.
-
 - [ ] **Step 3: Register exactly one new CTest**
-
-Append to `tests/CMakeLists.txt`:
 
 ```cmake
 add_executable(extractpdf_test_pdf_trim test_pdf_trim.c)
@@ -142,8 +138,6 @@ add_test(NAME extractpdf.pdf_trim COMMAND extractpdf_test_pdf_trim)
 set_tests_properties(extractpdf.pdf_trim PROPERTIES TIMEOUT 60)
 ```
 
-No existing CTest is renamed or removed.
-
 - [ ] **Step 4: Commit the strict RED surface**
 
 ```bash
@@ -151,40 +145,31 @@ git add tests/test_pdf_trim.c tests/fixtures/trim-interactive.pdf tests/CMakeLis
 git commit -m "test: lock MediaBox trim contract"
 ```
 
-- [ ] **Step 5: Create a canonical draft PR**
+- [ ] **Step 5: Create canonical draft PR**
 
-Create draft PR from `feat/mediabox-trim` to `master`:
-
-```text
-Title: feat: add immutable MediaBox physical trim transform
-Body: Tracks #51. Child of #48 / #2. Links committed spec. State that current checkpoint is strict compile RED and integration requires explicit authorization.
-```
+`feat/mediabox-trim` -> `master`, title `feat: add immutable MediaBox physical trim transform`, body tracks #51/#48/#2 and links the committed spec. State compile-RED checkpoint and explicit integration requirement.
 
 - [ ] **Step 6: Require attributable Linux compile RED**
 
-Expected latest PR workflow result:
+Expected:
 
 ```text
 existing 22 targets build
-new extractpdf_test_pdf_trim fails compilation only because:
-  extractpdf_page_trim is unknown and/or
-  extractpdf_trim_pages is undeclared
+only extractpdf_test_pdf_trim fails for missing extractpdf_page_trim / extractpdf_trim_pages
 ```
 
-Do not proceed if any old target fails or the new failure is fixture/CMake related.
+Stop if any old target fails or RED is caused by fixture/CMake defects.
 
 ---
 
-### Task 2: Add the public ABI shell and move RED from compile-time to runtime
+### Task 2: Add the public ABI shell and move RED to runtime
 
 **Files:**
 - Modify: `include/extractpdf/extractpdf.h`
 - Create: `src/pdf_trim.c`
 - Modify: `CMakeLists.txt`
-- Test: `tests/test_pdf_trim.c`
 
 **Interfaces:**
-- Produces public ABI:
 
 ```c
 typedef struct extractpdf_page_trim {
@@ -200,15 +185,8 @@ EXTRACTPDF_API extractpdf_status extractpdf_trim_pages(
     extractpdf_output **out_output);
 ```
 
-- [ ] **Step 1: Add the exact approved ABI**
-
-Place `extractpdf_page_trim` beside `extractpdf_page_crop`; place `extractpdf_trim_pages()` beside `extractpdf_crop_pages()`.
-
-No flags/options/general page-box enum are added.
-
-- [ ] **Step 2: Add the minimal shell**
-
-Create `src/pdf_trim.c`:
+- [ ] **Step 1: Add exact approved ABI** beside CropBox types/function.
+- [ ] **Step 2: Add minimal shell**:
 
 ```c
 #include "internal.h"
@@ -228,32 +206,20 @@ extractpdf_status extractpdf_trim_pages(
 }
 ```
 
-- [ ] **Step 3: Add only `src/pdf_trim.c` to root CMake**
-
-Do not add common helpers yet.
-
-- [ ] **Step 4: Run the latest PR workflow**
-
-Expected:
-
-```text
-all 23 executables compile
-CTest #1-#22 pass
-extractpdf.pdf_trim fails at runtime with "valid trim failed"
-```
-
-- [ ] **Step 5: Commit the ABI shell**
+- [ ] **Step 3: Add only `src/pdf_trim.c` to root CMake.**
+- [ ] **Step 4: Run PR workflow.** Expected 23 executables compile; old 22 CTests pass; only `extractpdf.pdf_trim` fails `valid trim failed`.
+- [ ] **Step 5: Commit**:
 
 ```bash
 git add include/extractpdf/extractpdf.h src/pdf_trim.c CMakeLists.txt
 git commit -m "feat: add MediaBox trim ABI shell"
 ```
 
-Review gate: public header exposes no MuPDF type and no API beyond the approved structure/function.
+Public ABI review gate: no MuPDF type, flags, generic box-rewrite API, or unrelated ABI.
 
 ---
 
-### Task 3: Extract the strict page-box common helper without changing CropBox behavior
+### Task 3: Extract strict page-box common helper without changing CropBox behavior
 
 **Files:**
 - Create: `src/pdf_page_box_common.h`
@@ -262,11 +228,8 @@ Review gate: public header exposes no MuPDF type and no API beyond the approved 
 - Modify: `src/pdf_crop_preflight.c`
 - Modify: `src/pdf_crop.c` only if include/name adjustment is required
 - Modify: `CMakeLists.txt`
-- Existing regression test: `extractpdf.pdf_crop`
 
 **Interfaces:**
-
-Create common view:
 
 ```c
 typedef struct extractpdf_pdf_page_box_view {
@@ -281,11 +244,7 @@ typedef struct extractpdf_pdf_page_box_view {
     int rotate_degrees;
     float user_unit;
 } extractpdf_pdf_page_box_view;
-```
 
-Create helper:
-
-```c
 extractpdf_status extractpdf_pdf_page_box_resolve(
     fz_context *ctx,
     pdf_document *document,
@@ -293,49 +252,10 @@ extractpdf_status extractpdf_pdf_page_box_resolve(
     extractpdf_pdf_page_box_view *out_view);
 ```
 
-- [ ] **Step 1: Characterize CropBox before extraction**
-
-Run only existing CropBox test on current Task-2 head:
-
-```bash
-ctest --test-dir build -R '^extractpdf\.pdf_crop$' --output-on-failure
-```
-
-Expected PASS. Record this as the before-extraction behavior.
-
-- [ ] **Step 2: Move only strict consumed-state logic into common helper**
-
-Move from crop preflight into `pdf_page_box_common.c`:
-
-```text
-page dictionary validation
-Parent traversal + cycle/depth protection
-nearest MediaBox lookup
-nearest CropBox lookup + explicit provenance
-strict four-finite-number parse
-normalized positive raw boxes
-visible intersection
-Rotate inherited validation
-page-local UserUnit validation
-pdf_to_public retrieval
-media_public derivation
-visible_public derivation
-```
-
-Do **not** move:
-
-```text
-crop request struct_size checks
-duplicate page checks
-crop shrink-only-to-visible policy
-crop changed/no-op classification
-crop security policy
-crop writer/orchestration
-```
-
-- [ ] **Step 3: Adapt CropBox plan builder to the common view**
-
-`extractpdf_pdf_crop_build_plan()` should consume `extractpdf_pdf_page_box_view` and preserve the exact integrated contract:
+- [ ] **Step 1: Characterize existing CropBox** with `ctest --test-dir build -R '^extractpdf\.pdf_crop$' --output-on-failure`; expect PASS before refactor.
+- [ ] **Step 2: Move only read-only consumed-state logic**: page dictionary; Parent cycle/depth; nearest MediaBox; nearest CropBox + presence provenance; strict four-number parsing; positive raw boxes; visible intersection; inherited Rotate; page-local UserUnit; `pdf_to_public`; `media_public`; `visible_public`.
+- [ ] **Step 3: Keep crop policy crop-specific**: struct_size, duplicate page, shrink-to-visible, changed/no-op, security, writer/orchestration.
+- [ ] **Step 4: Adapt crop plan mapping**:
 
 ```c
 public_to_pdf = fz_invert_matrix(view.pdf_to_public);
@@ -344,35 +264,9 @@ validate requested_pdf inside view.visible_pdf;
 changed = requested_public != view.visible_public;
 ```
 
-Keep `extractpdf_pdf_crop_plan` crop-specific.
-
-- [ ] **Step 4: Add common source to CMake and run CropBox regression**
-
-Expected:
-
-```text
-extractpdf.pdf_crop PASS
-all existing 22 baseline CTests PASS
-new trim test still runtime RED because shell returns UNSUPPORTED
-```
-
-Run both static and sanitizer suites before committing extraction.
-
-- [ ] **Step 5: Audit forbidden accidental behavior**
-
-`pdf_page_box_common.c` must contain no:
-
-```text
-pdf_dict_put
-pdf_dict_del
-pdf_graft_mapped_page
-serializer call
-JavaScript/form API
-```
-
-It is a read-only resolver only.
-
-- [ ] **Step 6: Commit the extraction**
+- [ ] **Step 5: Add common source to CMake and run static + sanitizer suites.** Expected baseline 22 pass; trim stays runtime RED.
+- [ ] **Step 6: Forbidden audit** common helper contains no `pdf_dict_put`, `pdf_dict_del`, graft, serializer, JS/form runtime.
+- [ ] **Step 7: Commit**:
 
 ```bash
 git add src/pdf_page_box_common.h src/pdf_page_box_common.c \
@@ -380,11 +274,11 @@ git add src/pdf_page_box_common.h src/pdf_page_box_common.c \
 git commit -m "refactor: share strict PDF page-box resolution"
 ```
 
-Reviewer gate: reject the task if CropBox behavior, statuses, no-op semantics, fixture expectations, or public ABI changed.
+Reject this task if any CropBox status, no-op, output semantics, tests, or public ABI changed.
 
 ---
 
-### Task 4: Lock strict MediaBox preflight, security, and no-op semantics
+### Task 4: Lock strict trim preflight, security, and all-no-op behavior
 
 **Files:**
 - Create: `src/pdf_trim_internal.h`
@@ -398,8 +292,6 @@ Reviewer gate: reject the task if CropBox behavior, statuses, no-op semantics, f
 
 **Interfaces:**
 
-Trim plan:
-
 ```c
 typedef struct extractpdf_pdf_trim_plan {
     int page_index;
@@ -407,11 +299,7 @@ typedef struct extractpdf_pdf_trim_plan {
     fz_rect requested_media_pdf;
     int changed;
 } extractpdf_pdf_trim_plan;
-```
 
-Preflight:
-
-```c
 extractpdf_status extractpdf_pdf_trim_build_plan(
     fz_context *ctx,
     pdf_document *document,
@@ -421,115 +309,26 @@ extractpdf_status extractpdf_pdf_trim_build_plan(
     int *out_any_changed);
 ```
 
-Security may initially call a shared-or-copied fail-closed helper, but do not refactor Phase 5 unrelated code.
-
-- [ ] **Step 1: Extend tests first with argument and malformed cases**
-
-Add helper requiring output reset:
-
-```c
-static int expect_trim_error(..., extractpdf_status expected)
-{
-    extractpdf_output *output = (extractpdf_output *)(uintptr_t)1;
-    extractpdf_status status = extractpdf_trim_pages(..., &output);
-    return status == expected && output == NULL;
-}
-```
-
-Lock at least:
-
-```text
-NULL document/trims/out_output
-trim_count == 0
-small struct_size
-out-of-range page
-negative page
-NaN/infinity
-zero/inverted rectangle
-duplicate page index
-request outside public MediaBox
-malformed MediaBox/CropBox -> FORMAT
-invalid inherited Rotate -> FORMAT
-invalid page-local UserUnit -> FORMAT
-non-PDF -> UNSUPPORTED
-encrypted -> UNSUPPORTED
-signed -> UNSUPPORTED
-```
-
-- [ ] **Step 2: Add an all-no-op test before implementation**
-
-Query public MediaBox via existing API and pass that exact rectangle as trim request.
-
-Require:
-
-```text
-OK
-output != NULL
-source remains unchanged
-repeated all-no-op calls produce byte-identical canonical bytes
-```
-
-Raw non-materialization is added in Task 5.
-
-- [ ] **Step 3: Run test to verify new RED**
-
-Expected first failure should be a missing validation/no-op behavior in the shell, not a compile error.
-
-- [ ] **Step 4: Implement trim-only plan building**
-
-For each request:
+- [ ] **Step 1: Add tests first** for null pointers, zero count, too-small struct, bad/duplicate index, NaN/inf, zero/inverted rect, request outside MediaBox, malformed consumed MediaBox/CropBox, invalid Rotate/UserUnit, non-PDF, encrypted, signed. Every failure initializes output to sentinel `(extractpdf_output *)(uintptr_t)1` and requires `output == NULL` afterward.
+- [ ] **Step 2: Add all-no-op test** by querying exact public MediaBox and submitting it unchanged. Require OK, source unchanged, repeated canonical outputs byte-identical.
+- [ ] **Step 3: Run test-first RED**; failure should now be missing validation/no-op behavior, not compile.
+- [ ] **Step 4: Implement trim plan**:
 
 ```c
 view = extractpdf_pdf_page_box_resolve(...);
 validate request inside view.media_public;
-public_to_pdf = fz_invert_matrix(view.pdf_to_public);
-requested_media_pdf = normalize(transform(request, public_to_pdf));
+requested_media_pdf = normalize(transform(request, inverse(view.pdf_to_public)));
 validate requested_media_pdf inside view.media_pdf;
 changed = request != view.media_public;
-
-if (changed && view.has_explicit_crop) {
-    visible_after = intersect(requested_media_pdf, view.crop_pdf);
-    if (empty(visible_after))
-        return EXTRACTPDF_ERROR_ARGUMENT;
-}
+if (changed && view.has_explicit_crop)
+    require positive intersection(requested_media_pdf, view.crop_pdf);
 ```
 
-Do not parse BleedBox/TrimBox/ArtBox.
+Do not inspect BleedBox/TrimBox/ArtBox.
 
-- [ ] **Step 5: Implement source security + all-no-op path**
-
-`extractpdf_trim_pages()` must:
-
-```text
-reset out_output
-reject non-PDF/encrypted/signed
-allocate plans safely
-build complete source plan
-if all no-op:
-  serialize source once using existing deterministic serializer
-else:
-  return UNSUPPORTED for now
-```
-
-Changed trim remains RED until Task 5.
-
-- [ ] **Step 6: Run static and sanitizer suites**
-
-Expected:
-
-```text
-all validation/no-op assertions pass
-all baseline 22 CTests pass
-extractpdf.pdf_trim fails only at first valid changed trim
-```
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add src/pdf_trim_internal.h src/pdf_trim_preflight.c src/pdf_trim.c \
-  tests/test_pdf_trim.c tests/CMakeLists.txt tests/fixtures/trim-malformed-*.pdf
-git commit -m "feat: preflight immutable MediaBox trims"
-```
+- [ ] **Step 5: Implement fail-closed security and all-no-op orchestration**. Changed batch still returns `UNSUPPORTED`; all-no-op serializes source once with existing deterministic serializer.
+- [ ] **Step 6: Run static + sanitizer suites**. Expected all validation/no-op assertions pass, baseline 22 pass, trim test fails only at first changed request.
+- [ ] **Step 7: Commit** `feat: preflight immutable MediaBox trims`.
 
 ---
 
@@ -543,9 +342,7 @@ git commit -m "feat: preflight immutable MediaBox trims"
 - Modify: `tests/test_pdf_trim.c`
 - Modify: `tests/CMakeLists.txt`
 
-**Interfaces:**
-- `extractpdf_trim_pages()` becomes functional for unrotated/default-UserUnit pages.
-- Raw helper API:
+**Test-only interfaces:**
 
 ```c
 int trim_raw_expect_local_mediabox(
@@ -562,132 +359,38 @@ int trim_raw_expect_preserved_graph(
     const unsigned char *after, size_t after_size);
 ```
 
-- [ ] **Step 1: Add preserved-CropBox fixture**
-
-Create deterministic pages covering:
-
-```text
-Page A:
-  inherited MediaBox [0 0 400 300]
-  inherited CropBox [50 40 350 260]
-  no local MediaBox/CropBox
-
-Page B:
-  inherited MediaBox [0 0 400 300]
-  inherited CropBox [50 40 350 260]
-```
-
-Use Page A for physical-only trim that still contains CropBox, e.g. public MediaBox request corresponding to raw `[20 10 380 290]`.
-Use Page B for trim clipping CropBox but retaining positive intersection, e.g. raw `[100 80 380 290]`.
-
-The exact public request rectangles must be derived/locked from `extractpdf_page_box_bounds(...MEDIA...)` and the common mapping, not guessed from a `(0,0)` assumption.
-
-- [ ] **Step 2: Add raw test helper**
-
-Link only this test executable privately to MuPDF. Verify:
+- [ ] **Step 1: Add inherited-CropBox fixture** with MediaBox `[0 0 400 300]`, CropBox `[50 40 350 260]`, child pages without local boxes. One page is trimmed physically while still containing all CropBox; another clips CropBox but leaves positive intersection.
+- [ ] **Step 2: Derive public trim requests from actual public MediaBox observations/mapping**, never assume its public origin is `(0,0)` when CropBox exists.
+- [ ] **Step 3: Add raw helper** and privately link MuPDF only to trim test. Prove changed inherited MediaBox becomes local, no-op inherited MediaBox remains inherited, CropBox raw object/value unchanged, and Contents/Resources/Annots/root AcroForm/root Outlines are semantically preserved without object-number identity assumptions.
+- [ ] **Step 4: Add public assertions before production**:
 
 ```text
-changed inherited MediaBox becomes local
-no-op inherited MediaBox remains inherited
-raw CropBox object/value remains unchanged
-Contents/Resources/Annots/root AcroForm/root Outlines remain semantically unchanged
+no CropBox fallback:
+  output MediaBox/CropBox/visible origin -> (0,0)
+  dimensions == requested physical dimensions
+  existing geometry follows re-anchored transform
+
+preserved CropBox physical-only:
+  MediaBox changes
+  visible/CropBox observation unchanged
+
+preserved CropBox clipped:
+  raw CropBox unchanged
+  visible == intersection(new MediaBox, CropBox)
+  visible public x0/y0 may be non-zero
+  no per-object rewrite
 ```
 
-Do not compare indirect object numbers as identity.
+Expected still RED on changed trim.
 
-- [ ] **Step 3: Add public page-frame assertions first**
-
-No-CropBox fallback page:
-
-```text
-source request uses source MediaBox public subrect
-output MediaBox/CropBox/visible origin == (0,0)
-output dimensions equal request width/height
-text/image/link/annotation/widget/destination geometry follows re-anchored page transform
-```
-
-Preserved-CropBox physical-only page:
-
-```text
-MediaBox changes
-visible page bounds unchanged
-CropBox public observation unchanged
-```
-
-Preserved-CropBox clipped page:
-
-```text
-MediaBox changes
-raw CropBox unchanged
-visible = intersection(new MediaBox, CropBox)
-visible public x0/y0 may be non-zero
-object geometry is not individually rewritten
-```
-
-Run now; expected changed trim RED remains `UNSUPPORTED`.
-
-- [ ] **Step 4: Implement private changed transform flow**
-
-Mirror CropBox isolation without sharing writer/orchestration:
-
-```text
-canonical source serialization
-fresh private context
-open memory stream
-pdf_disable_js
-security recheck
-allocate private plans/views
-rebuild complete trim plan in private graph
-resolve every target page before write
-verify private plan classification/semantics
-write only changed local /MediaBox arrays
-serialize private PDF
-cleanup all private state
-```
-
-Writer must be narrow:
-
-```c
-static void extractpdf_pdf_trim_put_mediabox(
-    fz_context *ctx,
-    pdf_document *document,
-    pdf_obj *page_obj,
-    fz_rect box)
-{
-    pdf_obj *array = NULL;
-    fz_var(array);
-    fz_try(ctx) {
-        array = pdf_new_array(ctx, document, 4);
-        pdf_array_push_real(ctx, array, box.x0);
-        pdf_array_push_real(ctx, array, box.y0);
-        pdf_array_push_real(ctx, array, box.x1);
-        pdf_array_push_real(ctx, array, box.y1);
-        pdf_dict_put(ctx, page_obj, PDF_NAME(MediaBox), array);
-    }
-    fz_always(ctx) { pdf_drop_obj(ctx, array); }
-    fz_catch(ctx) { fz_rethrow(ctx); }
-}
-```
-
-No other semantic dictionary key may be written.
-
-- [ ] **Step 5: Require static + ASan/UBSan 23/23**
-
-At this checkpoint unrotated/default-UserUnit fallback and preserved-CropBox cases must be GREEN.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/pdf_trim.c tests/test_pdf_trim.c tests/test_pdf_trim_raw.c \
-  tests/test_pdf_trim_internal.h tests/fixtures/trim-preserved-crop.pdf tests/CMakeLists.txt
-git commit -m "feat: apply isolated MediaBox trims"
-```
-
-Review gate: only `/MediaBox` writer, no graft, no per-object mutation, no default-box materialization.
+- [ ] **Step 5: Implement private changed flow**: canonical source serialize -> fresh context -> open bytes -> disable JS -> security recheck -> rebuild all private plans -> resolve all target pages -> verify private semantics before first write -> local `/MediaBox` writes only -> deterministic serialize -> cleanup.
+- [ ] **Step 6: Narrow writer** uses `pdf_new_array(ctx, private_document, 4)` and exactly one `pdf_dict_put(..., PDF_NAME(MediaBox), array)` semantic key. No journal/graft/runtime mutation.
+- [ ] **Step 7: Require static + ASan/UBSan 23/23** at this checkpoint.
+- [ ] **Step 8: Commit** `feat: apply isolated MediaBox trims`.
 
 ---
 
-### Task 6: Add Rotate/UserUnit and opaque Bleed/Trim/Art preservation
+### Task 6: Lock Rotate/UserUnit and opaque Bleed/Trim/Art preservation
 
 **Files:**
 - Create: `tests/test_pdf_trim_transforms.c`
@@ -697,303 +400,67 @@ Review gate: only `/MediaBox` writer, no graft, no per-object mutation, no defau
 - Modify: `tests/test_pdf_trim_internal.h`
 - Modify: `tests/test_pdf_trim_raw.c`
 - Modify: `tests/CMakeLists.txt`
-- Production changes only if a real common-mapping defect appears: `src/pdf_page_box_common.c`, `src/pdf_trim_preflight.c`, or `src/pdf_trim.c`.
+- Production correction only if a real defect appears: `src/pdf_page_box_common.c`, `src/pdf_trim_preflight.c`, `src/pdf_trim.c`.
 
-**Interfaces:**
-- Reuses common `pdf_to_public`; no per-rotation formula API.
-
-- [ ] **Step 1: Add transformed fixtures and tests first**
-
-Rotate fixture: valid `/Rotate 90`, changed MediaBox trim.
-
-UserUnit fixture: valid page-local `/UserUnit 2`, changed MediaBox trim.
-
-For each:
+- [ ] **Step 1: Add Rotate 90 test first**. Query public MediaBox, construct a valid public inset, trim, verify raw MediaBox equals inverse-mapped request and public behavior follows CropBox provenance.
+- [ ] **Step 2: Add page-local UserUnit 2 test** with same methodology.
+- [ ] **Step 3: Add default-box fixture**:
 
 ```text
-query current public MediaBox
-construct a strict inset in public space
-trim
-verify output raw MediaBox equals inverse-mapped request
-verify public MediaBox/visible behavior according to CropBox provenance
+page A: BleedBox/TrimBox/ArtBox absent
+page B: all explicit, with at least one raw box extending beyond future new MediaBox
 ```
 
-- [ ] **Step 2: Add opaque default-box preservation fixture**
+Require absent keys remain absent; explicit raw arrays unchanged; trim succeeds even when a production box's effective intersection becomes reduced or empty.
 
-Use pages with:
-
-```text
-one page: BleedBox/TrimBox/ArtBox all absent
-one page: explicit BleedBox/TrimBox/ArtBox values, including values extending beyond future new MediaBox
-```
-
-Require after trim:
-
-```text
-absent keys remain absent
-explicit raw arrays remain semantically unchanged
-trim succeeds even if an effective production box becomes reduced/empty
-```
-
-Do not add trim-specific malformed-production-box rejection tests; spec explicitly excludes those keys from consumed-state validation.
-
-- [ ] **Step 3: Run test-first RED/characterization**
-
-If Task 5 already handles Rotate/UserUnit through common matrix correctly, these tests may PASS immediately. That is acceptable characterization, not a reason to edit production.
-
-- [ ] **Step 4: Make only minimal production correction if tests expose a spec defect**
-
-Allowed correction surface is restricted to the three trim/common mapping files above. Do not introduce rotation switch/case tables or write extra boxes.
-
-- [ ] **Step 5: Run full static + sanitizer suites**
-
-Expected 23/23 in both configurations.
-
-- [ ] **Step 6: Commit tests and any required minimal correction**
-
-```bash
-git add tests/test_pdf_trim_transforms.c tests/test_pdf_trim_raw.c \
-  tests/test_pdf_trim_internal.h tests/fixtures/trim-rotate-90.pdf \
-  tests/fixtures/trim-userunit.pdf tests/fixtures/trim-default-boxes.pdf tests/CMakeLists.txt
-git add src/pdf_page_box_common.c src/pdf_trim_preflight.c src/pdf_trim.c
-git commit -m "test: lock transformed MediaBox trim semantics"
-```
-
-If production files did not change, do not stage them.
+- [ ] **Step 4: Run characterization**. If mapping already passes, do not edit production. If not, fix only common/trim mapping; never add rotation switch tables or extra box writes.
+- [ ] **Step 5: Run full static + sanitizer 23/23.**
+- [ ] **Step 6: Commit** `test: lock transformed MediaBox trim semantics`; stage production only if it actually changed.
 
 ---
 
-### Task 7: Lock batch determinism, failure atomicity, and final public preservation
+### Task 7: Lock batch determinism, failure atomicity, and lifetime preservation
 
 **Files:**
 - Modify: `tests/test_pdf_trim.c`
 - Modify: `tests/test_pdf_trim_transforms.c`
-- Modify: `tests/test_pdf_trim_raw.c` only if an existing helper needs one additional observation.
-- Production changes only for a real contract defect: `src/pdf_trim.c`, `src/pdf_trim_preflight.c`.
+- Modify: `tests/test_pdf_trim_raw.c` only if needed for one extra observation.
+- Production correction only for real contract defect: `src/pdf_trim.c`, `src/pdf_trim_preflight.c`.
 
-- [ ] **Step 1: Add all-no-op two-page determinism**
-
-Build two requests equal to each page's current public MediaBox.
-
-Require:
-
-```text
-OK
-no local MediaBox materialized merely because page was requested
-repeated outputs have same size and byte-identical data
-no assertion that canonical output equals original input bytes
-```
-
-- [ ] **Step 2: Add mixed no-op + changed batch**
-
-Require:
-
-```text
-no-op page remains structurally untouched
-changed page receives local MediaBox
-both output pages reopen correctly
-```
-
-- [ ] **Step 3: Add two-changed-page deterministic batch**
-
-Call identical changed batch twice on unchanged source:
-
-```c
-size_a == size_b
-memcmp(data_a, data_b, size_a) == 0
-```
-
-- [ ] **Step 4: Add failure-atomic ordering case**
-
-Batch:
-
-```text
-request 0 valid changed trim
-request 1 invalid/disjoint-with-preserved-CropBox trim
-```
-
-Require:
-
-```text
-EXTRACTPDF_ERROR_ARGUMENT
-output == NULL
-source page 0 unchanged
-source page 1 unchanged
-```
-
-- [ ] **Step 5: Add source-lifetime/public preservation checks**
-
-On a successful changed output:
-
-```text
-source still exposes original MediaBox/CropBox/text/link/annotation/form/outline observations
-close source
-reopen/use output successfully afterward
-objects outside new medium remain structurally enumerable where existing APIs enumerate by structure
-```
-
-- [ ] **Step 6: Run tests before production edits**
-
-Expected PASS if Tasks 4-6 fully implement the spec. Any failure is a contract defect; do not weaken tests unless they contradict the committed spec.
-
-- [ ] **Step 7: Make minimal correction only if required**
-
-No public ABI changes and no new transform framework.
-
-- [ ] **Step 8: Run full static + sanitizer 23/23 and commit**
-
-```bash
-git add tests/test_pdf_trim.c tests/test_pdf_trim_transforms.c tests/test_pdf_trim_raw.c
-git add src/pdf_trim.c src/pdf_trim_preflight.c
-git commit -m "test: lock MediaBox trim batch determinism"
-```
-
-If production files did not change, do not stage them.
+- [ ] **Step 1: Two-page all-no-op batch**: both current public MediaBoxes; require no local materialization and repeated canonical outputs byte-identical; do not compare to original file bytes.
+- [ ] **Step 2: Mixed no-op + changed**: no-op page structurally untouched, changed page local MediaBox.
+- [ ] **Step 3: Two changed pages**: identical batch twice -> same size + `memcmp == 0`.
+- [ ] **Step 4: Failure atomicity**: request 0 valid changed; request 1 invalid because it leaves empty preserved-CropBox intersection. Require `ARGUMENT`, output NULL, both source pages unchanged.
+- [ ] **Step 5: Source/output lifetime**: successful transform leaves source public observations unchanged; close source; output remains reopenable/fully usable; structurally enumerated objects outside new medium remain present.
+- [ ] **Step 6: Run tests before production edits**. Expected PASS if implementation already matches spec; failures are real contract defects unless test contradicts committed spec.
+- [ ] **Step 7: Minimal correction only if required**, no public ABI/general framework.
+- [ ] **Step 8: Run static + sanitizer 23/23 and commit** `test: lock MediaBox trim batch determinism`.
 
 ---
 
-### Task 8: Freeze exact head, run same-SHA cross-platform proof, review, and STOP
+### Task 8: Freeze exact head, same-SHA cross-platform proof, review, and STOP
 
 **Files:**
 - No intended source/test changes.
 - PR/issue metadata/comments only.
 
-**Interfaces:**
-- Consumes: final feature head from Task 7.
-- Produces: frozen exact-SHA Linux + sanitizer + macOS + Windows proof and integration authorization gate.
-
-- [ ] **Step 1: Freeze exact candidate SHA**
-
-After this point any source/test/spec change invalidates proof and requires a fresh run. Do not amend/rebase/force-push the proven head.
-
-- [ ] **Step 2: Audit net feature scope against baseline**
-
-Expected paths are limited to:
+- [ ] **Step 1: Freeze exact candidate SHA**. Any file change invalidates proof; no amend/rebase/force-push.
+- [ ] **Step 2: Audit net paths**. Expected only spec/plan, trim/common production, crop adaptation, trim tests/fixtures, CMake/header. Reused fixtures and workflow YAML untouched.
+- [ ] **Step 3: Forbidden audit**:
 
 ```text
-docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
-docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md
-include/extractpdf/extractpdf.h
-CMakeLists.txt
-src/pdf_page_box_common.h
-src/pdf_page_box_common.c
-src/pdf_crop_internal.h
-src/pdf_crop_preflight.c
-src/pdf_crop.c              # only if common-helper adaptation required
-src/pdf_trim_internal.h
-src/pdf_trim_preflight.c
-src/pdf_trim.c
-tests/CMakeLists.txt
-tests/test_pdf_trim.c
-tests/test_pdf_trim_raw.c
-tests/test_pdf_trim_internal.h
-tests/test_pdf_trim_transforms.c
-tests/fixtures/trim-interactive.pdf
-tests/fixtures/trim-preserved-crop.pdf
-tests/fixtures/trim-rotate-90.pdf
-tests/fixtures/trim-userunit.pdf
-tests/fixtures/trim-default-boxes.pdf
-tests/fixtures/trim-malformed-box.pdf
-tests/fixtures/trim-malformed-rotate.pdf
-tests/fixtures/trim-malformed-userunit.pdf
+pdf_page_box_common.c: no put/del/graft/serializer/runtime mutation
+pdf_trim_preflight.c: no writes/graft; no Bleed/Trim/Art parsing
+pdf_trim.c: sole semantic key write PDF_NAME(MediaBox); no graft/content/annot/form/widget/appearance/JS/event mutation
+crop path: CropBox regression unchanged and sole crop write remains PDF_NAME(CropBox)
+public header: no MuPDF type
 ```
 
-Reused fixtures and workflow files must not be modified.
-
-- [ ] **Step 3: Perform forbidden-surface audit**
-
-Require:
-
-```text
-pdf_page_box_common.c:
-  no put/del/graft/serializer/runtime mutation
-
-pdf_trim_preflight.c:
-  no put/del/graft
-  no Bleed/Trim/Art strict parsing
-
-pdf_trim.c:
-  no page graft
-  no content rewrite
-  no annotation/form/widget mutation
-  no appearance regeneration
-  no JS/event execution
-  sole semantic dictionary write key = PDF_NAME(MediaBox)
-
-crop regression:
-  CropBox writer remains sole PDF_NAME(CropBox) write for crop path
-  extractpdf.pdf_crop remains GREEN
-
-public header:
-  no MuPDF types
-```
-
-- [ ] **Step 4: Require fresh exact-head Linux PR GREEN**
-
-Same candidate SHA:
-
-```text
-static configure/build/test -> 23/23
-ASan/UBSan configure/build/test -> 23/23
-```
-
-- [ ] **Step 5: Trigger existing `full-ci` label on the draft PR**
-
-Do not edit workflow YAML. Require new workflow head SHA equals frozen candidate.
-
-Require:
-
-```text
-Linux static 23/23
-Linux ASan/UBSan 23/23
-macOS 23/23
-Windows DLL configure/build/test 23/23
-```
-
-Windows log must explicitly show:
-
-```text
-extractpdf.dll
-extractpdf_test_pdf_trim.exe
-extractpdf.pdf_trim as test 23/23
-100% tests passed out of 23
-```
-
-- [ ] **Step 6: Final Critical/Important review**
-
-Review exact source/tests against all invariants:
-
-```text
-public trim inputs are current Fitz page-space MediaBox coordinates
-MediaBox shrink-only
-source immutable
-all requests preflight before writes
-full-document copy, not graft
-private context re-resolves every page
-no source MuPDF pointer crosses contexts
-only changed pages receive local MediaBox
-no-op inherited MediaBox remains inherited
-no-CropBox fallback re-anchors output page frame
-preserved CropBox stays raw-unchanged and may yield non-zero visible origin
-physical-only trim is not mistaken for no-op
-Rotate/UserUnit use common page transform, no manual rotation geometry
-Bleed/Trim/Art absent/present raw state remains untouched and is not trim-validated
-links/annotations/Widgets/AcroForm/outline/destinations structurally preserved
-objects outside medium remain structurally present
-encrypted/signed fail closed
-output reset on failure
-canonical deterministic outputs
-CropBox #22 regression remains GREEN
-new trim #23 adds coverage without weakening old tests
-```
-
-Fetch submitted reviews and inline threads; no unresolved Critical/Important blocker may remain.
-
-- [ ] **Step 7: Record checkpoint and STOP**
-
-Post frozen SHA, workflow IDs, 23/23 evidence, scope audit, CropBox regression result, and review conclusion to #51 and draft PR.
-
-Do **not** mark ready, merge, close #51, update #48/#2 as integrated, delete branch, or begin poster split without explicit integration authorization.
+- [ ] **Step 4: Fresh exact-head Linux PR proof**: static 23/23 + ASan/UBSan 23/23.
+- [ ] **Step 5: Add existing `full-ci` label to draft PR only**; workflow YAML unchanged. Require same frozen head SHA and Linux static/sanitizer 23/23, macOS 23/23, Windows DLL 23/23. Windows logs must show `extractpdf.dll`, `extractpdf_test_pdf_trim.exe`, `extractpdf.pdf_trim` as test 23/23, and 100% of 23 tests.
+- [ ] **Step 6: Final Critical/Important review** against: current-Fitz MediaBox inputs; shrink-only; source immutable; all preflight before writes; full-document isolation; private re-resolution; no source MuPDF pointer crossing; no-op inheritance preservation; fallback re-anchor; preserved-CropBox non-zero visible origin; physical-only trim != no-op; Rotate/UserUnit via common matrix; opaque Bleed/Trim/Art; structural preservation; fail-closed security; output reset; deterministic output; CropBox #22 regression; new #23 coverage.
+- [ ] **Step 7: Fetch reviews/threads**; require no unresolved Critical/Important blocker.
+- [ ] **Step 8: Post checkpoint to #51 + draft PR and STOP**. Do not mark ready, merge, close #51, checkpoint #48/#2 as integrated, delete branch, or start poster split without explicit integration authorization.
 
 ---
 
@@ -1001,50 +468,22 @@ Do **not** mark ready, merge, close #51, update #48/#2 as integrated, delete bra
 
 **Files:**
 - No intended feature-tree changes.
-- Git/PR/issue metadata only.
 
-- [ ] **Step 1: Re-read exact frozen head/base/reviews/CI**
-
-If feature head moved, repeat Task 8. If master moved, inspect the new base and do not silently rebase the proven feature.
-
-- [ ] **Step 2: Prefer normal expected-head PR merge**
-
-Use merge commit semantics with expected frozen head guard.
-
-If draft->ready connector GraphQL remains broken, the already-approved fallback pattern is allowed only after this explicit integration authorization:
+- [ ] **Step 1: Re-read frozen head, current master, reviews, and exact-head CI**. If feature moved, repeat Task 8; if master moved, inspect rather than silently rebasing.
+- [ ] **Step 2: Prefer normal expected-head merge commit**.
+- [ ] **Step 3: If draft->ready connector GraphQL is still broken**, use only the already-approved fallback after explicit integration authorization:
 
 ```text
-create exact two-parent merge commit
+create two-parent merge commit
   tree = frozen feature tree
-  parent 1 = current verified master
-  parent 2 = exact frozen feature SHA
-update master with force=false
-verify GitHub associates PR as merged
+  parent1 = current verified master
+  parent2 = frozen feature SHA
+update master force=false
+verify PR is associated/merged
 ```
 
 Never force-update master.
 
-- [ ] **Step 3: Require integrated-master push proof**
-
-On exact merge SHA require:
-
-```text
-Linux static 23/23
-Linux ASan/UBSan 23/23
-macOS 23/23
-Windows DLL 23/23
-```
-
-Windows must explicitly build `extractpdf.dll` and `extractpdf_test_pdf_trim.exe`.
-
-- [ ] **Step 4: Close and checkpoint only after integrated proof**
-
-Only then:
-
-```text
-close #51 as completed
-record PR/merge SHA/integrated workflow in #51
-add checkpoint comments to #48 and #2
-```
-
-Do not auto-start poster split.
+- [ ] **Step 4: Require integrated-master push proof on exact merge SHA**: Linux static 23/23 + ASan/UBSan 23/23 + macOS 23/23 + Windows DLL 23/23, including `extractpdf_test_pdf_trim.exe`.
+- [ ] **Step 5: Only after proof** close #51 as completed and checkpoint #48/#2.
+- [ ] **Step 6: Do not auto-start poster split.**

--- a/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
+++ b/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
@@ -1,0 +1,777 @@
+# ExtractPDF Immutable MediaBox Physical Trim V1 Design
+
+Issue: #51  
+Parent roadmap: #48 / #2  
+Baseline master: `3fc48b5fb0f7a07926f7942fc4a4a3fb5e93a753`  
+Baseline content tree: `594499cfea3071f210b5b8781d73e942ba94a94d`  
+Depends on: integrated CropBox V1 (#49 / PR #50) and its page-transform direction correction
+
+## 1. Purpose
+
+MediaBox Physical Trim V1 completes the first Phase 6 page-box foundation before poster split.
+
+CropBox V1 changes the visible clipping region. MediaBox V1 changes the **physical page medium** by writing page-local `/MediaBox` values while deliberately preserving the rest of the page/document graph.
+
+The distinction is normative:
+
+```text
+CropBox transform
+    changes visible clipping intent
+
+MediaBox trim
+    changes physical medium extent
+```
+
+MediaBox V1 is not a synonym for CropBox V1 and does not automatically rewrite CropBox, BleedBox, TrimBox, or ArtBox.
+
+The reusable Phase 6 invariant remains:
+
+> Geometry-changing transforms alter the relevant page-box primitive and let the resulting PDF page transform determine public observations. They do not rewrite every content/interactive object unless a later API explicitly promises that behavior.
+
+Poster split must build on these two established page-box semantics rather than inventing a third coordinate model.
+
+## 2. Public API
+
+Add one request structure and one immutable transform primitive:
+
+```c
+typedef struct extractpdf_page_trim {
+    size_t struct_size;
+    int page_index;
+    extractpdf_rect bounds;
+} extractpdf_page_trim;
+
+EXTRACTPDF_API extractpdf_status extractpdf_trim_pages(
+    extractpdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_output **out_output);
+```
+
+### 2.1 Ownership
+
+- `document` remains immutable.
+- `trims` is caller-owned and read-only for the duration of the call.
+- success returns a new independent `extractpdf_output`.
+- the output owns copied serialized bytes and survives source document close.
+- every failure leaves `*out_output == NULL`.
+
+### 2.2 `struct_size`
+
+Every request element must have:
+
+```c
+struct_size >= offsetof(extractpdf_page_trim, bounds)
+             + sizeof(extractpdf_rect)
+```
+
+Smaller values return `EXTRACTPDF_ERROR_ARGUMENT`. Larger values are accepted for ABI-forward compatibility.
+
+## 3. Source coordinate contract
+
+`extractpdf_page_trim.bounds` is expressed in the **current source page's ExtractPDF/Fitz page space**.
+
+The direct public reference surface is:
+
+```c
+extractpdf_page_box_bounds(
+    page,
+    EXTRACTPDF_PAGE_BOX_MEDIA,
+    &media_bounds);
+```
+
+A caller may use any finite positive-area subrectangle of that current public MediaBox rectangle.
+
+The request is not expressed in raw PDF user space.
+
+### 3.1 Public MediaBox is not necessarily the visible page rectangle
+
+When an effective CropBox exists, MuPDF's page frame is anchored by that CropBox semantics. Therefore the public MediaBox rectangle can:
+
+- extend beyond the current visible page rectangle;
+- have negative coordinates;
+- have a non-zero origin;
+- remain larger than the visible page while still being a valid trim input domain.
+
+This is intentional. MediaBox trim is allowed to operate on physical page area outside the current CropBox.
+
+### 3.2 Strict source box model
+
+For every requested page, strict preflight resolves:
+
+```text
+media_pdf = normalized(nearest local/inherited MediaBox)
+
+if a local/inherited CropBox exists:
+    has_explicit_crop = true
+    crop_pdf = normalized(nearest local/inherited CropBox)
+else:
+    has_explicit_crop = false
+    crop_pdf = media_pdf       // source default only
+
+visible_pdf = intersection(media_pdf, crop_pdf)
+```
+
+`visible_pdf` must have positive width and height for the source page.
+
+A raw CropBox extending beyond MediaBox is accepted; only its effective intersection is used for source visible-page validity.
+
+### 3.3 PDF/public matrix direction
+
+This design inherits the already-integrated CropBox matrix correction as a project invariant:
+
+```text
+PDF user space --pdf_to_public--> ExtractPDF/Fitz page space
+ExtractPDF/Fitz page space --inverse(pdf_to_public)--> PDF user space
+```
+
+The matrix returned by MuPDF's page transform path must be treated accordingly inside ExtractPDF, regardless of contradictory prose comments in external headers/source.
+
+Strict public rectangles are derived as:
+
+```text
+media_public   = normalize(transform(media_pdf,   pdf_to_public))
+visible_public = normalize(transform(visible_pdf, pdf_to_public))
+```
+
+The implementation must not use MuPDF's tolerant box fallback/repair result as the strict source of truth.
+
+## 4. Shrink-only MediaBox rule
+
+For every request:
+
+```text
+finite(x0, y0, x1, y1)
+x0 < x1
+y0 < y1
+request.x0 >= media_public.x0
+request.y0 >= media_public.y0
+request.x1 <= media_public.x1
+request.y1 <= media_public.y1
+```
+
+Requests outside the current public MediaBox are `EXTRACTPDF_ERROR_ARGUMENT`.
+
+After public validation, map the request back to raw PDF user space using:
+
+```text
+public_to_pdf = inverse(pdf_to_public)
+requested_media_pdf = normalize(
+    transform(requested_public, public_to_pdf))
+```
+
+The raw request must also remain inside `media_pdf`; this second containment check is mandatory so floating-point or transform mistakes cannot serialize an expansion.
+
+V1 does not uncrop or enlarge MediaBox.
+
+## 5. Post-trim CropBox semantics
+
+MediaBox V1 never writes `/CropBox`.
+
+The post-trim visible-page behavior depends on whether CropBox existed as a real local/inherited page attribute before the trim.
+
+### 5.1 No local/inherited CropBox exists
+
+If CropBox is absent through the page inheritance chain, PDF defines CropBox by MediaBox fallback.
+
+After writing the new page-local MediaBox:
+
+```text
+output_media_pdf = requested_media_pdf
+output_crop_pdf  = output_media_pdf       // fallback
+output_visible_pdf = output_media_pdf
+```
+
+Because the page frame now falls back to the new MediaBox, reopening the output re-anchors the public page space to that new medium.
+
+Observable result:
+
+```text
+output MediaBox public origin  = (0,0)
+output CropBox public origin   = (0,0)
+output visible page origin     = (0,0)
+```
+
+subject to Rotate/UserUnit orientation and scaling.
+
+Existing content/annotation/link/widget/destination geometry is **not rewritten in PDF space**; its public coordinates change because the page transform changed.
+
+### 5.2 Local or inherited CropBox exists
+
+If a real CropBox attribute exists, its raw value remains structurally unchanged.
+
+Post-trim:
+
+```text
+output_media_pdf   = requested_media_pdf
+output_crop_pdf    = preserved raw effective CropBox
+output_visible_pdf = intersection(output_media_pdf, output_crop_pdf)
+```
+
+The intersection must have positive width and height. Otherwise the request returns `EXTRACTPDF_ERROR_ARGUMENT` before private writes.
+
+Because `/CropBox`, `/Rotate`, and `/UserUnit` are not changed, the page transform frame remains anchored by the preserved CropBox semantics.
+
+Therefore the output public visible rectangle is:
+
+```text
+normalize(transform(output_visible_pdf, existing pdf_to_public))
+```
+
+and **need not begin at `(0,0)`**.
+
+This non-zero-origin behavior is a required regression test. V1 must not secretly rewrite CropBox merely to re-origin the page.
+
+### 5.3 Physical-only trim is valid
+
+A changed MediaBox may still fully contain the preserved effective CropBox.
+
+In that case:
+
+```text
+MediaBox changes
+visible page does not change
+page transform does not change
+```
+
+This is a valid physical-only trim and must not be collapsed into a semantic no-op.
+
+No-op is defined only by equality with the current MediaBox, not by equality of the visible page result.
+
+### 5.4 Trim that clips a preserved CropBox
+
+If the new MediaBox cuts into a preserved CropBox but leaves positive intersection:
+
+- MediaBox changes;
+- raw CropBox remains unchanged;
+- visible page becomes the intersection;
+- page frame remains CropBox-anchored;
+- existing object geometry is not translated or rewritten.
+
+The resulting public visible bounds may have non-zero x0/y0 and reduced width/height.
+
+## 6. BleedBox / TrimBox / ArtBox policy
+
+MediaBox V1 does not write, normalize, materialize, or delete:
+
+```text
+/BleedBox
+/TrimBox
+/ArtBox
+```
+
+PDF semantics define these boxes relative to CropBox when absent and reduce boxes that extend outside MediaBox to their effective intersection with MediaBox.
+
+Therefore changing MediaBox may change their **effective region** without changing their raw dictionary representation.
+
+V1 explicitly permits this derived effect.
+
+- absent Bleed/Trim/Art keys remain absent;
+- explicit keys remain byte/structure-equivalent at the semantic-object level;
+- V1 does not reject a trim merely because one of these production boxes would have a reduced or empty effective region;
+- V1 only requires a positive post-trim effective CropBox intersection because that defines ExtractPDF's visible page contract.
+
+A future production-printing-box API may impose stronger rules. This trim primitive does not silently invent them.
+
+## 7. Strict page-box preflight
+
+Transformation is stricter than tolerant rendering.
+
+Before any source serialization/private write, each requested page must satisfy:
+
+- page object is a dictionary;
+- `/Parent` traversal for inheritable attributes is finite and acyclic;
+- inheritance traversal depth is at most 256;
+- nearest local/inherited `/MediaBox` exists;
+- nearest local/inherited `/CropBox`, when present, is tracked as explicitly present rather than losing that provenance through MediaBox fallback;
+- MediaBox and present CropBox are arrays of exactly four finite numeric values;
+- normalized MediaBox and present CropBox have positive dimensions;
+- source MediaBox/CropBox effective intersection has positive dimensions;
+- effective inherited `/Rotate`, when present, is an integer multiple of 90;
+- page-local `/UserUnit`, when present, is finite and strictly positive;
+- public MediaBox and visible rectangles derived from the strict raw model are finite and positive-area.
+
+Malformed structure returns `EXTRACTPDF_ERROR_FORMAT`.
+
+Structurally valid inheritance depth greater than 256 returns `EXTRACTPDF_ERROR_UNSUPPORTED`.
+
+The validator must not rely on MuPDF silently substituting Letter-size/unit rectangles for malformed or empty boxes.
+
+## 8. Rotate and UserUnit
+
+Valid Rotate and UserUnit are supported in V1.
+
+- `/Rotate` uses normal page inheritance and must be a multiple of 90.
+- `/UserUnit` remains page-local; absent means 1.0.
+- neither key is written by this transform.
+- mapping uses the same strict `pdf_to_public` page matrix and its inverse as CropBox V1.
+- no hand-coded per-rotation switch table is allowed for request mapping.
+
+Rotate 90 and non-default UserUnit are mandatory deterministic fixtures.
+
+## 9. Atomic batch semantics
+
+`extractpdf_trim_pages()` is an immutable atomic batch transform.
+
+### 9.1 Public validation
+
+Before source serialization/private mutation:
+
+- `out_output != NULL`, then immediately set `*out_output = NULL`;
+- `document != NULL`;
+- `trims != NULL`;
+- `trim_count > 0`;
+- allocation arithmetic is overflow-safe;
+- every request satisfies the minimum `struct_size`;
+- every page index is in range;
+- no page index appears more than once;
+- every request rectangle is finite and positive-area;
+- every requested page passes strict page-box preflight;
+- every request is shrink-only against current MediaBox;
+- every changed request maps to a finite positive-area raw MediaBox;
+- every changed request with explicit/inherited CropBox leaves positive post-trim MediaBox/CropBox intersection;
+- encrypted input is rejected;
+- already-signed input is rejected.
+
+Duplicate page indices return `EXTRACTPDF_ERROR_ARGUMENT`; no last-writer-wins behavior exists.
+
+### 9.2 No partial publication
+
+All requests are validated before any private write.
+
+For changed batches, every target page is reparsed/revalidated in the private graph before the first `/MediaBox` write.
+
+Any private inconsistency, write failure, or final serialization failure discards the private graph and leaves `*out_output == NULL`.
+
+Failure atomicity is achieved by isolation, not journal rollback.
+
+## 10. Full-document isolation
+
+A batch containing at least one changed request uses:
+
+```text
+source extractpdf_document
+        ↓
+strict source preflight for all requested pages
+        ↓
+canonical full-PDF serialization
+        ↓
+fresh private MuPDF context
+        ↓
+open private PDF / disable JavaScript immediately
+        ↓
+security recheck
+        ↓
+re-resolve + revalidate every target page
+        ↓
+verify private plan remains semantically consistent
+        ↓
+write local /MediaBox only for changed requests
+        ↓
+deterministic full-PDF serialization
+        ↓
+new immutable extractpdf_output
+```
+
+No `pdf_obj *`, `pdf_page *`, annotation pointer, Widget pointer, editor ref, or other MuPDF identity crosses from source context into private context.
+
+`pdf_graft_mapped_page()` is prohibited; this is transform preservation, not composition.
+
+## 11. Write surface
+
+For every changed page the sole semantic dictionary write is:
+
+```text
+page dictionary /MediaBox = normalized requested raw rectangle
+```
+
+The write is page-local even when source MediaBox was inherited.
+
+MediaBox V1 must not write or normalize:
+
+```text
+/CropBox
+/BleedBox
+/TrimBox
+/ArtBox
+/Rotate
+/UserUnit
+/Contents
+/Resources
+/Annots
+/AA
+/OpenAction
+/AcroForm
+/Outlines
+/Names
+/Dests
+```
+
+It must not invoke:
+
+- content-stream transformation;
+- annotation create/update/delete;
+- link mutation;
+- Widget geometry mutation;
+- form value mutation/recalculation;
+- appearance regeneration;
+- JavaScript;
+- form event/validation/format/calculation/activation execution.
+
+## 12. Structural preservation
+
+Except for the page-local MediaBox write and PDF-defined derived page-box effects, the complete source PDF graph is preserved.
+
+Structurally unchanged objects include:
+
+- page content streams;
+- resources;
+- ordinary annotations;
+- Links;
+- Widgets;
+- AcroForm hierarchy/values/options;
+- outline hierarchy/titles/actions;
+- internal destination objects;
+- metadata;
+- page-tree parent/kids structure.
+
+### 12.1 Objects outside the new MediaBox
+
+Objects are not deleted merely because their geometry lies partly or wholly outside the new physical medium.
+
+They remain enumerable through existing APIs when those APIs enumerate by PDF structure rather than visibility.
+
+Their public geometry is determined only by the output page transform; V1 never clamps object bounds to the new MediaBox.
+
+### 12.2 Interactive identity
+
+This immutable transform introduces no persistent public object identity.
+
+Snapshot indices remain snapshot-local and editor refs remain editor-session-local.
+
+## 13. Observable output requirements
+
+The deterministic V1 suite must verify behavior through existing public APIs, not only raw MediaBox inspection.
+
+At minimum it proves both page-frame modes.
+
+### 13.1 No-CropBox fallback case
+
+For a page with no local/inherited CropBox:
+
+1. MediaBox changes to the requested physical region;
+2. output CropBox follows MediaBox by fallback;
+3. output visible page dimensions match the requested physical dimensions;
+4. output visible/public MediaBox origin is `(0,0)`;
+5. render is clipped to the new medium;
+6. text/image/link/annotation/widget coordinates change according to the newly re-anchored page transform;
+7. internal destination resolution on a trimmed target page follows the target page's new transform;
+8. source page remains unchanged.
+
+### 13.2 Preserved-CropBox case
+
+For a page with local/inherited CropBox:
+
+1. raw CropBox remains unchanged;
+2. MediaBox changes to the requested region;
+3. effective visible region is `intersection(new MediaBox, preserved CropBox)`;
+4. public visible bounds may be non-zero;
+5. if new MediaBox still contains all of CropBox, visible page geometry remains unchanged despite a real physical trim;
+6. if new MediaBox clips CropBox, visible bounds shrink without rewriting object geometry;
+7. text/image/link/annotation/widget public coordinates remain in the preserved CropBox-anchored frame;
+8. URI/content/value/title bytes and logical page/field relationships remain unchanged;
+9. outline/internal destinations retain their logical target and follow only the target page transform;
+10. objects outside the new medium remain structurally enumerable.
+
+### 13.3 Output lifetime
+
+The output must reopen and remain fully usable after the source document is closed.
+
+## 14. No-op semantics
+
+A request is a semantic no-op only when its public `bounds` are component-wise numerically equal to the page's **current public MediaBox rectangle**.
+
+NaN is rejected before comparison; `-0.0` and `+0.0` compare equal.
+
+A no-op request:
+
+- does not write `/MediaBox`;
+- does not materialize inherited MediaBox;
+- does not touch page-tree ancestors;
+- does not write any other page/document dictionary.
+
+A physical MediaBox change that leaves visible CropBox behavior unchanged is **not** a no-op.
+
+### 14.1 All-no-op batch
+
+If every request is a no-op:
+
+1. validate the full batch, including security and page structure;
+2. run the existing deterministic source serialization exactly once;
+3. return those bytes directly;
+4. do not open a private PDF graph;
+5. do not write any page dictionary.
+
+Repeated all-no-op calls on the same unchanged source must be byte-identical.
+
+No promise is made that canonical output bytes equal the original input file bytes.
+
+### 14.2 Mixed batch
+
+No-op pages remain structurally untouched. Changed pages receive local `/MediaBox` values only.
+
+## 15. Error model
+
+Use existing public status values only.
+
+### `EXTRACTPDF_ERROR_ARGUMENT`
+
+- null required public pointer;
+- zero `trim_count`;
+- insufficient request `struct_size`;
+- out-of-range page index;
+- duplicate page index;
+- NaN/infinity request coordinate;
+- zero/inverted request rectangle;
+- request extends outside current public MediaBox;
+- raw inverse-mapped request extends outside current raw MediaBox;
+- changed request leaves empty/non-positive MediaBox/CropBox intersection when a real CropBox exists.
+
+### `EXTRACTPDF_ERROR_FORMAT`
+
+- malformed page dictionary/page tree;
+- missing/malformed MediaBox;
+- malformed explicitly present CropBox;
+- source MediaBox/CropBox intersection is empty;
+- invalid inherited Rotate representation;
+- invalid page-local UserUnit;
+- private reparse produces a structurally inconsistent target page or changed plan.
+
+### `EXTRACTPDF_ERROR_UNSUPPORTED`
+
+- source is not a PDF;
+- encrypted source;
+- already-signed source;
+- structurally valid inheritance depth greater than 256;
+- valid but unsupported PDF condition prevents the preservation contract.
+
+### `EXTRACTPDF_ERROR_NOMEM`
+
+Allocation overflow/failure.
+
+### mapped MuPDF operational errors
+
+Unexpected MuPDF failures map through the existing status boundary and never escape as exceptions.
+
+## 16. Security / active behavior policy
+
+MediaBox V1 executes no active PDF behavior.
+
+- private JavaScript is disabled immediately after open;
+- no JavaScript action is executed;
+- no form validation/format/calculation/activation event is invoked;
+- no high-level form setter/recalculation API is used;
+- no annotation or Widget appearance regeneration is requested;
+- encrypted input fails closed;
+- signed input fails closed because full rewrite invalidates signature semantics.
+
+Security rewrite belongs to the later dedicated #48 slice.
+
+## 17. Private architecture boundary
+
+The second page-box transform now justifies one narrow shared private resolver.
+
+Expected direction:
+
+```text
+src/pdf_page_box_common.[ch]
+    strict page-tree inheritance walk
+    MediaBox/CropBox parsing + CropBox provenance
+    Rotate/UserUnit validation
+    raw MediaBox/CropBox/effective-visible calculation
+    PDF -> public matrix capture
+    raw <-> public rectangle mapping helpers
+
+src/pdf_crop_preflight.c
+    CropBox-specific request policy
+
+src/pdf_trim_preflight.c
+    MediaBox-specific request policy
+
+src/pdf_crop.c
+    existing CropBox orchestration/write
+
+src/pdf_trim.c
+    MediaBox orchestration/write
+```
+
+The common unit must remain read-only. It performs no dictionary writes and owns no transform orchestration.
+
+CropBox implementation should be migrated only as necessary to consume this shared resolver; its public behavior and already-proven 22nd CTest contract must remain unchanged.
+
+No generic `transform options` struct, transform registry, visitor framework, or arbitrary page-box rewrite API is authorized.
+
+No new public editor/session object is authorized.
+
+## 18. Test architecture
+
+Add one new CTest:
+
+```text
+extractpdf.pdf_trim
+```
+
+Integrated baseline:
+
+```text
+22 CTests
+```
+
+Target after this slice:
+
+```text
+23 CTests
+```
+
+The first strict RED occurs before any trim production implementation:
+
+- all existing 22 executable targets continue to build;
+- the new trim test target fails to compile only because `extractpdf_page_trim` / `extractpdf_trim_pages()` do not yet exist;
+- existing CropBox and all Phase 2-5 tests remain untouched and green.
+
+## 19. Required deterministic fixtures/cases
+
+The final trim target must cover at least:
+
+1. **no CropBox fallback** — changed MediaBox becomes both physical and visible region, with output origin re-anchored;
+2. **explicit CropBox, physical-only trim** — MediaBox shrinks but still contains CropBox; visible page and object coordinates remain unchanged;
+3. **explicit CropBox, clipping trim** — MediaBox clips part of CropBox; raw CropBox unchanged and public visible bounds become smaller/non-zero;
+4. **inherited CropBox** — same preserved-frame semantics without materializing CropBox;
+5. **inherited MediaBox changed** — changed page receives local MediaBox only;
+6. **inherited MediaBox no-op** — no local MediaBox materialization;
+7. **raw CropBox outside MediaBox** — valid source intersection and deterministic further MediaBox shrink;
+8. **Rotate 90**;
+9. **non-default page-local UserUnit**;
+10. **explicit BleedBox/TrimBox/ArtBox** — raw entries unchanged;
+11. **absent BleedBox/TrimBox/ArtBox** — keys remain absent;
+12. **two-page interactive preservation** — text, image, URI link, internal link, ordinary annotation, Widget + AcroForm value, outline destination;
+13. **object outside new MediaBox** — remains structurally enumerable;
+14. **multi-page changed batch**;
+15. **all-no-op batch determinism**;
+16. **mixed no-op + changed batch**;
+17. **duplicate page index**;
+18. **out-of-range page index**;
+19. **NaN / infinity**;
+20. **zero/inverted request rect**;
+21. **request outside current MediaBox**;
+22. **request disjoint from preserved CropBox** — `ARGUMENT`;
+23. **malformed MediaBox**;
+24. **malformed CropBox**;
+25. **bad inherited Rotate**;
+26. **bad page-local UserUnit**;
+27. **source immutability**;
+28. **output lifetime after source close**;
+29. **repeated changed batch deterministic bytes**;
+30. **failure output reset to NULL**.
+
+Fixtures should be deterministic repository data. Existing fixtures may be reused read-only where their contract matches; do not mutate fixtures owned by earlier integrated tests.
+
+## 20. Raw structural assertions
+
+Private test helpers may inspect raw PDF structure only to prove invariants that public APIs cannot observe directly.
+
+Allowed assertions include:
+
+- changed page has local normalized `/MediaBox`;
+- changed inherited MediaBox does not modify ancestor;
+- no-op inherited MediaBox remains inherited;
+- raw explicit/inherited CropBox remains unchanged and is not materialized locally merely by trim;
+- explicit Bleed/Trim/Art entries remain semantically equal;
+- absent Bleed/Trim/Art entries remain absent;
+- Contents/Resources/Annots/AcroForm/Outlines/Names/Dests structures remain semantically preserved.
+
+Tests must not depend on indirect object numbers created by serialization.
+
+Semantic/deep comparison must avoid naïve recursion through cyclic Widget/AcroForm graphs.
+
+## 21. Verification gates
+
+After a later approved implementation plan:
+
+```text
+committed design spec
+        ↓
+implementation plan
+        ↓
+strict compile RED
+        ↓
+minimal ABI/runtime RED
+        ↓
+minimal GREEN
+        ↓
+Linux static 23/23
+        ↓
+Linux ASan/UBSan 23/23
+        ↓
+freeze exact feature SHA
+        ↓
+same-SHA Linux/macOS/Windows full-ci
+        ↓
+Critical/Important architecture + scope review
+        ↓
+STOP — explicit integration authorization
+        ↓
+merge exact proven feature SHA
+        ↓
+integrated-master push proof
+        ↓
+close #51 / update #48/#2
+```
+
+Any source/test/spec change after candidate freeze invalidates same-SHA proof.
+
+Do not edit workflow YAML merely to obtain proof. Use the existing `full-ci` label mechanism unless a separate infrastructure defect is identified and approved.
+
+## 22. Explicit non-goals
+
+V1 does not provide:
+
+- explicit CropBox mutation in the same call;
+- BleedBox mutation;
+- TrimBox mutation;
+- ArtBox mutation;
+- content-stream translation;
+- per-object geometry translation;
+- deletion of objects outside MediaBox;
+- poster split;
+- flatten/bake;
+- arbitrary content editing;
+- optimize/garbage collection;
+- image recompression;
+- encryption/decryption/re-encryption;
+- incremental save;
+- JavaScript/form runtime;
+- signature-preserving rewrite;
+- persistent PDF object IDs;
+- multithreaded handle semantics.
+
+## 23. Completion criterion
+
+MediaBox Physical Trim V1 is complete only when one exact feature head proves all of the following:
+
+- immutable source -> immutable output;
+- shrink-only public MediaBox input;
+- correct PDF/public inverse mapping under Rotate/UserUnit;
+- no-CropBox fallback re-anchors output page space correctly;
+- preserved CropBox keeps its frame and can produce non-zero output visible bounds;
+- physical-only trim is distinguishable from CropBox crop;
+- raw Crop/Bleed/Trim/Art keys remain untouched;
+- only changed pages receive local MediaBox;
+- complete interactive/document-root graph remains structurally coherent;
+- deterministic/no-op/failure-atomic batch behavior;
+- 23/23 static + sanitizer tests;
+- same-SHA Linux/macOS/Windows proof;
+- no Critical/Important architecture blocker;
+- explicit integration authorization followed by integrated-master proof.
+
+Only after this page-box foundation is integrated should Phase 6 proceed to poster split.

--- a/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
+++ b/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
@@ -6,6 +6,8 @@ Baseline master: `3fc48b5fb0f7a07926f7942fc4a4a3fb5e93a753`
 Baseline content tree: `594499cfea3071f210b5b8781d73e942ba94a94d`  
 Depends on: integrated CropBox V1 (#49 / PR #50) and its page-transform direction correction
 
+> **Normative correction:** `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md` supersedes this document wherever this original design says that preserving a raw `/CropBox` necessarily preserves the same public page frame after `/MediaBox` clips that CropBox, or says that the output visible public rectangle may retain a non-zero origin. Implementation planning is blocked until that correction is reviewed and approved.
+
 ## 1. Purpose
 
 MediaBox Physical Trim V1 completes the first Phase 6 page-box foundation before poster split.
@@ -86,7 +88,7 @@ The request is not expressed in raw PDF user space.
 
 ### 3.1 Public MediaBox is not necessarily the visible page rectangle
 
-When an effective CropBox exists, MuPDF's page frame is anchored by that CropBox semantics. Therefore the public MediaBox rectangle can:
+When an effective CropBox exists, MuPDF's page frame is anchored by the current effective CropBox/MediaBox intersection. Therefore the public MediaBox rectangle can:
 
 - extend beyond the current visible page rectangle;
 - have negative coordinates;
@@ -125,8 +127,6 @@ PDF user space --pdf_to_public--> ExtractPDF/Fitz page space
 ExtractPDF/Fitz page space --inverse(pdf_to_public)--> PDF user space
 ```
 
-The matrix returned by MuPDF's page transform path must be treated accordingly inside ExtractPDF, regardless of contradictory prose comments in external headers/source.
-
 Strict public rectangles are derived as:
 
 ```text
@@ -160,47 +160,40 @@ requested_media_pdf = normalize(
     transform(requested_public, public_to_pdf))
 ```
 
-The raw request must also remain inside `media_pdf`; this second containment check is mandatory so floating-point or transform mistakes cannot serialize an expansion.
+The raw request must also remain inside `media_pdf`.
 
 V1 does not uncrop or enlarge MediaBox.
 
-## 5. Post-trim CropBox semantics
+## 5. Post-trim CropBox and page-frame semantics
 
 MediaBox V1 never writes `/CropBox`.
 
-The post-trim visible-page behavior depends on whether CropBox existed as a real local/inherited page attribute before the trim.
+The authoritative page-frame behavior is defined by the normative correction referenced at the top of this document.
 
 ### 5.1 No local/inherited CropBox exists
 
-If CropBox is absent through the page inheritance chain, PDF defines CropBox by MediaBox fallback.
+If CropBox is absent through the page inheritance chain, it falls back to MediaBox.
 
-After writing the new page-local MediaBox:
-
-```text
-output_media_pdf = requested_media_pdf
-output_crop_pdf  = output_media_pdf       // fallback
-output_visible_pdf = output_media_pdf
-```
-
-Because the page frame now falls back to the new MediaBox, reopening the output re-anchors the public page space to that new medium.
-
-Observable result:
+After writing the new MediaBox:
 
 ```text
-output MediaBox public origin  = (0,0)
-output CropBox public origin   = (0,0)
-output visible page origin     = (0,0)
+output_media_pdf   = requested_media_pdf
+output_visible_pdf = requested_media_pdf
 ```
 
-subject to Rotate/UserUnit orientation and scaling.
+Reopening the output re-anchors the public page frame to the new medium.
 
-The source request rectangle is expressed in the **source** page frame. Its x0/y0 coordinates are therefore not required to survive as output public coordinates in this fallback case. Only the requested physical region and its public dimensions survive; reopening establishes the new page frame at `(0,0)`.
+For deterministic unrotated/UserUnit=1 fixtures:
 
-Existing content/annotation/link/widget/destination geometry is **not rewritten in PDF space**; its public coordinates change because the page transform changed.
+```text
+output visible public bounds = [0,0,width,height]
+```
+
+The source request x0/y0 are not required to survive as output public x0/y0.
 
 ### 5.2 Local or inherited CropBox exists
 
-If a real CropBox attribute exists, its raw value remains structurally unchanged.
+The raw CropBox remains structurally unchanged.
 
 Post-trim:
 
@@ -210,49 +203,36 @@ output_crop_pdf    = preserved raw effective CropBox
 output_visible_pdf = intersection(output_media_pdf, output_crop_pdf)
 ```
 
-The intersection must have positive width and height. Otherwise the request returns `EXTRACTPDF_ERROR_ARGUMENT` before private writes.
+The intersection must have positive area or the request returns `EXTRACTPDF_ERROR_ARGUMENT` before private writes.
 
-Because `/CropBox`, `/Rotate`, and `/UserUnit` are not changed, the page transform frame remains anchored by the preserved CropBox semantics.
-
-Therefore the output public visible rectangle is:
+Two subcases are normative:
 
 ```text
-normalize(transform(output_visible_pdf, existing pdf_to_public))
+output_visible_pdf == source visible_pdf
+    => physical-only trim
+    => page frame unchanged
+    => visible/object public geometry unchanged
+
+output_visible_pdf != source visible_pdf
+    => MediaBox clips effective CropBox
+    => output page frame re-anchors to output_visible_pdf
+    => visible public origin is re-established at (0,0)
+    => object public geometry follows the new page transform
 ```
 
-and **need not begin at `(0,0)`**.
-
-In this preserved-frame case, the output public MediaBox rectangle is observed in the same page frame as the source request, so a successfully written MediaBox is expected to correspond to the requested public rectangle subject only to the exact numeric mapping contract.
-
-This non-zero-origin behavior is a required regression test. V1 must not secretly rewrite CropBox merely to re-origin the page.
+The transform must not rewrite CropBox or individual object coordinates merely to preserve the old frame.
 
 ### 5.3 Physical-only trim is valid
 
-A changed MediaBox may still fully contain the preserved effective CropBox.
+A changed MediaBox that leaves `output_visible_pdf == source visible_pdf` is still a real transform and is not a no-op.
 
-In that case:
+No-op is defined only by equality with the current public MediaBox.
 
-```text
-MediaBox changes
-visible page does not change
-page transform does not change
-```
+### 5.4 Output MediaBox may be non-zero
 
-This is a valid physical-only trim and must not be collapsed into a semantic no-op.
+When MediaBox extends outside `output_visible_pdf`, the **output public MediaBox** may have negative/non-zero coordinates relative to the output visible frame.
 
-No-op is defined only by equality with the current MediaBox, not by equality of the visible page result.
-
-### 5.4 Trim that clips a preserved CropBox
-
-If the new MediaBox cuts into a preserved CropBox but leaves positive intersection:
-
-- MediaBox changes;
-- raw CropBox remains unchanged;
-- visible page becomes the intersection;
-- page frame remains CropBox-anchored;
-- existing object geometry is not translated or rewritten.
-
-The resulting public visible bounds may have non-zero x0/y0 and reduced width/height.
+This is distinct from visible public bounds, which are anchored to the current effective visible origin.
 
 ## 6. BleedBox / TrimBox / ArtBox policy
 
@@ -264,64 +244,50 @@ MediaBox V1 does not write, normalize, materialize, or delete:
 /ArtBox
 ```
 
-PDF semantics define these boxes relative to CropBox when absent and reduce boxes that extend outside MediaBox to their effective intersection with MediaBox.
-
-Therefore changing MediaBox may change their **effective region** without changing their raw dictionary representation.
-
-V1 explicitly permits this derived effect.
+PDF semantics may change their effective region when MediaBox changes. V1 permits this derived effect.
 
 - absent Bleed/Trim/Art keys remain absent;
 - explicit keys remain semantically/structurally unchanged;
 - V1 does not reject a trim merely because one of these production boxes would have a reduced or empty effective region;
 - V1 only requires a positive post-trim effective CropBox intersection because that defines ExtractPDF's visible page contract.
 
-These three keys are **opaque preservation state** for this slice. V1 does not parse or validate their values as part of trim preflight because it does not consume them to compute MediaBox or visible-page semantics. A malformed explicit BleedBox/TrimBox/ArtBox that the source PDF can otherwise open is preserved unchanged rather than normalized, repaired, or converted into a trim-specific status.
-
-A future production-printing-box API may impose stronger rules. This trim primitive does not silently invent them.
+These keys are **opaque preservation state** for this slice. V1 does not parse or validate their values as trim-preflight inputs.
 
 ## 7. Strict page-box preflight
-
-Transformation is stricter than tolerant rendering for the state it actually consumes.
 
 Before any source serialization/private write, each requested page must satisfy:
 
 - page object is a dictionary;
-- `/Parent` traversal for inheritable attributes is finite and acyclic;
+- `/Parent` traversal is finite and acyclic;
 - inheritance traversal depth is at most 256;
 - nearest local/inherited `/MediaBox` exists;
-- nearest local/inherited `/CropBox`, when present, is tracked as explicitly present rather than losing that provenance through MediaBox fallback;
+- nearest local/inherited `/CropBox`, when present, is tracked as truly present rather than losing provenance through fallback;
 - MediaBox and present CropBox are arrays of exactly four finite numeric values;
 - normalized MediaBox and present CropBox have positive dimensions;
 - source MediaBox/CropBox effective intersection has positive dimensions;
 - effective inherited `/Rotate`, when present, is an integer multiple of 90;
 - page-local `/UserUnit`, when present, is finite and strictly positive;
-- public MediaBox and visible rectangles derived from the strict raw model are finite and positive-area.
+- public MediaBox and visible rectangles are finite and positive-area.
 
-BleedBox/TrimBox/ArtBox are deliberately excluded from this strict consumed-state validation per §6.
+BleedBox/TrimBox/ArtBox are excluded from this consumed-state validation.
 
-Malformed consumed structure returns `EXTRACTPDF_ERROR_FORMAT`.
-
-Structurally valid inheritance depth greater than 256 returns `EXTRACTPDF_ERROR_UNSUPPORTED`.
-
-The validator must not rely on MuPDF silently substituting Letter-size/unit rectangles for malformed or empty MediaBox/CropBox values.
+Malformed consumed structure returns `EXTRACTPDF_ERROR_FORMAT`. Structurally valid inheritance depth greater than 256 returns `EXTRACTPDF_ERROR_UNSUPPORTED`.
 
 ## 8. Rotate and UserUnit
 
-Valid Rotate and UserUnit are supported in V1.
+Valid Rotate and UserUnit are supported.
 
 - `/Rotate` uses normal page inheritance and must be a multiple of 90.
 - `/UserUnit` remains page-local; absent means 1.0.
-- neither key is written by this transform.
-- mapping uses the same strict `pdf_to_public` page matrix and its inverse as CropBox V1.
-- no hand-coded per-rotation switch table is allowed for request mapping.
+- neither key is written.
+- mapping uses `pdf_to_public` and its inverse.
+- no hand-coded per-rotation request mapping is allowed.
 
 Rotate 90 and non-default UserUnit are mandatory deterministic fixtures.
 
 ## 9. Atomic batch semantics
 
 `extractpdf_trim_pages()` is an immutable atomic batch transform.
-
-### 9.1 Public validation
 
 Before source serialization/private mutation:
 
@@ -330,32 +296,21 @@ Before source serialization/private mutation:
 - `trims != NULL`;
 - `trim_count > 0`;
 - allocation arithmetic is overflow-safe;
-- every request satisfies the minimum `struct_size`;
-- every page index is in range;
-- no page index appears more than once;
+- every request satisfies minimum `struct_size`;
+- every page index is in range and unique;
 - every request rectangle is finite and positive-area;
 - every requested page passes strict page-box preflight;
 - every request is shrink-only against current MediaBox;
 - every changed request maps to a finite positive-area raw MediaBox;
-- every changed request with explicit/inherited CropBox leaves positive post-trim MediaBox/CropBox intersection;
+- every changed request leaves a positive post-trim visible intersection;
 - encrypted input is rejected;
 - already-signed input is rejected.
 
-Duplicate page indices return `EXTRACTPDF_ERROR_ARGUMENT`; no last-writer-wins behavior exists.
-
-### 9.2 No partial publication
-
-All requests are validated before any private write.
-
-For changed batches, every target page is reparsed/revalidated in the private graph before the first `/MediaBox` write.
-
-Any private inconsistency, write failure, or final serialization failure discards the private graph and leaves `*out_output == NULL`.
-
-Failure atomicity is achieved by isolation, not journal rollback.
+All requests are validated before any private write. Any private inconsistency/write/serialization failure discards the private graph and leaves `*out_output == NULL`.
 
 ## 10. Full-document isolation
 
-A batch containing at least one changed request uses:
+A changed batch uses:
 
 ```text
 source extractpdf_document
@@ -381,21 +336,11 @@ deterministic full-PDF serialization
 new immutable extractpdf_output
 ```
 
-No `pdf_obj *`, `pdf_page *`, annotation pointer, Widget pointer, editor ref, or other MuPDF identity crosses from source context into private context.
+No MuPDF object/page/annotation/widget/editor identity crosses contexts.
 
-Private-plan consistency is checked **before the first write**. At minimum, reparsing must preserve for each request:
+Private-plan consistency is checked before the first write and must reproduce CropBox provenance, source visible intersection, requested raw MediaBox containment, post-trim visible intersection, changed/no-op classification, and frame-preserving/frame-changing classification.
 
-- target page index;
-- valid MediaBox/CropBox consumed structure;
-- whether CropBox is truly present versus MediaBox fallback;
-- effective Rotate/UserUnit semantics;
-- inverse-mapped requested raw MediaBox containment;
-- changed/no-op classification;
-- positive post-trim visible intersection when CropBox is present.
-
-A private canonical reparse that changes one of these consumed semantics is `EXTRACTPDF_ERROR_FORMAT`; the implementation must not continue by silently accepting a different plan.
-
-`pdf_graft_mapped_page()` is prohibited; this is transform preservation, not composition.
+`pdf_graft_mapped_page()` is prohibited.
 
 ## 11. Write surface
 
@@ -427,183 +372,116 @@ MediaBox V1 must not write or normalize:
 /Dests
 ```
 
-It must not invoke:
-
-- content-stream transformation;
-- annotation create/update/delete;
-- link mutation;
-- Widget geometry mutation;
-- form value mutation/recalculation;
-- appearance regeneration;
-- JavaScript;
-- form event/validation/format/calculation/activation execution.
+It must not invoke content transformation, annotation/link/widget mutation, form mutation/recalculation, appearance regeneration, JavaScript, or form event execution.
 
 ## 12. Structural preservation
 
 Except for the page-local MediaBox write and PDF-defined derived page-box effects, the complete source PDF graph is preserved.
 
-Structurally unchanged objects include:
+Content/resources/annotations/Links/Widgets/AcroForm/outlines/internal destinations/metadata/page-tree structure remain semantically unchanged.
 
-- page content streams;
-- resources;
-- ordinary annotations;
-- Links;
-- Widgets;
-- AcroForm hierarchy/values/options;
-- outline hierarchy/titles/actions;
-- internal destination objects;
-- metadata;
-- page-tree parent/kids structure.
-
-### 12.1 Objects outside the new MediaBox
-
-Objects are not deleted merely because their geometry lies partly or wholly outside the new physical medium.
-
-They remain enumerable through existing APIs when those APIs enumerate by PDF structure rather than visibility.
-
-Their public geometry is determined only by the output page transform; V1 never clamps object bounds to the new MediaBox.
-
-### 12.2 Interactive identity
+Objects outside the new MediaBox are not deleted and are not clamped; their public geometry follows the output page transform.
 
 This immutable transform introduces no persistent public object identity.
 
-Snapshot indices remain snapshot-local and editor refs remain editor-session-local.
-
 ## 13. Observable output requirements
 
-The deterministic V1 suite must verify behavior through existing public APIs, not only raw MediaBox inspection.
+The deterministic suite must prove both frame modes.
 
-At minimum it proves both page-frame modes.
+### 13.1 No-CropBox fallback
 
-### 13.1 No-CropBox fallback case
+- MediaBox changes;
+- CropBox fallback follows MediaBox;
+- visible public bounds re-anchor to `(0,0)`;
+- render clips to new medium;
+- public object/destination coordinates follow the new page transform;
+- source remains unchanged.
 
-For a page with no local/inherited CropBox:
+### 13.2 Real CropBox, physical-only trim
 
-1. MediaBox changes to the requested physical region;
-2. output CropBox follows MediaBox by fallback;
-3. output visible page dimensions match the requested physical dimensions;
-4. output visible/public MediaBox origin is `(0,0)` rather than preserving the source request x0/y0;
-5. render is clipped to the new medium;
-6. text/image/link/annotation/widget coordinates change according to the newly re-anchored page transform;
-7. internal destination resolution on a trimmed target page follows the target page's new transform;
-8. source page remains unchanged.
+- raw CropBox unchanged;
+- MediaBox changes;
+- effective visible intersection unchanged;
+- visible public bounds unchanged;
+- object and destination public geometry unchanged;
+- transform is still not a no-op.
 
-### 13.2 Preserved-CropBox case
+### 13.3 Real CropBox, clipping trim
 
-For a page with local/inherited CropBox:
+- raw CropBox unchanged;
+- MediaBox changes;
+- effective visible intersection shrinks;
+- output visible public bounds re-anchor to `(0,0)` with reduced dimensions;
+- public object/destination geometry follows the new output page transform;
+- no underlying object geometry is rewritten;
+- at least one fixture proves output public MediaBox may have negative/non-zero coordinates relative to the output visible frame.
 
-1. raw CropBox remains unchanged;
-2. MediaBox changes to the requested region;
-3. effective visible region is `intersection(new MediaBox, preserved CropBox)`;
-4. public visible bounds may be non-zero;
-5. if new MediaBox still contains all of CropBox, visible page geometry remains unchanged despite a real physical trim;
-6. if new MediaBox clips CropBox, visible bounds shrink without rewriting object geometry;
-7. text/image/link/annotation/widget public coordinates remain in the preserved CropBox-anchored frame;
-8. URI/content/value/title bytes and logical page/field relationships remain unchanged;
-9. outline/internal destinations retain their logical target and follow only the target page transform;
-10. objects outside the new medium remain structurally enumerable.
+### 13.4 Output lifetime
 
-### 13.3 Output lifetime
-
-The output must reopen and remain fully usable after the source document is closed.
+Output remains usable after the source document closes.
 
 ## 14. No-op semantics
 
-A request is a semantic no-op only when its public `bounds` are component-wise numerically equal to the page's **current public MediaBox rectangle**.
+A request is a no-op only when its public bounds equal the page's current public MediaBox rectangle component-wise. `-0.0 == +0.0`; NaN is rejected first.
 
-NaN is rejected before comparison; `-0.0` and `+0.0` compare equal.
+No-op pages do not materialize local MediaBox or touch ancestors/other dictionaries.
 
-A no-op request:
+If all requests are no-op, validate completely, serialize source once, return canonical bytes directly, and do not reopen/write a private graph. Repeated all-no-op calls must be byte-identical. No promise is made against original input bytes.
 
-- does not write `/MediaBox`;
-- does not materialize inherited MediaBox;
-- does not touch page-tree ancestors;
-- does not write any other page/document dictionary.
-
-A physical MediaBox change that leaves visible CropBox behavior unchanged is **not** a no-op.
-
-### 14.1 All-no-op batch
-
-If every request is a no-op:
-
-1. validate the full batch, including security and consumed page structure;
-2. run the existing deterministic source serialization exactly once;
-3. return those bytes directly;
-4. do not open a private PDF graph;
-5. do not write any page dictionary.
-
-Repeated all-no-op calls on the same unchanged source must be byte-identical.
-
-No promise is made that canonical output bytes equal the original input file bytes.
-
-### 14.2 Mixed batch
-
-No-op pages remain structurally untouched. Changed pages receive local `/MediaBox` values only.
+Mixed batches leave no-op pages untouched and write local MediaBox only on changed pages.
 
 ## 15. Error model
 
-Use existing public status values only.
-
 ### `EXTRACTPDF_ERROR_ARGUMENT`
 
-- null required public pointer;
+- null required pointer;
 - zero `trim_count`;
-- insufficient request `struct_size`;
-- out-of-range page index;
-- duplicate page index;
-- NaN/infinity request coordinate;
-- zero/inverted request rectangle;
-- request extends outside current public MediaBox;
-- raw inverse-mapped request extends outside current raw MediaBox;
-- changed request leaves empty/non-positive MediaBox/CropBox intersection when a real CropBox exists.
+- insufficient `struct_size`;
+- out-of-range/duplicate page index;
+- NaN/infinity;
+- zero/inverted request;
+- request outside current public MediaBox;
+- inverse-mapped request outside raw MediaBox;
+- changed request leaves empty/non-positive post-trim visible intersection.
 
 ### `EXTRACTPDF_ERROR_FORMAT`
 
 - malformed page dictionary/page tree;
 - missing/malformed MediaBox;
-- malformed explicitly present CropBox;
-- source MediaBox/CropBox intersection is empty;
-- invalid inherited Rotate representation;
+- malformed truly present CropBox;
+- source MediaBox/CropBox intersection empty;
+- invalid inherited Rotate;
 - invalid page-local UserUnit;
-- private reparse produces a structurally inconsistent target page or changed plan.
+- private reparse changes consumed target/plan semantics.
 
-Malformed BleedBox/TrimBox/ArtBox are not trim-specific `FORMAT` conditions because V1 does not consume those values; they follow the opaque preservation policy in §6.
+Malformed Bleed/Trim/Art are not trim-specific FORMAT conditions.
 
 ### `EXTRACTPDF_ERROR_UNSUPPORTED`
 
-- source is not a PDF;
-- encrypted source;
-- already-signed source;
-- structurally valid inheritance depth greater than 256;
-- valid but unsupported PDF condition prevents the preservation contract.
+- non-PDF;
+- encrypted;
+- signed;
+- valid inheritance depth >256;
+- valid unsupported condition preventing preservation.
 
 ### `EXTRACTPDF_ERROR_NOMEM`
 
 Allocation overflow/failure.
 
-### mapped MuPDF operational errors
-
-Unexpected MuPDF failures map through the existing status boundary and never escape as exceptions.
+Unexpected MuPDF operational failures map through the existing status boundary.
 
 ## 16. Security / active behavior policy
 
-MediaBox V1 executes no active PDF behavior.
-
-- private JavaScript is disabled immediately after open;
-- no JavaScript action is executed;
-- no form validation/format/calculation/activation event is invoked;
-- no high-level form setter/recalculation API is used;
-- no annotation or Widget appearance regeneration is requested;
-- encrypted input fails closed;
-- signed input fails closed because full rewrite invalidates signature semantics.
-
-Security rewrite belongs to the later dedicated #48 slice.
+- disable private JavaScript immediately after open;
+- no JS actions;
+- no form validation/format/calculation/activation;
+- no form setter/recalculation;
+- no annotation/widget appearance regeneration;
+- encrypted and signed input fail closed.
 
 ## 17. Private architecture boundary
 
-The second page-box transform now justifies one narrow shared private resolver.
-
-Expected direction:
+The second page-box transform justifies one narrow shared read-only resolver:
 
 ```text
 src/pdf_page_box_common.[ch]
@@ -627,15 +505,9 @@ src/pdf_trim.c
     MediaBox orchestration/write
 ```
 
-The common unit must remain read-only. It performs no dictionary writes and owns no transform orchestration.
+The common unit is read-only and does not parse Bleed/Trim/Art. CropBox migration is only what is necessary to consume this resolver; its public behavior and existing 22nd CTest must remain unchanged.
 
-It consumes only MediaBox/CropBox/Rotate/UserUnit state needed by the two transforms; it must not start parsing Bleed/Trim/Art merely because those names are also page boxes.
-
-CropBox implementation should be migrated only as necessary to consume this shared resolver; its public behavior and already-proven 22nd CTest contract must remain unchanged.
-
-No generic `transform options` struct, transform registry, visitor framework, or arbitrary page-box rewrite API is authorized.
-
-No new public editor/session object is authorized.
+No generic transform options/registry/visitor framework or public editor session is authorized.
 
 ## 18. Test architecture
 
@@ -645,91 +517,65 @@ Add one new CTest:
 extractpdf.pdf_trim
 ```
 
-Integrated baseline:
+Baseline 22 CTests -> target 23 CTests.
 
-```text
-22 CTests
-```
+First strict RED: old 22 executable targets continue to build/pass; new trim target fails to compile only because `extractpdf_page_trim` / `extractpdf_trim_pages()` are absent.
 
-Target after this slice:
+## 19. Required deterministic cases
 
-```text
-23 CTests
-```
+Final trim target covers at least:
 
-The first strict RED occurs before any trim production implementation:
+1. no-CropBox fallback + frame re-anchor;
+2. real CropBox physical-only trim + unchanged frame;
+3. real CropBox clipping trim + frame re-anchor;
+4. output MediaBox non-zero/negative relative to visible frame;
+5. inherited CropBox semantics;
+6. inherited MediaBox changed/local materialization;
+7. inherited MediaBox no-op/no materialization;
+8. raw CropBox outside MediaBox;
+9. Rotate 90;
+10. page-local non-default UserUnit;
+11. explicit opaque Bleed/Trim/Art preserved;
+12. absent Bleed/Trim/Art remain absent;
+13. two-page interactive preservation;
+14. object outside new MediaBox remains enumerable;
+15. multi-page changed batch;
+16. all-no-op determinism;
+17. mixed batch;
+18. duplicate/out-of-range/nonfinite/empty/outside-MediaBox rejection;
+19. disjoint post-trim visible intersection rejection;
+20. malformed MediaBox/CropBox/Rotate/UserUnit;
+21. source immutability;
+22. output lifetime;
+23. repeated changed determinism;
+24. failure output reset.
 
-- all existing 22 executable targets continue to build;
-- the new trim test target fails to compile only because `extractpdf_page_trim` / `extractpdf_trim_pages()` do not yet exist;
-- existing CropBox and all Phase 2-5 tests remain untouched and green.
-
-## 19. Required deterministic fixtures/cases
-
-The final trim target must cover at least:
-
-1. **no CropBox fallback** — changed MediaBox becomes both physical and visible region, with output origin re-anchored and source request x0/y0 not preserved as output origin;
-2. **explicit CropBox, physical-only trim** — MediaBox shrinks but still contains CropBox; visible page and object coordinates remain unchanged;
-3. **explicit CropBox, clipping trim** — MediaBox clips part of CropBox; raw CropBox unchanged and public visible bounds become smaller/non-zero;
-4. **inherited CropBox** — same preserved-frame semantics without materializing CropBox;
-5. **inherited MediaBox changed** — changed page receives local MediaBox only;
-6. **inherited MediaBox no-op** — no local MediaBox materialization;
-7. **raw CropBox outside MediaBox** — valid source intersection and deterministic further MediaBox shrink;
-8. **Rotate 90**;
-9. **non-default page-local UserUnit**;
-10. **explicit BleedBox/TrimBox/ArtBox** — raw entries unchanged, including opaque preservation rather than normalization;
-11. **absent BleedBox/TrimBox/ArtBox** — keys remain absent;
-12. **two-page interactive preservation** — text, image, URI link, internal link, ordinary annotation, Widget + AcroForm value, outline destination;
-13. **object outside new MediaBox** — remains structurally enumerable;
-14. **multi-page changed batch**;
-15. **all-no-op batch determinism**;
-16. **mixed no-op + changed batch**;
-17. **duplicate page index**;
-18. **out-of-range page index**;
-19. **NaN / infinity**;
-20. **zero/inverted request rect**;
-21. **request outside current MediaBox**;
-22. **request disjoint from preserved CropBox** — `ARGUMENT`;
-23. **malformed MediaBox**;
-24. **malformed CropBox**;
-25. **bad inherited Rotate**;
-26. **bad page-local UserUnit**;
-27. **source immutability**;
-28. **output lifetime after source close**;
-29. **repeated changed batch deterministic bytes**;
-30. **failure output reset to NULL**.
-
-Fixtures should be deterministic repository data. Existing fixtures may be reused read-only where their contract matches; do not mutate fixtures owned by earlier integrated tests.
+Earlier integrated fixtures may be reused read-only; do not modify them.
 
 ## 20. Raw structural assertions
 
-Private test helpers may inspect raw PDF structure only to prove invariants that public APIs cannot observe directly.
+Test-only MuPDF helpers may prove:
 
-Allowed assertions include:
-
-- changed page has local normalized `/MediaBox`;
+- changed page has local normalized MediaBox;
 - changed inherited MediaBox does not modify ancestor;
 - no-op inherited MediaBox remains inherited;
-- raw explicit/inherited CropBox remains unchanged and is not materialized locally merely by trim;
-- explicit Bleed/Trim/Art entries remain semantically equal without repair/normalization;
-- absent Bleed/Trim/Art entries remain absent;
-- Contents/Resources/Annots/AcroForm/Outlines/Names/Dests structures remain semantically preserved.
+- raw CropBox preserved/not spuriously materialized;
+- explicit Bleed/Trim/Art semantically equal without repair;
+- absent Bleed/Trim/Art remain absent;
+- Contents/Resources/Annots/AcroForm/Outlines/Names/Dests preserved.
 
-Tests must not depend on indirect object numbers created by serialization.
-
-Semantic/deep comparison must avoid naïve recursion through cyclic Widget/AcroForm graphs.
+Do not depend on indirect object numbers or naïve deep recursion through cyclic form graphs.
 
 ## 21. Verification gates
 
-After a later approved implementation plan:
-
 ```text
-committed design spec
+committed design + correction
         ↓
 implementation plan
         ↓
 strict compile RED
         ↓
-minimal ABI/runtime RED
+ABI/runtime RED
         ↓
 minimal GREEN
         ↓
@@ -741,7 +587,7 @@ freeze exact feature SHA
         ↓
 same-SHA Linux/macOS/Windows full-ci
         ↓
-Critical/Important architecture + scope review
+Critical/Important review
         ↓
 STOP — explicit integration authorization
         ↓
@@ -749,53 +595,32 @@ merge exact proven feature SHA
         ↓
 integrated-master push proof
         ↓
-close #51 / update #48/#2
+close #51 / checkpoint #48/#2
 ```
 
-Any source/test/spec change after candidate freeze invalidates same-SHA proof.
-
-Do not edit workflow YAML merely to obtain proof. Use the existing `full-ci` label mechanism unless a separate infrastructure defect is identified and approved.
+Any source/test/spec change after freeze invalidates proof. Do not edit workflow YAML merely to obtain proof; use existing `full-ci` label mechanism.
 
 ## 22. Explicit non-goals
 
-V1 does not provide:
-
-- explicit CropBox mutation in the same call;
-- BleedBox mutation;
-- TrimBox mutation;
-- ArtBox mutation;
-- content-stream translation;
-- per-object geometry translation;
-- deletion of objects outside MediaBox;
-- poster split;
-- flatten/bake;
-- arbitrary content editing;
-- optimize/garbage collection;
-- image recompression;
-- encryption/decryption/re-encryption;
-- incremental save;
-- JavaScript/form runtime;
-- signature-preserving rewrite;
-- persistent PDF object IDs;
-- multithreaded handle semantics.
+No CropBox/BleedBox/TrimBox/ArtBox mutation, content/object translation, deletion outside MediaBox, poster split, flatten, arbitrary editing, optimize/gc, image recompression, security rewrite, incremental save, JS/form runtime, signature-preserving rewrite, persistent object IDs, or multithreaded handle semantics.
 
 ## 23. Completion criterion
 
-MediaBox Physical Trim V1 is complete only when one exact feature head proves all of the following:
+Complete only when one exact feature head proves:
 
 - immutable source -> immutable output;
 - shrink-only public MediaBox input;
-- correct PDF/public inverse mapping under Rotate/UserUnit;
-- no-CropBox fallback re-anchors output page space correctly;
-- preserved CropBox keeps its frame and can produce non-zero output visible bounds;
-- physical-only trim is distinguishable from CropBox crop;
-- raw Crop/Bleed/Trim/Art keys remain untouched;
+- correct source inverse mapping under Rotate/UserUnit;
+- no-CropBox fallback re-anchor;
+- physical-only real-CropBox trim keeps effective frame unchanged;
+- clipping real-CropBox trim re-anchors to new effective intersection;
+- raw Crop/Bleed/Trim/Art untouched;
 - only changed pages receive local MediaBox;
-- complete interactive/document-root graph remains structurally coherent;
+- interactive/root graph remains coherent;
 - deterministic/no-op/failure-atomic batch behavior;
-- 23/23 static + sanitizer tests;
-- same-SHA Linux/macOS/Windows proof;
-- no Critical/Important architecture blocker;
-- explicit integration authorization followed by integrated-master proof.
+- 23/23 static + sanitizer;
+- same-SHA Linux/macOS/Windows;
+- no Critical/Important blocker;
+- explicit integration authorization + integrated-master proof.
 
 Only after this page-box foundation is integrated should Phase 6 proceed to poster split.

--- a/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
+++ b/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md
@@ -194,6 +194,8 @@ output visible page origin     = (0,0)
 
 subject to Rotate/UserUnit orientation and scaling.
 
+The source request rectangle is expressed in the **source** page frame. Its x0/y0 coordinates are therefore not required to survive as output public coordinates in this fallback case. Only the requested physical region and its public dimensions survive; reopening establishes the new page frame at `(0,0)`.
+
 Existing content/annotation/link/widget/destination geometry is **not rewritten in PDF space**; its public coordinates change because the page transform changed.
 
 ### 5.2 Local or inherited CropBox exists
@@ -219,6 +221,8 @@ normalize(transform(output_visible_pdf, existing pdf_to_public))
 ```
 
 and **need not begin at `(0,0)`**.
+
+In this preserved-frame case, the output public MediaBox rectangle is observed in the same page frame as the source request, so a successfully written MediaBox is expected to correspond to the requested public rectangle subject only to the exact numeric mapping contract.
 
 This non-zero-origin behavior is a required regression test. V1 must not secretly rewrite CropBox merely to re-origin the page.
 
@@ -267,15 +271,17 @@ Therefore changing MediaBox may change their **effective region** without changi
 V1 explicitly permits this derived effect.
 
 - absent Bleed/Trim/Art keys remain absent;
-- explicit keys remain byte/structure-equivalent at the semantic-object level;
+- explicit keys remain semantically/structurally unchanged;
 - V1 does not reject a trim merely because one of these production boxes would have a reduced or empty effective region;
 - V1 only requires a positive post-trim effective CropBox intersection because that defines ExtractPDF's visible page contract.
+
+These three keys are **opaque preservation state** for this slice. V1 does not parse or validate their values as part of trim preflight because it does not consume them to compute MediaBox or visible-page semantics. A malformed explicit BleedBox/TrimBox/ArtBox that the source PDF can otherwise open is preserved unchanged rather than normalized, repaired, or converted into a trim-specific status.
 
 A future production-printing-box API may impose stronger rules. This trim primitive does not silently invent them.
 
 ## 7. Strict page-box preflight
 
-Transformation is stricter than tolerant rendering.
+Transformation is stricter than tolerant rendering for the state it actually consumes.
 
 Before any source serialization/private write, each requested page must satisfy:
 
@@ -291,11 +297,13 @@ Before any source serialization/private write, each requested page must satisfy:
 - page-local `/UserUnit`, when present, is finite and strictly positive;
 - public MediaBox and visible rectangles derived from the strict raw model are finite and positive-area.
 
-Malformed structure returns `EXTRACTPDF_ERROR_FORMAT`.
+BleedBox/TrimBox/ArtBox are deliberately excluded from this strict consumed-state validation per §6.
+
+Malformed consumed structure returns `EXTRACTPDF_ERROR_FORMAT`.
 
 Structurally valid inheritance depth greater than 256 returns `EXTRACTPDF_ERROR_UNSUPPORTED`.
 
-The validator must not rely on MuPDF silently substituting Letter-size/unit rectangles for malformed or empty boxes.
+The validator must not rely on MuPDF silently substituting Letter-size/unit rectangles for malformed or empty MediaBox/CropBox values.
 
 ## 8. Rotate and UserUnit
 
@@ -374,6 +382,18 @@ new immutable extractpdf_output
 ```
 
 No `pdf_obj *`, `pdf_page *`, annotation pointer, Widget pointer, editor ref, or other MuPDF identity crosses from source context into private context.
+
+Private-plan consistency is checked **before the first write**. At minimum, reparsing must preserve for each request:
+
+- target page index;
+- valid MediaBox/CropBox consumed structure;
+- whether CropBox is truly present versus MediaBox fallback;
+- effective Rotate/UserUnit semantics;
+- inverse-mapped requested raw MediaBox containment;
+- changed/no-op classification;
+- positive post-trim visible intersection when CropBox is present.
+
+A private canonical reparse that changes one of these consumed semantics is `EXTRACTPDF_ERROR_FORMAT`; the implementation must not continue by silently accepting a different plan.
 
 `pdf_graft_mapped_page()` is prohibited; this is transform preservation, not composition.
 
@@ -462,7 +482,7 @@ For a page with no local/inherited CropBox:
 1. MediaBox changes to the requested physical region;
 2. output CropBox follows MediaBox by fallback;
 3. output visible page dimensions match the requested physical dimensions;
-4. output visible/public MediaBox origin is `(0,0)`;
+4. output visible/public MediaBox origin is `(0,0)` rather than preserving the source request x0/y0;
 5. render is clipped to the new medium;
 6. text/image/link/annotation/widget coordinates change according to the newly re-anchored page transform;
 7. internal destination resolution on a trimmed target page follows the target page's new transform;
@@ -506,7 +526,7 @@ A physical MediaBox change that leaves visible CropBox behavior unchanged is **n
 
 If every request is a no-op:
 
-1. validate the full batch, including security and page structure;
+1. validate the full batch, including security and consumed page structure;
 2. run the existing deterministic source serialization exactly once;
 3. return those bytes directly;
 4. do not open a private PDF graph;
@@ -546,6 +566,8 @@ Use existing public status values only.
 - invalid inherited Rotate representation;
 - invalid page-local UserUnit;
 - private reparse produces a structurally inconsistent target page or changed plan.
+
+Malformed BleedBox/TrimBox/ArtBox are not trim-specific `FORMAT` conditions because V1 does not consume those values; they follow the opaque preservation policy in §6.
 
 ### `EXTRACTPDF_ERROR_UNSUPPORTED`
 
@@ -607,6 +629,8 @@ src/pdf_trim.c
 
 The common unit must remain read-only. It performs no dictionary writes and owns no transform orchestration.
 
+It consumes only MediaBox/CropBox/Rotate/UserUnit state needed by the two transforms; it must not start parsing Bleed/Trim/Art merely because those names are also page boxes.
+
 CropBox implementation should be migrated only as necessary to consume this shared resolver; its public behavior and already-proven 22nd CTest contract must remain unchanged.
 
 No generic `transform options` struct, transform registry, visitor framework, or arbitrary page-box rewrite API is authorized.
@@ -643,7 +667,7 @@ The first strict RED occurs before any trim production implementation:
 
 The final trim target must cover at least:
 
-1. **no CropBox fallback** — changed MediaBox becomes both physical and visible region, with output origin re-anchored;
+1. **no CropBox fallback** — changed MediaBox becomes both physical and visible region, with output origin re-anchored and source request x0/y0 not preserved as output origin;
 2. **explicit CropBox, physical-only trim** — MediaBox shrinks but still contains CropBox; visible page and object coordinates remain unchanged;
 3. **explicit CropBox, clipping trim** — MediaBox clips part of CropBox; raw CropBox unchanged and public visible bounds become smaller/non-zero;
 4. **inherited CropBox** — same preserved-frame semantics without materializing CropBox;
@@ -652,7 +676,7 @@ The final trim target must cover at least:
 7. **raw CropBox outside MediaBox** — valid source intersection and deterministic further MediaBox shrink;
 8. **Rotate 90**;
 9. **non-default page-local UserUnit**;
-10. **explicit BleedBox/TrimBox/ArtBox** — raw entries unchanged;
+10. **explicit BleedBox/TrimBox/ArtBox** — raw entries unchanged, including opaque preservation rather than normalization;
 11. **absent BleedBox/TrimBox/ArtBox** — keys remain absent;
 12. **two-page interactive preservation** — text, image, URI link, internal link, ordinary annotation, Widget + AcroForm value, outline destination;
 13. **object outside new MediaBox** — remains structurally enumerable;
@@ -686,7 +710,7 @@ Allowed assertions include:
 - changed inherited MediaBox does not modify ancestor;
 - no-op inherited MediaBox remains inherited;
 - raw explicit/inherited CropBox remains unchanged and is not materialized locally merely by trim;
-- explicit Bleed/Trim/Art entries remain semantically equal;
+- explicit Bleed/Trim/Art entries remain semantically equal without repair/normalization;
 - absent Bleed/Trim/Art entries remain absent;
 - Contents/Resources/Annots/AcroForm/Outlines/Names/Dests structures remain semantically preserved.
 

--- a/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md
+++ b/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md
@@ -1,0 +1,429 @@
+# ExtractPDF MediaBox Trim V1 Page-Frame Correction
+
+Issue: #51  
+Normative amendment to: `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md`  
+Baseline master: `3fc48b5fb0f7a07926f7942fc4a4a3fb5e93a753`  
+MuPDF baseline: 1.28.2
+
+## Status
+
+This document is a **normative correction** to the committed MediaBox Physical Trim V1 design. It takes precedence wherever the original spec says that preserving a raw `/CropBox` necessarily preserves the same public page frame after `/MediaBox` clips that CropBox, or says that the post-trim public visible rectangle may retain a non-zero origin.
+
+No public API, ownership model, write-surface policy, security policy, batch policy, or physical-trim scope changes. The correction is limited to the page-frame semantics that result from MuPDF's effective CropBox/MediaBox intersection.
+
+No RED or production implementation has started, so this correction is applied before implementation planning.
+
+## 1. Counterexample in the approved design
+
+The approved spec distinguished:
+
+```text
+raw MediaBox  = [0, 0, 400, 300]
+raw CropBox   = [50, 40, 350, 260]
+```
+
+and correctly observed that the source public MediaBox may extend outside the visible page frame.
+
+The incorrect claim was that after shrinking MediaBox so that it clips the preserved raw CropBox:
+
+```text
+new MediaBox intersects only part of preserved CropBox
+```
+
+MuPDF would continue to anchor the public page frame to the original raw CropBox.
+
+That would imply a non-zero public visible rectangle after trim. MuPDF 1.28.2 does not behave that way.
+
+## 2. MuPDF 1.28.2 behavior
+
+`pdf_page_obj_transform_box()` resolves the page's MediaBox and CropBox and, before establishing the page origin, performs:
+
+```c
+cropbox = pdf_to_rect(ctx, obj);
+cropbox = fz_intersect_rect(cropbox, mediabox);
+```
+
+It then transforms that **effective intersection** and translates its top-left corner to the Fitz page origin:
+
+```c
+cropbox = fz_transform_rect(cropbox, *page_ctm);
+*page_ctm = fz_concat(
+    *page_ctm,
+    fz_translate(-cropbox.x0, -cropbox.y0));
+```
+
+Therefore ExtractPDF must model the public page frame as anchored to the **effective visible CropBox intersection**, not blindly to the preserved raw CropBox object.
+
+This is consistent with the already-integrated CropBox V1 project invariant:
+
+```text
+PDF user space --pdf_to_public--> ExtractPDF/Fitz page space
+ExtractPDF/Fitz page space --inverse(pdf_to_public)--> PDF user space
+```
+
+The source `pdf_to_public` matrix is valid for mapping the caller's request into raw PDF coordinates. After `/MediaBox` is changed, reopening the output may produce a different `pdf_to_public` matrix because the effective CropBox intersection may have changed.
+
+## 3. Corrected page-frame invariant
+
+Strict source resolution remains:
+
+```text
+media_pdf = normalized(nearest local/inherited MediaBox)
+
+if a real local/inherited CropBox exists:
+    has_crop_box = true
+    crop_pdf = normalized(nearest local/inherited CropBox)
+else:
+    has_crop_box = false
+    crop_pdf = media_pdf
+
+visible_pdf = intersection(media_pdf, crop_pdf)
+```
+
+`visible_pdf` must have positive area.
+
+For a requested physical trim:
+
+```text
+requested_public
+    -- inverse(source pdf_to_public) -->
+requested_media_pdf
+```
+
+After the write, define the **post-trim effective visible box** as:
+
+```text
+if has_crop_box:
+    output_visible_pdf = intersection(requested_media_pdf, crop_pdf)
+else:
+    output_visible_pdf = requested_media_pdf
+```
+
+`output_visible_pdf` must have positive area.
+
+When the output is reopened, MuPDF derives a new page transform whose origin is anchored to `output_visible_pdf` after Rotate/UserUnit processing.
+
+## 4. Output visible origin
+
+For every valid output page, the public visible rectangle observed through:
+
+```c
+extractpdf_page_bounds(...)
+extractpdf_page_box_bounds(..., EXTRACTPDF_PAGE_BOX_CROP, ...)
+```
+
+is anchored at the current effective visible page origin.
+
+For deterministic unrotated/UserUnit=1 fixtures this means:
+
+```text
+output visible public bounds = [0, 0, width, height]
+```
+
+where width/height are the dimensions of `output_visible_pdf` after the normal page transform.
+
+The MediaBox trim spec must **not** require a non-zero public visible x0/y0 after clipping a preserved CropBox.
+
+The useful non-zero rectangle is instead the **public MediaBox** relative to the effective visible frame. A MediaBox that extends outside the effective CropBox may legitimately have negative or non-zero public coordinates.
+
+## 5. Three distinct cases
+
+### 5.1 No real CropBox: fallback follows MediaBox
+
+Source:
+
+```text
+has_crop_box = false
+crop_pdf = media_pdf by fallback
+```
+
+After changing MediaBox:
+
+```text
+output_media_pdf   = requested_media_pdf
+output_visible_pdf = requested_media_pdf
+```
+
+The output page frame re-anchors to the new MediaBox.
+
+Observable result:
+
+```text
+output visible origin  = (0,0)
+output CropBox fallback = output MediaBox
+```
+
+Source request x0/y0 are coordinates in the source frame and are not preserved as output public x0/y0.
+
+### 5.2 Real CropBox, physical-only MediaBox trim
+
+If:
+
+```text
+intersection(requested_media_pdf, crop_pdf)
+    == source visible_pdf
+```
+
+then the effective visible box is unchanged.
+
+Observable result:
+
+```text
+MediaBox changes
+raw CropBox unchanged
+visible box unchanged
+page transform unchanged
+ordinary public object geometry unchanged
+```
+
+This remains a real transform because `/MediaBox` changed. It is not a no-op.
+
+### 5.3 Real CropBox, MediaBox clips the effective visible box
+
+If:
+
+```text
+intersection(requested_media_pdf, crop_pdf)
+    != source visible_pdf
+```
+
+but the new intersection still has positive area, the trim is valid.
+
+Observable result:
+
+```text
+raw CropBox unchanged
+output visible PDF box = new MediaBox ∩ raw CropBox
+output page frame re-anchors to that new effective intersection
+output visible public origin = (0,0)
+object PDF geometry unchanged
+object public geometry changes only through the new page transform
+```
+
+The implementation must not preserve the old public frame by rewriting CropBox or translating individual objects.
+
+## 6. Worked example
+
+Source raw boxes:
+
+```text
+MediaBox = [0, 0, 400, 300]
+CropBox  = [50, 40, 350, 260]
+Rotate   = 0
+UserUnit = 1
+```
+
+Source effective visible PDF box:
+
+```text
+[50, 40, 350, 260]
+```
+
+Source public observations are approximately:
+
+```text
+visible public = [0, 0, 300, 220]
+MediaBox public extends beyond that visible frame
+```
+
+### Physical-only request
+
+Choose a new MediaBox that still contains the source effective visible box, for example raw:
+
+```text
+[20, 20, 380, 280]
+```
+
+Then:
+
+```text
+intersection(new MediaBox, CropBox)
+    = [50, 40, 350, 260]
+```
+
+so the public page frame and ordinary object coordinates remain unchanged.
+
+### Clipping request
+
+Choose a new MediaBox whose intersection with CropBox is smaller, for example raw:
+
+```text
+[20, 20, 380, 220]
+```
+
+Then:
+
+```text
+output visible PDF = [50, 40, 350, 220]
+```
+
+MuPDF re-anchors the output page transform to that new effective box. The output visible public rectangle begins at `(0,0)` and has the new visible dimensions.
+
+The output public MediaBox may still extend outside that visible frame because its raw x/y extent is larger than the effective intersection. That is where negative/non-zero public MediaBox coordinates are expected and should be tested.
+
+## 7. Corrected request/output relationship
+
+The caller's request remains defined in the **source** public MediaBox frame:
+
+```c
+extractpdf_page_box_bounds(
+    source_page,
+    EXTRACTPDF_PAGE_BOX_MEDIA,
+    &source_media_public);
+```
+
+The request must be a finite positive-area subrectangle of that source MediaBox.
+
+The implementation maps it with the **source** inverse page transform to `requested_media_pdf` and writes only that raw rectangle.
+
+The output public MediaBox is then derived from the **output** page transform. Consequently:
+
+- when the effective visible box is unchanged, source and output frames are the same and the output MediaBox corresponds to the requested source public rectangle;
+- when the effective visible box changes, the output frame re-anchors and the output MediaBox public coordinates are not required to equal the source request coordinates;
+- raw physical region equality is the invariant across the transform, not public-coordinate equality across different page frames.
+
+## 8. Corrected preservation observations
+
+The deterministic suite must distinguish frame-preserving and frame-changing MediaBox trims.
+
+### Required frame-preserving case
+
+A real/inherited CropBox exists and the new MediaBox still leaves the source effective visible intersection unchanged.
+
+Prove:
+
+```text
+raw MediaBox changed
+raw CropBox unchanged
+visible public bounds unchanged
+text/image/link/annotation/Widget public geometry unchanged
+internal/outline target public coordinates unchanged on that target page
+```
+
+### Required frame-changing case
+
+A real/inherited CropBox exists and the new MediaBox clips the effective visible intersection.
+
+Prove:
+
+```text
+raw MediaBox changed
+raw CropBox unchanged
+output visible public bounds start at (0,0)
+output visible dimensions shrink
+page transform changes
+text/image/link/annotation/Widget public geometry follows the new transform
+internal/outline target public coordinates follow the target page's new transform
+no underlying object geometry is rewritten
+```
+
+Also prove at least one case where:
+
+```text
+output MediaBox public bounds
+```
+
+have negative/non-zero coordinates relative to the output visible frame. This replaces the incorrect requirement for non-zero **visible** bounds.
+
+## 9. Raw CropBox outside MediaBox
+
+The correction also applies when the preserved raw CropBox extends outside MediaBox.
+
+Source validity remains based on:
+
+```text
+source visible = source MediaBox ∩ raw CropBox
+```
+
+After trim:
+
+```text
+output visible = requested MediaBox ∩ raw CropBox
+```
+
+Frame-preserving/no-frame-change is determined by equality of the **effective intersections**, not by whether requested MediaBox contains the entire raw CropBox object.
+
+This distinction is mandatory for the existing CropBox-outside-MediaBox regression fixture.
+
+## 10. Impact on no-op semantics
+
+No-op semantics are unchanged.
+
+A MediaBox request is a no-op only when it equals the current public MediaBox rectangle component-wise under the source frame.
+
+A changed MediaBox that leaves `output_visible_pdf == source_visible_pdf` remains a real physical-only trim, even though the page transform and visible observations stay unchanged.
+
+## 11. Impact on private preflight
+
+The future shared page-box resolver still exposes:
+
+```text
+media_pdf
+crop_pdf
+visible_pdf
+has_crop_box
+pdf_to_public
+media_public
+visible_public
+Rotate/UserUnit
+```
+
+Trim planning additionally computes:
+
+```text
+requested_media_pdf
+output_visible_pdf
+frame_changes = output_visible_pdf != source visible_pdf
+```
+
+The future private reparse consistency check must reproduce the same:
+
+- CropBox provenance;
+- source effective visible intersection;
+- requested raw MediaBox containment;
+- post-trim effective visible intersection;
+- changed/no-op classification;
+- frame-preserving versus frame-changing classification.
+
+All checks occur before the first private write.
+
+## 12. Unchanged policies
+
+The following approved requirements remain unchanged:
+
+- public API is `extractpdf_page_trim` + `extractpdf_trim_pages()`;
+- source is immutable;
+- output is independent immutable bytes;
+- V1 is shrink-only against source MediaBox;
+- only changed pages receive a local `/MediaBox`;
+- `/CropBox`, `/BleedBox`, `/TrimBox`, `/ArtBox`, `/Rotate`, `/UserUnit`, content/resources/interactive/root objects are never written as side effects;
+- Bleed/Trim/Art are opaque preservation state and are not trim-preflight inputs;
+- objects outside the new medium remain in the graph;
+- no page grafting;
+- no content/object geometry rewrite;
+- no JavaScript/form runtime or appearance regeneration;
+- encrypted and signed input fail closed;
+- no-op canonical serialization and deterministic batch behavior remain required;
+- 22 -> 23 CTests;
+- exact-head Linux static + ASan/UBSan and same-SHA Linux/macOS/Windows proof remain required;
+- explicit integration authorization and integrated-master proof remain required.
+
+## 13. Implementation-planning gate
+
+The implementation plan must use this corrected model. In particular it must not encode either of these rejected assumptions:
+
+```text
+preserved raw CropBox => public page frame always unchanged
+
+MediaBox clips CropBox => output visible public origin may stay non-zero
+```
+
+Instead it must explicitly test both:
+
+```text
+physical-only MediaBox trim => effective visible intersection unchanged => frame unchanged
+
+clipping MediaBox trim => effective visible intersection changed => frame re-anchored
+```
+
+Implementation planning remains blocked until this correction is reviewed and approved.

--- a/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md
+++ b/docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md
@@ -7,43 +7,26 @@ MuPDF baseline: 1.28.2
 
 ## Status
 
-This document is a **normative correction** to the committed MediaBox Physical Trim V1 design. It takes precedence wherever the original spec says that preserving a raw `/CropBox` necessarily preserves the same public page frame after `/MediaBox` clips that CropBox, or says that the post-trim public visible rectangle may retain a non-zero origin.
+This file records the architecture correction discovered during implementation-plan self-review. The main MediaBox trim design spec has now been consolidated to match this correction; this document remains the explicit counterexample/evidence record.
 
-No public API, ownership model, write-surface policy, security policy, batch policy, or physical-trim scope changes. The correction is limited to the page-frame semantics that result from MuPDF's effective CropBox/MediaBox intersection.
+No RED or production implementation had started when the correction was found.
 
-No RED or production implementation has started, so this correction is applied before implementation planning.
+## 1. Rejected assumption
 
-## 1. Counterexample in the approved design
+The earlier draft assumed that preserving a raw `/CropBox` also preserved the same public page frame when a new `/MediaBox` clipped that CropBox, producing a non-zero public visible origin.
 
-The approved spec distinguished:
+That is false for MuPDF 1.28.2.
 
-```text
-raw MediaBox  = [0, 0, 400, 300]
-raw CropBox   = [50, 40, 350, 260]
-```
+## 2. MuPDF behavior
 
-and correctly observed that the source public MediaBox may extend outside the visible page frame.
-
-The incorrect claim was that after shrinking MediaBox so that it clips the preserved raw CropBox:
-
-```text
-new MediaBox intersects only part of preserved CropBox
-```
-
-MuPDF would continue to anchor the public page frame to the original raw CropBox.
-
-That would imply a non-zero public visible rectangle after trim. MuPDF 1.28.2 does not behave that way.
-
-## 2. MuPDF 1.28.2 behavior
-
-`pdf_page_obj_transform_box()` resolves the page's MediaBox and CropBox and, before establishing the page origin, performs:
+Before establishing the page origin, `pdf_page_obj_transform_box()` computes:
 
 ```c
 cropbox = pdf_to_rect(ctx, obj);
 cropbox = fz_intersect_rect(cropbox, mediabox);
 ```
 
-It then transforms that **effective intersection** and translates its top-left corner to the Fitz page origin:
+and then anchors the page transform to that effective intersection:
 
 ```c
 cropbox = fz_transform_rect(cropbox, *page_ctm);
@@ -52,45 +35,34 @@ cropbox = fz_transform_rect(cropbox, *page_ctm);
     fz_translate(-cropbox.x0, -cropbox.y0));
 ```
 
-Therefore ExtractPDF must model the public page frame as anchored to the **effective visible CropBox intersection**, not blindly to the preserved raw CropBox object.
+Therefore the public frame is anchored to the **effective visible CropBox/MediaBox intersection**, not blindly to the preserved raw CropBox object.
 
-This is consistent with the already-integrated CropBox V1 project invariant:
-
-```text
-PDF user space --pdf_to_public--> ExtractPDF/Fitz page space
-ExtractPDF/Fitz page space --inverse(pdf_to_public)--> PDF user space
-```
-
-The source `pdf_to_public` matrix is valid for mapping the caller's request into raw PDF coordinates. After `/MediaBox` is changed, reopening the output may produce a different `pdf_to_public` matrix because the effective CropBox intersection may have changed.
-
-## 3. Corrected page-frame invariant
+## 3. Correct invariant
 
 Strict source resolution remains:
 
 ```text
-media_pdf = normalized(nearest local/inherited MediaBox)
+media_pdf = normalized(effective MediaBox)
 
-if a real local/inherited CropBox exists:
+if a real CropBox exists:
     has_crop_box = true
-    crop_pdf = normalized(nearest local/inherited CropBox)
+    crop_pdf = normalized(effective raw CropBox)
 else:
     has_crop_box = false
     crop_pdf = media_pdf
 
-visible_pdf = intersection(media_pdf, crop_pdf)
+source_visible_pdf = intersection(media_pdf, crop_pdf)
 ```
 
-`visible_pdf` must have positive area.
-
-For a requested physical trim:
+A request is supplied in source public page space and maps through:
 
 ```text
 requested_public
-    -- inverse(source pdf_to_public) -->
+  -- inverse(source pdf_to_public) -->
 requested_media_pdf
 ```
 
-After the write, define the **post-trim effective visible box** as:
+Post-trim:
 
 ```text
 if has_crop_box:
@@ -99,331 +71,91 @@ else:
     output_visible_pdf = requested_media_pdf
 ```
 
-`output_visible_pdf` must have positive area.
+The output page transform is derived from `output_visible_pdf` after Rotate/UserUnit processing.
 
-When the output is reopened, MuPDF derives a new page transform whose origin is anchored to `output_visible_pdf` after Rotate/UserUnit processing.
+## 4. Three required cases
 
-## 4. Output visible origin
-
-For every valid output page, the public visible rectangle observed through:
-
-```c
-extractpdf_page_bounds(...)
-extractpdf_page_box_bounds(..., EXTRACTPDF_PAGE_BOX_CROP, ...)
-```
-
-is anchored at the current effective visible page origin.
-
-For deterministic unrotated/UserUnit=1 fixtures this means:
+### No real CropBox
 
 ```text
-output visible public bounds = [0, 0, width, height]
-```
-
-where width/height are the dimensions of `output_visible_pdf` after the normal page transform.
-
-The MediaBox trim spec must **not** require a non-zero public visible x0/y0 after clipping a preserved CropBox.
-
-The useful non-zero rectangle is instead the **public MediaBox** relative to the effective visible frame. A MediaBox that extends outside the effective CropBox may legitimately have negative or non-zero public coordinates.
-
-## 5. Three distinct cases
-
-### 5.1 No real CropBox: fallback follows MediaBox
-
-Source:
-
-```text
-has_crop_box = false
-crop_pdf = media_pdf by fallback
-```
-
-After changing MediaBox:
-
-```text
-output_media_pdf   = requested_media_pdf
 output_visible_pdf = requested_media_pdf
 ```
 
-The output page frame re-anchors to the new MediaBox.
+The output frame re-anchors to the new MediaBox. For deterministic unrotated/UserUnit=1 fixtures, visible public bounds start at `(0,0)`.
 
-Observable result:
-
-```text
-output visible origin  = (0,0)
-output CropBox fallback = output MediaBox
-```
-
-Source request x0/y0 are coordinates in the source frame and are not preserved as output public x0/y0.
-
-### 5.2 Real CropBox, physical-only MediaBox trim
+### Real CropBox, physical-only trim
 
 If:
 
 ```text
-intersection(requested_media_pdf, crop_pdf)
-    == source visible_pdf
+output_visible_pdf == source_visible_pdf
 ```
 
-then the effective visible box is unchanged.
-
-Observable result:
+then:
 
 ```text
 MediaBox changes
 raw CropBox unchanged
-visible box unchanged
-page transform unchanged
-ordinary public object geometry unchanged
+page frame unchanged
+visible public geometry unchanged
+ordinary object public geometry unchanged
 ```
 
-This remains a real transform because `/MediaBox` changed. It is not a no-op.
+This is still a real physical trim, not a no-op.
 
-### 5.3 Real CropBox, MediaBox clips the effective visible box
+### Real CropBox, clipping trim
 
 If:
 
 ```text
-intersection(requested_media_pdf, crop_pdf)
-    != source visible_pdf
+output_visible_pdf != source_visible_pdf
 ```
 
-but the new intersection still has positive area, the trim is valid.
-
-Observable result:
+but remains positive-area, then:
 
 ```text
+MediaBox changes
 raw CropBox unchanged
-output visible PDF box = new MediaBox ∩ raw CropBox
-output page frame re-anchors to that new effective intersection
-output visible public origin = (0,0)
-object PDF geometry unchanged
-object public geometry changes only through the new page transform
+page frame re-anchors to output_visible_pdf
+visible public bounds restart at the new effective origin
+object PDF geometry remains unchanged
+object public geometry follows the new page transform
 ```
 
-The implementation must not preserve the old public frame by rewriting CropBox or translating individual objects.
+The implementation must not rewrite CropBox or individual objects to preserve the old public frame.
 
-## 6. Worked example
+## 5. Non-zero rectangle to test
 
-Source raw boxes:
+The output **visible** public rectangle should not be required to preserve a non-zero origin after clipping.
+
+Instead, test a case where the output **MediaBox public rectangle** is negative/non-zero relative to the output visible frame because MediaBox extends outside the effective CropBox intersection.
+
+## 6. Raw CropBox outside MediaBox
+
+Frame-preserving versus frame-changing classification is based on equality of effective intersections:
 
 ```text
-MediaBox = [0, 0, 400, 300]
-CropBox  = [50, 40, 350, 260]
-Rotate   = 0
-UserUnit = 1
+source_visible_pdf
+vs
+requested_media_pdf ∩ raw crop_pdf
 ```
 
-Source effective visible PDF box:
+It is not based on whether requested MediaBox contains the entire raw CropBox object.
+
+## 7. Planning consequence
+
+The implementation plan must explicitly test:
 
 ```text
-[50, 40, 350, 260]
+physical-only trim
+  => effective visible intersection unchanged
+  => frame unchanged
+
+clipping trim
+  => effective visible intersection changed
+  => frame re-anchored
 ```
 
-Source public observations are approximately:
+and must store/revalidate enough private plan state to distinguish those two cases before the first private write.
 
-```text
-visible public = [0, 0, 300, 220]
-MediaBox public extends beyond that visible frame
-```
-
-### Physical-only request
-
-Choose a new MediaBox that still contains the source effective visible box, for example raw:
-
-```text
-[20, 20, 380, 280]
-```
-
-Then:
-
-```text
-intersection(new MediaBox, CropBox)
-    = [50, 40, 350, 260]
-```
-
-so the public page frame and ordinary object coordinates remain unchanged.
-
-### Clipping request
-
-Choose a new MediaBox whose intersection with CropBox is smaller, for example raw:
-
-```text
-[20, 20, 380, 220]
-```
-
-Then:
-
-```text
-output visible PDF = [50, 40, 350, 220]
-```
-
-MuPDF re-anchors the output page transform to that new effective box. The output visible public rectangle begins at `(0,0)` and has the new visible dimensions.
-
-The output public MediaBox may still extend outside that visible frame because its raw x/y extent is larger than the effective intersection. That is where negative/non-zero public MediaBox coordinates are expected and should be tested.
-
-## 7. Corrected request/output relationship
-
-The caller's request remains defined in the **source** public MediaBox frame:
-
-```c
-extractpdf_page_box_bounds(
-    source_page,
-    EXTRACTPDF_PAGE_BOX_MEDIA,
-    &source_media_public);
-```
-
-The request must be a finite positive-area subrectangle of that source MediaBox.
-
-The implementation maps it with the **source** inverse page transform to `requested_media_pdf` and writes only that raw rectangle.
-
-The output public MediaBox is then derived from the **output** page transform. Consequently:
-
-- when the effective visible box is unchanged, source and output frames are the same and the output MediaBox corresponds to the requested source public rectangle;
-- when the effective visible box changes, the output frame re-anchors and the output MediaBox public coordinates are not required to equal the source request coordinates;
-- raw physical region equality is the invariant across the transform, not public-coordinate equality across different page frames.
-
-## 8. Corrected preservation observations
-
-The deterministic suite must distinguish frame-preserving and frame-changing MediaBox trims.
-
-### Required frame-preserving case
-
-A real/inherited CropBox exists and the new MediaBox still leaves the source effective visible intersection unchanged.
-
-Prove:
-
-```text
-raw MediaBox changed
-raw CropBox unchanged
-visible public bounds unchanged
-text/image/link/annotation/Widget public geometry unchanged
-internal/outline target public coordinates unchanged on that target page
-```
-
-### Required frame-changing case
-
-A real/inherited CropBox exists and the new MediaBox clips the effective visible intersection.
-
-Prove:
-
-```text
-raw MediaBox changed
-raw CropBox unchanged
-output visible public bounds start at (0,0)
-output visible dimensions shrink
-page transform changes
-text/image/link/annotation/Widget public geometry follows the new transform
-internal/outline target public coordinates follow the target page's new transform
-no underlying object geometry is rewritten
-```
-
-Also prove at least one case where:
-
-```text
-output MediaBox public bounds
-```
-
-have negative/non-zero coordinates relative to the output visible frame. This replaces the incorrect requirement for non-zero **visible** bounds.
-
-## 9. Raw CropBox outside MediaBox
-
-The correction also applies when the preserved raw CropBox extends outside MediaBox.
-
-Source validity remains based on:
-
-```text
-source visible = source MediaBox ∩ raw CropBox
-```
-
-After trim:
-
-```text
-output visible = requested MediaBox ∩ raw CropBox
-```
-
-Frame-preserving/no-frame-change is determined by equality of the **effective intersections**, not by whether requested MediaBox contains the entire raw CropBox object.
-
-This distinction is mandatory for the existing CropBox-outside-MediaBox regression fixture.
-
-## 10. Impact on no-op semantics
-
-No-op semantics are unchanged.
-
-A MediaBox request is a no-op only when it equals the current public MediaBox rectangle component-wise under the source frame.
-
-A changed MediaBox that leaves `output_visible_pdf == source_visible_pdf` remains a real physical-only trim, even though the page transform and visible observations stay unchanged.
-
-## 11. Impact on private preflight
-
-The future shared page-box resolver still exposes:
-
-```text
-media_pdf
-crop_pdf
-visible_pdf
-has_crop_box
-pdf_to_public
-media_public
-visible_public
-Rotate/UserUnit
-```
-
-Trim planning additionally computes:
-
-```text
-requested_media_pdf
-output_visible_pdf
-frame_changes = output_visible_pdf != source visible_pdf
-```
-
-The future private reparse consistency check must reproduce the same:
-
-- CropBox provenance;
-- source effective visible intersection;
-- requested raw MediaBox containment;
-- post-trim effective visible intersection;
-- changed/no-op classification;
-- frame-preserving versus frame-changing classification.
-
-All checks occur before the first private write.
-
-## 12. Unchanged policies
-
-The following approved requirements remain unchanged:
-
-- public API is `extractpdf_page_trim` + `extractpdf_trim_pages()`;
-- source is immutable;
-- output is independent immutable bytes;
-- V1 is shrink-only against source MediaBox;
-- only changed pages receive a local `/MediaBox`;
-- `/CropBox`, `/BleedBox`, `/TrimBox`, `/ArtBox`, `/Rotate`, `/UserUnit`, content/resources/interactive/root objects are never written as side effects;
-- Bleed/Trim/Art are opaque preservation state and are not trim-preflight inputs;
-- objects outside the new medium remain in the graph;
-- no page grafting;
-- no content/object geometry rewrite;
-- no JavaScript/form runtime or appearance regeneration;
-- encrypted and signed input fail closed;
-- no-op canonical serialization and deterministic batch behavior remain required;
-- 22 -> 23 CTests;
-- exact-head Linux static + ASan/UBSan and same-SHA Linux/macOS/Windows proof remain required;
-- explicit integration authorization and integrated-master proof remain required.
-
-## 13. Implementation-planning gate
-
-The implementation plan must use this corrected model. In particular it must not encode either of these rejected assumptions:
-
-```text
-preserved raw CropBox => public page frame always unchanged
-
-MediaBox clips CropBox => output visible public origin may stay non-zero
-```
-
-Instead it must explicitly test both:
-
-```text
-physical-only MediaBox trim => effective visible intersection unchanged => frame unchanged
-
-clipping MediaBox trim => effective visible intersection changed => frame re-anchored
-```
-
-Implementation planning remains blocked until this correction is reviewed and approved.
+All other approved policies remain unchanged: public ABI, shrink-only MediaBox input, MediaBox-only semantic write, opaque Bleed/Trim/Art preservation, full-document isolation, security fail-closed behavior, deterministic batch semantics, 22 -> 23 CTests, exact-head cross-platform proof, and explicit integration authorization.

--- a/include/extractpdf/extractpdf.h
+++ b/include/extractpdf/extractpdf.h
@@ -48,6 +48,12 @@ typedef struct extractpdf_page_crop {
     extractpdf_rect bounds;
 } extractpdf_page_crop;
 
+typedef struct extractpdf_page_trim {
+    size_t struct_size;
+    int page_index;
+    extractpdf_rect bounds;
+} extractpdf_page_trim;
+
 typedef struct extractpdf_quad {
     extractpdf_point ul;
     extractpdf_point ur;
@@ -428,6 +434,12 @@ EXTRACTPDF_API extractpdf_status extractpdf_crop_pages(
     extractpdf_document *document,
     const extractpdf_page_crop *crops,
     size_t crop_count,
+    extractpdf_output **out_output);
+
+EXTRACTPDF_API extractpdf_status extractpdf_trim_pages(
+    extractpdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
     extractpdf_output **out_output);
 
 EXTRACTPDF_API extractpdf_status extractpdf_output_data(

--- a/src/pdf_crop.c
+++ b/src/pdf_crop.c
@@ -48,7 +48,7 @@ static extractpdf_status extractpdf_pdf_crop_transform_changed(
 {
     extractpdf_output *seed = NULL;
     extractpdf_pdf_crop_plan *private_plans = NULL;
-    extractpdf_pdf_crop_page_view *private_views = NULL;
+    extractpdf_pdf_page_box_view *private_views = NULL;
     fz_context *private_ctx = NULL;
     fz_stream *stream = NULL;
     pdf_document *private_document = NULL;
@@ -111,7 +111,7 @@ static extractpdf_status extractpdf_pdf_crop_transform_changed(
     }
     private_plans = (extractpdf_pdf_crop_plan *)calloc(
         crop_count, sizeof(*private_plans));
-    private_views = (extractpdf_pdf_crop_page_view *)calloc(
+    private_views = (extractpdf_pdf_page_box_view *)calloc(
         crop_count, sizeof(*private_views));
     if (private_plans == NULL || private_views == NULL) {
         status = EXTRACTPDF_ERROR_NOMEM;
@@ -133,7 +133,7 @@ static extractpdf_status extractpdf_pdf_crop_transform_changed(
     }
 
     for (index = 0; index < crop_count; ++index) {
-        status = extractpdf_pdf_crop_resolve_page(
+        status = extractpdf_pdf_page_box_resolve(
             private_ctx,
             private_document,
             private_plans[index].page_index,

--- a/src/pdf_crop_internal.h
+++ b/src/pdf_crop_internal.h
@@ -1,18 +1,7 @@
 #ifndef EXTRACTPDF_PDF_CROP_INTERNAL_H
 #define EXTRACTPDF_PDF_CROP_INTERNAL_H
 
-#include "pdf_internal.h"
-
-typedef struct extractpdf_pdf_crop_page_view {
-    pdf_obj *page_obj;
-    fz_rect media_pdf;
-    fz_rect crop_pdf;
-    fz_rect visible_pdf;
-    fz_matrix pdf_to_public;
-    extractpdf_rect visible_public;
-    int rotate_degrees;
-    float user_unit;
-} extractpdf_pdf_crop_page_view;
+#include "pdf_page_box_common.h"
 
 typedef struct extractpdf_pdf_crop_plan {
     int page_index;
@@ -24,12 +13,6 @@ typedef struct extractpdf_pdf_crop_plan {
 extractpdf_status extractpdf_pdf_crop_check_security(
     fz_context *ctx,
     pdf_document *document);
-
-extractpdf_status extractpdf_pdf_crop_resolve_page(
-    fz_context *ctx,
-    pdf_document *document,
-    int page_index,
-    extractpdf_pdf_crop_page_view *out_view);
 
 extractpdf_status extractpdf_pdf_crop_build_plan(
     fz_context *ctx,

--- a/src/pdf_crop_preflight.c
+++ b/src/pdf_crop_preflight.c
@@ -2,9 +2,6 @@
 
 #include <math.h>
 #include <stddef.h>
-#include <string.h>
-
-#define EXTRACTPDF_PDF_CROP_MAX_PAGE_TREE_DEPTH 256
 
 static int extractpdf_pdf_crop_dict_has_key(
     fz_context *ctx,
@@ -107,212 +104,6 @@ extractpdf_status extractpdf_pdf_crop_check_security(
     return EXTRACTPDF_OK;
 }
 
-static extractpdf_status extractpdf_pdf_crop_parse_box(
-    fz_context *ctx,
-    pdf_obj *object,
-    fz_rect *out_rect)
-{
-    float x0;
-    float y0;
-    float x1;
-    float y1;
-
-    if (!pdf_is_array(ctx, object) || pdf_array_len(ctx, object) != 4)
-        return EXTRACTPDF_ERROR_FORMAT;
-    if (!pdf_is_number(ctx, pdf_array_get(ctx, object, 0)) ||
-        !pdf_is_number(ctx, pdf_array_get(ctx, object, 1)) ||
-        !pdf_is_number(ctx, pdf_array_get(ctx, object, 2)) ||
-        !pdf_is_number(ctx, pdf_array_get(ctx, object, 3)))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    x0 = pdf_to_real(ctx, pdf_array_get(ctx, object, 0));
-    y0 = pdf_to_real(ctx, pdf_array_get(ctx, object, 1));
-    x1 = pdf_to_real(ctx, pdf_array_get(ctx, object, 2));
-    y1 = pdf_to_real(ctx, pdf_array_get(ctx, object, 3));
-    if (!isfinite(x0) || !isfinite(y0) || !isfinite(x1) || !isfinite(y1))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    out_rect->x0 = fminf(x0, x1);
-    out_rect->y0 = fminf(y0, y1);
-    out_rect->x1 = fmaxf(x0, x1);
-    out_rect->y1 = fmaxf(y0, y1);
-    if (!(out_rect->x0 < out_rect->x1) ||
-        !(out_rect->y0 < out_rect->y1))
-        return EXTRACTPDF_ERROR_FORMAT;
-    return EXTRACTPDF_OK;
-}
-
-static int extractpdf_pdf_crop_same_object(
-    fz_context *ctx,
-    pdf_obj *left,
-    pdf_obj *right)
-{
-    return pdf_objcmp_resolve(ctx, left, right) == 0;
-}
-
-static extractpdf_status extractpdf_pdf_crop_resolve_page_imp(
-    fz_context *ctx,
-    pdf_document *document,
-    int page_index,
-    extractpdf_pdf_crop_page_view *out_view)
-{
-    pdf_obj *page_obj;
-    pdf_obj *node;
-    pdf_obj *seen[EXTRACTPDF_PDF_CROP_MAX_PAGE_TREE_DEPTH + 1];
-    size_t seen_count = 0;
-    pdf_obj *media_obj = NULL;
-    pdf_obj *crop_obj = NULL;
-    pdf_obj *rotate_obj = NULL;
-    pdf_obj *user_unit_obj;
-    fz_rect public_visible;
-    int page_count;
-    int rotate = 0;
-    float user_unit = 1.0f;
-    size_t depth;
-
-    page_count = pdf_count_pages(ctx, document);
-    if (page_index < 0 || page_index >= page_count)
-        return EXTRACTPDF_ERROR_ARGUMENT;
-
-    page_obj = pdf_lookup_page_obj(ctx, document, page_index);
-    if (!pdf_is_dict(ctx, page_obj))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    node = page_obj;
-    for (depth = 0;; ++depth) {
-        pdf_obj *parent;
-        size_t index;
-
-        if (depth > EXTRACTPDF_PDF_CROP_MAX_PAGE_TREE_DEPTH)
-            return EXTRACTPDF_ERROR_UNSUPPORTED;
-        if (!pdf_is_dict(ctx, node))
-            return EXTRACTPDF_ERROR_FORMAT;
-
-        for (index = 0; index < seen_count; ++index) {
-            if (extractpdf_pdf_crop_same_object(ctx, seen[index], node))
-                return EXTRACTPDF_ERROR_FORMAT;
-        }
-        seen[seen_count++] = node;
-
-        if (media_obj == NULL) {
-            pdf_obj *value = pdf_dict_get(ctx, node, PDF_NAME(MediaBox));
-            if (value != NULL)
-                media_obj = value;
-        }
-        if (crop_obj == NULL) {
-            pdf_obj *value = pdf_dict_get(ctx, node, PDF_NAME(CropBox));
-            if (value != NULL)
-                crop_obj = value;
-        }
-        if (rotate_obj == NULL) {
-            pdf_obj *value = pdf_dict_get(ctx, node, PDF_NAME(Rotate));
-            if (value != NULL)
-                rotate_obj = value;
-        }
-
-        parent = pdf_dict_get(ctx, node, PDF_NAME(Parent));
-        if (parent == NULL || pdf_is_null(ctx, parent))
-            break;
-        node = parent;
-    }
-
-    if (media_obj == NULL)
-        return EXTRACTPDF_ERROR_FORMAT;
-    if (extractpdf_pdf_crop_parse_box(ctx, media_obj, &out_view->media_pdf) !=
-        EXTRACTPDF_OK)
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    if (crop_obj == NULL)
-        out_view->crop_pdf = out_view->media_pdf;
-    else if (extractpdf_pdf_crop_parse_box(ctx, crop_obj, &out_view->crop_pdf) !=
-             EXTRACTPDF_OK)
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    out_view->visible_pdf.x0 = fmaxf(
-        out_view->media_pdf.x0, out_view->crop_pdf.x0);
-    out_view->visible_pdf.y0 = fmaxf(
-        out_view->media_pdf.y0, out_view->crop_pdf.y0);
-    out_view->visible_pdf.x1 = fminf(
-        out_view->media_pdf.x1, out_view->crop_pdf.x1);
-    out_view->visible_pdf.y1 = fminf(
-        out_view->media_pdf.y1, out_view->crop_pdf.y1);
-    if (!(out_view->visible_pdf.x0 < out_view->visible_pdf.x1) ||
-        !(out_view->visible_pdf.y0 < out_view->visible_pdf.y1))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    if (rotate_obj != NULL) {
-        if (!pdf_is_int(ctx, rotate_obj))
-            return EXTRACTPDF_ERROR_FORMAT;
-        rotate = pdf_to_int(ctx, rotate_obj);
-        if (rotate % 90 != 0)
-            return EXTRACTPDF_ERROR_FORMAT;
-        rotate %= 360;
-        if (rotate < 0)
-            rotate += 360;
-    }
-
-    user_unit_obj = pdf_dict_get(ctx, page_obj, PDF_NAME(UserUnit));
-    if (user_unit_obj != NULL) {
-        if (!pdf_is_number(ctx, user_unit_obj))
-            return EXTRACTPDF_ERROR_FORMAT;
-        user_unit = pdf_to_real(ctx, user_unit_obj);
-        if (!isfinite(user_unit) || !(user_unit > 0.0f))
-            return EXTRACTPDF_ERROR_FORMAT;
-    }
-
-    pdf_page_obj_transform(
-        ctx, page_obj, NULL, &out_view->pdf_to_public);
-    public_visible = fz_transform_rect(
-        out_view->visible_pdf, out_view->pdf_to_public);
-    if (!isfinite(public_visible.x0) || !isfinite(public_visible.y0) ||
-        !isfinite(public_visible.x1) || !isfinite(public_visible.y1))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    out_view->page_obj = page_obj;
-    out_view->visible_public.x0 = fminf(public_visible.x0, public_visible.x1);
-    out_view->visible_public.y0 = fminf(public_visible.y0, public_visible.y1);
-    out_view->visible_public.x1 = fmaxf(public_visible.x0, public_visible.x1);
-    out_view->visible_public.y1 = fmaxf(public_visible.y0, public_visible.y1);
-    if (!(out_view->visible_public.x0 < out_view->visible_public.x1) ||
-        !(out_view->visible_public.y0 < out_view->visible_public.y1))
-        return EXTRACTPDF_ERROR_FORMAT;
-
-    out_view->rotate_degrees = rotate;
-    out_view->user_unit = user_unit;
-    return EXTRACTPDF_OK;
-}
-
-extractpdf_status extractpdf_pdf_crop_resolve_page(
-    fz_context *ctx,
-    pdf_document *document,
-    int page_index,
-    extractpdf_pdf_crop_page_view *out_view)
-{
-    extractpdf_status status = EXTRACTPDF_OK;
-    int caught_code = FZ_ERROR_NONE;
-
-    if (ctx == NULL || document == NULL || out_view == NULL)
-        return EXTRACTPDF_ERROR_ARGUMENT;
-    memset(out_view, 0, sizeof(*out_view));
-
-    fz_var(status);
-    fz_var(caught_code);
-    fz_try(ctx)
-    {
-        status = extractpdf_pdf_crop_resolve_page_imp(
-            ctx, document, page_index, out_view);
-    }
-    fz_catch(ctx)
-    {
-        caught_code = fz_caught(ctx);
-        fz_report_error(ctx);
-    }
-
-    if (caught_code != FZ_ERROR_NONE)
-        return extractpdf_status_from_mupdf(caught_code);
-    return status;
-}
-
 static int extractpdf_pdf_crop_finite_public_rect(extractpdf_rect rect)
 {
     return isfinite(rect.x0) && isfinite(rect.y0) &&
@@ -343,8 +134,6 @@ extractpdf_status extractpdf_pdf_crop_build_plan(
     extractpdf_pdf_crop_plan *plans,
     int *out_any_changed)
 {
-    extractpdf_status status = EXTRACTPDF_OK;
-    int caught_code = FZ_ERROR_NONE;
     size_t index;
     const size_t minimum_size =
         offsetof(extractpdf_page_crop, bounds) + sizeof(extractpdf_rect);
@@ -355,93 +144,69 @@ extractpdf_status extractpdf_pdf_crop_build_plan(
         crop_count == 0 || plans == NULL || out_any_changed == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    fz_var(status);
-    fz_var(caught_code);
-    fz_try(ctx)
-    {
-        for (index = 0; index < crop_count && status == EXTRACTPDF_OK; ++index) {
-            extractpdf_pdf_crop_page_view view;
-            fz_rect public_rect;
-            fz_rect requested_pdf;
-            fz_matrix public_to_pdf;
-            size_t prior;
+    for (index = 0; index < crop_count; ++index) {
+        extractpdf_pdf_page_box_view view;
+        fz_rect public_rect;
+        fz_rect requested_pdf;
+        fz_matrix public_to_pdf;
+        extractpdf_status status;
+        size_t prior;
 
-            if (crops[index].struct_size < minimum_size) {
-                status = EXTRACTPDF_ERROR_ARGUMENT;
-                break;
-            }
-            if (!extractpdf_pdf_crop_finite_public_rect(crops[index].bounds) ||
-                !(crops[index].bounds.x0 < crops[index].bounds.x1) ||
-                !(crops[index].bounds.y0 < crops[index].bounds.y1)) {
-                status = EXTRACTPDF_ERROR_ARGUMENT;
-                break;
-            }
-            for (prior = 0; prior < index; ++prior) {
-                if (crops[prior].page_index == crops[index].page_index) {
-                    status = EXTRACTPDF_ERROR_ARGUMENT;
-                    break;
-                }
-            }
-            if (status != EXTRACTPDF_OK)
-                break;
+        if (crops[index].struct_size < minimum_size)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        if (!extractpdf_pdf_crop_finite_public_rect(crops[index].bounds) ||
+            !(crops[index].bounds.x0 < crops[index].bounds.x1) ||
+            !(crops[index].bounds.y0 < crops[index].bounds.y1))
+            return EXTRACTPDF_ERROR_ARGUMENT;
 
-            status = extractpdf_pdf_crop_resolve_page_imp(
-                ctx, document, crops[index].page_index, &view);
-            if (status != EXTRACTPDF_OK)
-                break;
-            if (!extractpdf_pdf_crop_public_inside(
-                    crops[index].bounds, view.visible_public)) {
-                status = EXTRACTPDF_ERROR_ARGUMENT;
-                break;
-            }
-
-            plans[index].page_index = crops[index].page_index;
-            plans[index].requested_public = crops[index].bounds;
-            plans[index].changed = !extractpdf_pdf_crop_rect_equal(
-                crops[index].bounds, view.visible_public);
-
-            public_rect.x0 = crops[index].bounds.x0;
-            public_rect.y0 = crops[index].bounds.y0;
-            public_rect.x1 = crops[index].bounds.x1;
-            public_rect.y1 = crops[index].bounds.y1;
-            public_to_pdf = fz_invert_matrix(view.pdf_to_public);
-            requested_pdf = fz_transform_rect(public_rect, public_to_pdf);
-            if (!isfinite(requested_pdf.x0) || !isfinite(requested_pdf.y0) ||
-                !isfinite(requested_pdf.x1) || !isfinite(requested_pdf.y1)) {
-                status = EXTRACTPDF_ERROR_ARGUMENT;
-                break;
-            }
-
-            plans[index].requested_pdf.x0 = fminf(
-                requested_pdf.x0, requested_pdf.x1);
-            plans[index].requested_pdf.y0 = fminf(
-                requested_pdf.y0, requested_pdf.y1);
-            plans[index].requested_pdf.x1 = fmaxf(
-                requested_pdf.x0, requested_pdf.x1);
-            plans[index].requested_pdf.y1 = fmaxf(
-                requested_pdf.y0, requested_pdf.y1);
-
-            if (!(plans[index].requested_pdf.x0 < plans[index].requested_pdf.x1) ||
-                !(plans[index].requested_pdf.y0 < plans[index].requested_pdf.y1) ||
-                plans[index].requested_pdf.x0 < view.visible_pdf.x0 ||
-                plans[index].requested_pdf.y0 < view.visible_pdf.y0 ||
-                plans[index].requested_pdf.x1 > view.visible_pdf.x1 ||
-                plans[index].requested_pdf.y1 > view.visible_pdf.y1) {
-                status = EXTRACTPDF_ERROR_ARGUMENT;
-                break;
-            }
-
-            if (plans[index].changed)
-                *out_any_changed = 1;
+        for (prior = 0; prior < index; ++prior) {
+            if (crops[prior].page_index == crops[index].page_index)
+                return EXTRACTPDF_ERROR_ARGUMENT;
         }
-    }
-    fz_catch(ctx)
-    {
-        caught_code = fz_caught(ctx);
-        fz_report_error(ctx);
+
+        status = extractpdf_pdf_page_box_resolve(
+            ctx, document, crops[index].page_index, &view);
+        if (status != EXTRACTPDF_OK)
+            return status;
+        if (!extractpdf_pdf_crop_public_inside(
+                crops[index].bounds, view.visible_public))
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        plans[index].page_index = crops[index].page_index;
+        plans[index].requested_public = crops[index].bounds;
+        plans[index].changed = !extractpdf_pdf_crop_rect_equal(
+            crops[index].bounds, view.visible_public);
+
+        public_rect.x0 = crops[index].bounds.x0;
+        public_rect.y0 = crops[index].bounds.y0;
+        public_rect.x1 = crops[index].bounds.x1;
+        public_rect.y1 = crops[index].bounds.y1;
+        public_to_pdf = fz_invert_matrix(view.pdf_to_public);
+        requested_pdf = fz_transform_rect(public_rect, public_to_pdf);
+        if (!isfinite(requested_pdf.x0) || !isfinite(requested_pdf.y0) ||
+            !isfinite(requested_pdf.x1) || !isfinite(requested_pdf.y1))
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        plans[index].requested_pdf.x0 = fminf(
+            requested_pdf.x0, requested_pdf.x1);
+        plans[index].requested_pdf.y0 = fminf(
+            requested_pdf.y0, requested_pdf.y1);
+        plans[index].requested_pdf.x1 = fmaxf(
+            requested_pdf.x0, requested_pdf.x1);
+        plans[index].requested_pdf.y1 = fmaxf(
+            requested_pdf.y0, requested_pdf.y1);
+
+        if (!(plans[index].requested_pdf.x0 < plans[index].requested_pdf.x1) ||
+            !(plans[index].requested_pdf.y0 < plans[index].requested_pdf.y1) ||
+            plans[index].requested_pdf.x0 < view.visible_pdf.x0 ||
+            plans[index].requested_pdf.y0 < view.visible_pdf.y0 ||
+            plans[index].requested_pdf.x1 > view.visible_pdf.x1 ||
+            plans[index].requested_pdf.y1 > view.visible_pdf.y1)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        if (plans[index].changed)
+            *out_any_changed = 1;
     }
 
-    if (caught_code != FZ_ERROR_NONE)
-        return extractpdf_status_from_mupdf(caught_code);
-    return status;
+    return EXTRACTPDF_OK;
 }

--- a/src/pdf_page_box_common.c
+++ b/src/pdf_page_box_common.c
@@ -1,0 +1,237 @@
+#include "pdf_page_box_common.h"
+
+#include <math.h>
+#include <string.h>
+
+#define EXTRACTPDF_PDF_PAGE_BOX_MAX_PAGE_TREE_DEPTH 256
+
+static extractpdf_status extractpdf_pdf_page_box_parse_box(
+    fz_context *ctx,
+    pdf_obj *object,
+    fz_rect *out_rect)
+{
+    float x0;
+    float y0;
+    float x1;
+    float y1;
+
+    if (!pdf_is_array(ctx, object) || pdf_array_len(ctx, object) != 4)
+        return EXTRACTPDF_ERROR_FORMAT;
+    if (!pdf_is_number(ctx, pdf_array_get(ctx, object, 0)) ||
+        !pdf_is_number(ctx, pdf_array_get(ctx, object, 1)) ||
+        !pdf_is_number(ctx, pdf_array_get(ctx, object, 2)) ||
+        !pdf_is_number(ctx, pdf_array_get(ctx, object, 3)))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    x0 = pdf_to_real(ctx, pdf_array_get(ctx, object, 0));
+    y0 = pdf_to_real(ctx, pdf_array_get(ctx, object, 1));
+    x1 = pdf_to_real(ctx, pdf_array_get(ctx, object, 2));
+    y1 = pdf_to_real(ctx, pdf_array_get(ctx, object, 3));
+    if (!isfinite(x0) || !isfinite(y0) || !isfinite(x1) || !isfinite(y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    out_rect->x0 = fminf(x0, x1);
+    out_rect->y0 = fminf(y0, y1);
+    out_rect->x1 = fmaxf(x0, x1);
+    out_rect->y1 = fmaxf(y0, y1);
+    if (!(out_rect->x0 < out_rect->x1) ||
+        !(out_rect->y0 < out_rect->y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+    return EXTRACTPDF_OK;
+}
+
+static int extractpdf_pdf_page_box_same_object(
+    fz_context *ctx,
+    pdf_obj *left,
+    pdf_obj *right)
+{
+    return pdf_objcmp_resolve(ctx, left, right) == 0;
+}
+
+static extractpdf_status extractpdf_pdf_page_box_public_rect(
+    fz_rect raw,
+    fz_matrix pdf_to_public,
+    extractpdf_rect *out_public)
+{
+    fz_rect transformed = fz_transform_rect(raw, pdf_to_public);
+
+    if (!isfinite(transformed.x0) || !isfinite(transformed.y0) ||
+        !isfinite(transformed.x1) || !isfinite(transformed.y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    out_public->x0 = fminf(transformed.x0, transformed.x1);
+    out_public->y0 = fminf(transformed.y0, transformed.y1);
+    out_public->x1 = fmaxf(transformed.x0, transformed.x1);
+    out_public->y1 = fmaxf(transformed.y0, transformed.y1);
+    if (!(out_public->x0 < out_public->x1) ||
+        !(out_public->y0 < out_public->y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+    return EXTRACTPDF_OK;
+}
+
+static extractpdf_status extractpdf_pdf_page_box_resolve_imp(
+    fz_context *ctx,
+    pdf_document *document,
+    int page_index,
+    extractpdf_pdf_page_box_view *out_view)
+{
+    pdf_obj *page_obj;
+    pdf_obj *node;
+    pdf_obj *seen[EXTRACTPDF_PDF_PAGE_BOX_MAX_PAGE_TREE_DEPTH + 1];
+    size_t seen_count = 0;
+    pdf_obj *media_obj = NULL;
+    pdf_obj *crop_obj = NULL;
+    pdf_obj *rotate_obj = NULL;
+    pdf_obj *user_unit_obj;
+    int page_count;
+    int rotate = 0;
+    float user_unit = 1.0f;
+    size_t depth;
+    extractpdf_status status;
+
+    page_count = pdf_count_pages(ctx, document);
+    if (page_index < 0 || page_index >= page_count)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    page_obj = pdf_lookup_page_obj(ctx, document, page_index);
+    if (!pdf_is_dict(ctx, page_obj))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    node = page_obj;
+    for (depth = 0;; ++depth) {
+        pdf_obj *parent;
+        size_t index;
+
+        if (depth > EXTRACTPDF_PDF_PAGE_BOX_MAX_PAGE_TREE_DEPTH)
+            return EXTRACTPDF_ERROR_UNSUPPORTED;
+        if (!pdf_is_dict(ctx, node))
+            return EXTRACTPDF_ERROR_FORMAT;
+
+        for (index = 0; index < seen_count; ++index) {
+            if (extractpdf_pdf_page_box_same_object(ctx, seen[index], node))
+                return EXTRACTPDF_ERROR_FORMAT;
+        }
+        seen[seen_count++] = node;
+
+        if (media_obj == NULL) {
+            pdf_obj *value = pdf_dict_get(ctx, node, PDF_NAME(MediaBox));
+            if (value != NULL)
+                media_obj = value;
+        }
+        if (crop_obj == NULL) {
+            pdf_obj *value = pdf_dict_get(ctx, node, PDF_NAME(CropBox));
+            if (value != NULL)
+                crop_obj = value;
+        }
+        if (rotate_obj == NULL) {
+            pdf_obj *value = pdf_dict_get(ctx, node, PDF_NAME(Rotate));
+            if (value != NULL)
+                rotate_obj = value;
+        }
+
+        parent = pdf_dict_get(ctx, node, PDF_NAME(Parent));
+        if (parent == NULL || pdf_is_null(ctx, parent))
+            break;
+        node = parent;
+    }
+
+    if (media_obj == NULL)
+        return EXTRACTPDF_ERROR_FORMAT;
+    status = extractpdf_pdf_page_box_parse_box(
+        ctx, media_obj, &out_view->media_pdf);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    out_view->has_explicit_crop = crop_obj != NULL;
+    if (crop_obj == NULL) {
+        out_view->crop_pdf = out_view->media_pdf;
+    }
+    else {
+        status = extractpdf_pdf_page_box_parse_box(
+            ctx, crop_obj, &out_view->crop_pdf);
+        if (status != EXTRACTPDF_OK)
+            return status;
+    }
+
+    out_view->visible_pdf.x0 = fmaxf(
+        out_view->media_pdf.x0, out_view->crop_pdf.x0);
+    out_view->visible_pdf.y0 = fmaxf(
+        out_view->media_pdf.y0, out_view->crop_pdf.y0);
+    out_view->visible_pdf.x1 = fminf(
+        out_view->media_pdf.x1, out_view->crop_pdf.x1);
+    out_view->visible_pdf.y1 = fminf(
+        out_view->media_pdf.y1, out_view->crop_pdf.y1);
+    if (!(out_view->visible_pdf.x0 < out_view->visible_pdf.x1) ||
+        !(out_view->visible_pdf.y0 < out_view->visible_pdf.y1))
+        return EXTRACTPDF_ERROR_FORMAT;
+
+    if (rotate_obj != NULL) {
+        if (!pdf_is_int(ctx, rotate_obj))
+            return EXTRACTPDF_ERROR_FORMAT;
+        rotate = pdf_to_int(ctx, rotate_obj);
+        if (rotate % 90 != 0)
+            return EXTRACTPDF_ERROR_FORMAT;
+        rotate %= 360;
+        if (rotate < 0)
+            rotate += 360;
+    }
+
+    user_unit_obj = pdf_dict_get(ctx, page_obj, PDF_NAME(UserUnit));
+    if (user_unit_obj != NULL) {
+        if (!pdf_is_number(ctx, user_unit_obj))
+            return EXTRACTPDF_ERROR_FORMAT;
+        user_unit = pdf_to_real(ctx, user_unit_obj);
+        if (!isfinite(user_unit) || !(user_unit > 0.0f))
+            return EXTRACTPDF_ERROR_FORMAT;
+    }
+
+    pdf_page_obj_transform(
+        ctx, page_obj, NULL, &out_view->pdf_to_public);
+
+    status = extractpdf_pdf_page_box_public_rect(
+        out_view->media_pdf, out_view->pdf_to_public,
+        &out_view->media_public);
+    if (status != EXTRACTPDF_OK)
+        return status;
+    status = extractpdf_pdf_page_box_public_rect(
+        out_view->visible_pdf, out_view->pdf_to_public,
+        &out_view->visible_public);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    out_view->page_obj = page_obj;
+    out_view->rotate_degrees = rotate;
+    out_view->user_unit = user_unit;
+    return EXTRACTPDF_OK;
+}
+
+extractpdf_status extractpdf_pdf_page_box_resolve(
+    fz_context *ctx,
+    pdf_document *document,
+    int page_index,
+    extractpdf_pdf_page_box_view *out_view)
+{
+    extractpdf_status status = EXTRACTPDF_OK;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (ctx == NULL || document == NULL || out_view == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    memset(out_view, 0, sizeof(*out_view));
+
+    fz_var(status);
+    fz_var(caught_code);
+    fz_try(ctx)
+    {
+        status = extractpdf_pdf_page_box_resolve_imp(
+            ctx, document, page_index, out_view);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    return status;
+}

--- a/src/pdf_page_box_common.h
+++ b/src/pdf_page_box_common.h
@@ -1,0 +1,25 @@
+#ifndef EXTRACTPDF_PDF_PAGE_BOX_COMMON_H
+#define EXTRACTPDF_PDF_PAGE_BOX_COMMON_H
+
+#include "pdf_internal.h"
+
+typedef struct extractpdf_pdf_page_box_view {
+    pdf_obj *page_obj;
+    fz_rect media_pdf;
+    fz_rect crop_pdf;
+    fz_rect visible_pdf;
+    fz_matrix pdf_to_public;
+    extractpdf_rect media_public;
+    extractpdf_rect visible_public;
+    int has_explicit_crop;
+    int rotate_degrees;
+    float user_unit;
+} extractpdf_pdf_page_box_view;
+
+extractpdf_status extractpdf_pdf_page_box_resolve(
+    fz_context *ctx,
+    pdf_document *document,
+    int page_index,
+    extractpdf_pdf_page_box_view *out_view);
+
+#endif

--- a/src/pdf_trim.c
+++ b/src/pdf_trim.c
@@ -1,4 +1,7 @@
-#include "internal.h"
+#include "pdf_trim_internal.h"
+
+#include <stdint.h>
+#include <stdlib.h>
 
 extractpdf_status extractpdf_trim_pages(
     extractpdf_document *document,
@@ -6,12 +9,50 @@ extractpdf_status extractpdf_trim_pages(
     size_t trim_count,
     extractpdf_output **out_output)
 {
+    pdf_document *source_pdf;
+    extractpdf_pdf_trim_plan *plans = NULL;
+    extractpdf_status status;
+    int any_changed = 0;
+
     if (out_output == NULL)
         return EXTRACTPDF_ERROR_ARGUMENT;
     *out_output = NULL;
 
-    if (document == NULL || trims == NULL || trim_count == 0)
+    if (document == NULL || document->ctx == NULL || document->doc == NULL ||
+        trims == NULL || trim_count == 0)
         return EXTRACTPDF_ERROR_ARGUMENT;
 
-    return EXTRACTPDF_ERROR_UNSUPPORTED;
+    source_pdf = pdf_document_from_fz_document(document->ctx, document->doc);
+    if (source_pdf == NULL)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+
+    status = extractpdf_pdf_trim_check_security(document->ctx, source_pdf);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    if (trim_count > SIZE_MAX / sizeof(*plans))
+        return EXTRACTPDF_ERROR_NOMEM;
+    plans = (extractpdf_pdf_trim_plan *)calloc(trim_count, sizeof(*plans));
+    if (plans == NULL)
+        return EXTRACTPDF_ERROR_NOMEM;
+
+    status = extractpdf_pdf_trim_build_plan(
+        document->ctx,
+        source_pdf,
+        trims,
+        trim_count,
+        plans,
+        &any_changed);
+    if (status == EXTRACTPDF_OK) {
+        if (any_changed) {
+            status = EXTRACTPDF_ERROR_UNSUPPORTED;
+        }
+        else {
+            status = extractpdf_serialize_pdf(
+                document->ctx, source_pdf, out_output);
+        }
+    }
+
+    free(plans);
+    return status;
 }

--- a/src/pdf_trim.c
+++ b/src/pdf_trim.c
@@ -1,7 +1,249 @@
 #include "pdf_trim_internal.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
+
+static void extractpdf_pdf_trim_discard_log(
+    void *user,
+    const char *message)
+{
+    (void)user;
+    (void)message;
+}
+
+static int extractpdf_pdf_trim_close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.001f;
+}
+
+static int extractpdf_pdf_trim_rect_equivalent(fz_rect left, fz_rect right)
+{
+    return extractpdf_pdf_trim_close_float(left.x0, right.x0) &&
+        extractpdf_pdf_trim_close_float(left.y0, right.y0) &&
+        extractpdf_pdf_trim_close_float(left.x1, right.x1) &&
+        extractpdf_pdf_trim_close_float(left.y1, right.y1);
+}
+
+static int extractpdf_pdf_trim_plan_equivalent(
+    const extractpdf_pdf_trim_plan *left,
+    const extractpdf_pdf_trim_plan *right)
+{
+    return left->page_index == right->page_index &&
+        left->requested_public.x0 == right->requested_public.x0 &&
+        left->requested_public.y0 == right->requested_public.y0 &&
+        left->requested_public.x1 == right->requested_public.x1 &&
+        left->requested_public.y1 == right->requested_public.y1 &&
+        extractpdf_pdf_trim_rect_equivalent(
+            left->requested_media_pdf, right->requested_media_pdf) &&
+        extractpdf_pdf_trim_rect_equivalent(
+            left->output_visible_pdf, right->output_visible_pdf) &&
+        left->changed == right->changed &&
+        left->frame_changed == right->frame_changed;
+}
+
+static int extractpdf_pdf_trim_view_equivalent(
+    const extractpdf_pdf_page_box_view *left,
+    const extractpdf_pdf_page_box_view *right)
+{
+    return extractpdf_pdf_trim_rect_equivalent(
+               left->media_pdf, right->media_pdf) &&
+        extractpdf_pdf_trim_rect_equivalent(
+            left->crop_pdf, right->crop_pdf) &&
+        extractpdf_pdf_trim_rect_equivalent(
+            left->visible_pdf, right->visible_pdf) &&
+        left->has_explicit_crop == right->has_explicit_crop &&
+        left->rotate_degrees == right->rotate_degrees &&
+        extractpdf_pdf_trim_close_float(left->user_unit, right->user_unit);
+}
+
+static void extractpdf_pdf_trim_put_mediabox(
+    fz_context *ctx,
+    pdf_document *document,
+    pdf_obj *page_obj,
+    fz_rect box)
+{
+    pdf_obj *array = NULL;
+
+    fz_var(array);
+    fz_try(ctx)
+    {
+        array = pdf_new_array(ctx, document, 4);
+        pdf_array_push_real(ctx, array, box.x0);
+        pdf_array_push_real(ctx, array, box.y0);
+        pdf_array_push_real(ctx, array, box.x1);
+        pdf_array_push_real(ctx, array, box.y1);
+        pdf_dict_put(ctx, page_obj, PDF_NAME(MediaBox), array);
+    }
+    fz_always(ctx)
+    {
+        pdf_drop_obj(ctx, array);
+    }
+    fz_catch(ctx)
+    {
+        fz_rethrow(ctx);
+    }
+}
+
+static extractpdf_status extractpdf_pdf_trim_transform_changed(
+    fz_context *source_ctx,
+    pdf_document *source_pdf,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    const extractpdf_pdf_trim_plan *source_plans,
+    extractpdf_output **out_output)
+{
+    extractpdf_output *seed = NULL;
+    extractpdf_pdf_trim_plan *private_plans = NULL;
+    extractpdf_pdf_page_box_view *private_views = NULL;
+    fz_context *private_ctx = NULL;
+    fz_stream *stream = NULL;
+    pdf_document *private_document = NULL;
+    extractpdf_status status;
+    int private_any_changed = 0;
+    int caught_code = FZ_ERROR_NONE;
+    size_t index;
+
+    status = extractpdf_serialize_pdf(source_ctx, source_pdf, &seed);
+    if (status != EXTRACTPDF_OK)
+        return status;
+
+    private_ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (private_ctx == NULL) {
+        extractpdf_drop_output(seed);
+        return EXTRACTPDF_ERROR_NOMEM;
+    }
+    fz_set_error_callback(
+        private_ctx, extractpdf_pdf_trim_discard_log, NULL);
+    fz_set_warning_callback(
+        private_ctx, extractpdf_pdf_trim_discard_log, NULL);
+
+    fz_var(stream);
+    fz_var(private_document);
+    fz_var(caught_code);
+    fz_try(private_ctx)
+    {
+        stream = fz_open_memory(private_ctx, seed->data, seed->size);
+        private_document = pdf_open_document_with_stream(private_ctx, stream);
+        pdf_disable_js(private_ctx, private_document);
+    }
+    fz_always(private_ctx)
+    {
+        fz_drop_stream(private_ctx, stream);
+        stream = NULL;
+    }
+    fz_catch(private_ctx)
+    {
+        caught_code = fz_caught(private_ctx);
+        fz_report_error(private_ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE) {
+        status = extractpdf_status_from_mupdf(caught_code);
+        pdf_drop_document(private_ctx, private_document);
+        fz_drop_context(private_ctx);
+        extractpdf_drop_output(seed);
+        return status;
+    }
+
+    status = extractpdf_pdf_trim_check_security(
+        private_ctx, private_document);
+    if (status != EXTRACTPDF_OK)
+        goto cleanup;
+
+    if (trim_count > SIZE_MAX / sizeof(*private_plans) ||
+        trim_count > SIZE_MAX / sizeof(*private_views)) {
+        status = EXTRACTPDF_ERROR_NOMEM;
+        goto cleanup;
+    }
+    private_plans = (extractpdf_pdf_trim_plan *)calloc(
+        trim_count, sizeof(*private_plans));
+    private_views = (extractpdf_pdf_page_box_view *)calloc(
+        trim_count, sizeof(*private_views));
+    if (private_plans == NULL || private_views == NULL) {
+        status = EXTRACTPDF_ERROR_NOMEM;
+        goto cleanup;
+    }
+
+    status = extractpdf_pdf_trim_build_plan(
+        private_ctx,
+        private_document,
+        trims,
+        trim_count,
+        private_plans,
+        &private_any_changed);
+    if (status != EXTRACTPDF_OK)
+        goto cleanup;
+    if (!private_any_changed) {
+        status = EXTRACTPDF_ERROR_FORMAT;
+        goto cleanup;
+    }
+
+    for (index = 0; index < trim_count; ++index) {
+        extractpdf_pdf_page_box_view source_view;
+
+        if (!extractpdf_pdf_trim_plan_equivalent(
+                &source_plans[index], &private_plans[index])) {
+            status = EXTRACTPDF_ERROR_FORMAT;
+            goto cleanup;
+        }
+
+        status = extractpdf_pdf_page_box_resolve(
+            source_ctx,
+            source_pdf,
+            source_plans[index].page_index,
+            &source_view);
+        if (status != EXTRACTPDF_OK)
+            goto cleanup;
+        status = extractpdf_pdf_page_box_resolve(
+            private_ctx,
+            private_document,
+            private_plans[index].page_index,
+            &private_views[index]);
+        if (status != EXTRACTPDF_OK)
+            goto cleanup;
+        if (!extractpdf_pdf_trim_view_equivalent(
+                &source_view, &private_views[index])) {
+            status = EXTRACTPDF_ERROR_FORMAT;
+            goto cleanup;
+        }
+    }
+
+    caught_code = FZ_ERROR_NONE;
+    fz_var(caught_code);
+    fz_try(private_ctx)
+    {
+        for (index = 0; index < trim_count; ++index) {
+            if (!private_plans[index].changed)
+                continue;
+            extractpdf_pdf_trim_put_mediabox(
+                private_ctx,
+                private_document,
+                private_views[index].page_obj,
+                private_plans[index].requested_media_pdf);
+        }
+    }
+    fz_catch(private_ctx)
+    {
+        caught_code = fz_caught(private_ctx);
+        fz_report_error(private_ctx);
+    }
+    if (caught_code != FZ_ERROR_NONE) {
+        status = extractpdf_status_from_mupdf(caught_code);
+        goto cleanup;
+    }
+
+    status = extractpdf_serialize_pdf(
+        private_ctx, private_document, out_output);
+
+cleanup:
+    free(private_views);
+    free(private_plans);
+    pdf_drop_document(private_ctx, private_document);
+    fz_drop_context(private_ctx);
+    extractpdf_drop_output(seed);
+    return status;
+}
 
 extractpdf_status extractpdf_trim_pages(
     extractpdf_document *document,
@@ -45,7 +287,13 @@ extractpdf_status extractpdf_trim_pages(
         &any_changed);
     if (status == EXTRACTPDF_OK) {
         if (any_changed) {
-            status = EXTRACTPDF_ERROR_UNSUPPORTED;
+            status = extractpdf_pdf_trim_transform_changed(
+                document->ctx,
+                source_pdf,
+                trims,
+                trim_count,
+                plans,
+                out_output);
         }
         else {
             status = extractpdf_serialize_pdf(

--- a/src/pdf_trim.c
+++ b/src/pdf_trim.c
@@ -1,0 +1,17 @@
+#include "internal.h"
+
+extractpdf_status extractpdf_trim_pages(
+    extractpdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_output **out_output)
+{
+    if (out_output == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (document == NULL || trims == NULL || trim_count == 0)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    return EXTRACTPDF_ERROR_UNSUPPORTED;
+}

--- a/src/pdf_trim_internal.h
+++ b/src/pdf_trim_internal.h
@@ -1,0 +1,27 @@
+#ifndef EXTRACTPDF_PDF_TRIM_INTERNAL_H
+#define EXTRACTPDF_PDF_TRIM_INTERNAL_H
+
+#include "pdf_page_box_common.h"
+
+typedef struct extractpdf_pdf_trim_plan {
+    int page_index;
+    extractpdf_rect requested_public;
+    fz_rect requested_media_pdf;
+    fz_rect output_visible_pdf;
+    int changed;
+    int frame_changed;
+} extractpdf_pdf_trim_plan;
+
+extractpdf_status extractpdf_pdf_trim_check_security(
+    fz_context *ctx,
+    pdf_document *document);
+
+extractpdf_status extractpdf_pdf_trim_build_plan(
+    fz_context *ctx,
+    pdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_pdf_trim_plan *plans,
+    int *out_any_changed);
+
+#endif

--- a/src/pdf_trim_preflight.c
+++ b/src/pdf_trim_preflight.c
@@ -137,6 +137,17 @@ static int extractpdf_pdf_trim_raw_equal(fz_rect left, fz_rect right)
         left.x1 == right.x1 && left.y1 == right.y1;
 }
 
+static fz_rect extractpdf_pdf_trim_normalize(fz_rect rect)
+{
+    fz_rect result;
+
+    result.x0 = fminf(rect.x0, rect.x1);
+    result.y0 = fminf(rect.y0, rect.y1);
+    result.x1 = fmaxf(rect.x0, rect.x1);
+    result.y1 = fmaxf(rect.y0, rect.y1);
+    return result;
+}
+
 static fz_rect extractpdf_pdf_trim_intersection(fz_rect left, fz_rect right)
 {
     fz_rect result;
@@ -206,15 +217,8 @@ extractpdf_status extractpdf_pdf_trim_build_plan(
         public_rect.x1 = trims[index].bounds.x1;
         public_rect.y1 = trims[index].bounds.y1;
         public_to_pdf = fz_invert_matrix(view.pdf_to_public);
-        requested_media_pdf = fz_transform_rect(public_rect, public_to_pdf);
-        requested_media_pdf.x0 = fminf(
-            requested_media_pdf.x0, requested_media_pdf.x1);
-        requested_media_pdf.y0 = fminf(
-            requested_media_pdf.y0, requested_media_pdf.y1);
-        requested_media_pdf.x1 = fmaxf(
-            requested_media_pdf.x0, requested_media_pdf.x1);
-        requested_media_pdf.y1 = fmaxf(
-            requested_media_pdf.y0, requested_media_pdf.y1);
+        requested_media_pdf = extractpdf_pdf_trim_normalize(
+            fz_transform_rect(public_rect, public_to_pdf));
 
         if (!extractpdf_pdf_trim_positive_raw(requested_media_pdf) ||
             !extractpdf_pdf_trim_raw_inside(

--- a/src/pdf_trim_preflight.c
+++ b/src/pdf_trim_preflight.c
@@ -1,0 +1,250 @@
+#include "pdf_trim_internal.h"
+
+#include <math.h>
+#include <stddef.h>
+
+static int extractpdf_pdf_trim_dict_has_key(
+    fz_context *ctx,
+    pdf_obj *dictionary,
+    pdf_obj *key)
+{
+    int count;
+    int index;
+
+    count = pdf_dict_len(ctx, dictionary);
+    for (index = 0; index < count; ++index) {
+        if (pdf_name_eq(ctx, pdf_dict_get_key(ctx, dictionary, index), key))
+            return 1;
+    }
+    return 0;
+}
+
+typedef struct extractpdf_pdf_trim_signature_scan {
+    pdf_document *document;
+    int has_signed_field;
+} extractpdf_pdf_trim_signature_scan;
+
+static void extractpdf_pdf_trim_scan_signature_field(
+    fz_context *ctx,
+    pdf_obj *field,
+    void *data,
+    pdf_obj **ft)
+{
+    extractpdf_pdf_trim_signature_scan *scan =
+        (extractpdf_pdf_trim_signature_scan *)data;
+
+    if (scan->has_signed_field)
+        return;
+    if (!pdf_name_eq(ctx, *ft, PDF_NAME(Sig)))
+        return;
+    if (pdf_signature_is_signed(ctx, scan->document, field))
+        scan->has_signed_field = 1;
+}
+
+static int extractpdf_pdf_trim_has_signed_field(
+    fz_context *ctx,
+    pdf_document *document)
+{
+    static pdf_obj *field_type_names[2] = {PDF_NAME(FT), NULL};
+    extractpdf_pdf_trim_signature_scan scan;
+    pdf_obj *field_type = NULL;
+    pdf_obj *fields;
+
+    scan.document = document;
+    scan.has_signed_field = 0;
+    fields = pdf_dict_getp(
+        ctx,
+        pdf_trailer(ctx, document),
+        "Root/AcroForm/Fields");
+    pdf_walk_tree(
+        ctx,
+        fields,
+        PDF_NAME(Kids),
+        extractpdf_pdf_trim_scan_signature_field,
+        NULL,
+        &scan,
+        field_type_names,
+        &field_type);
+    return scan.has_signed_field;
+}
+
+extractpdf_status extractpdf_pdf_trim_check_security(
+    fz_context *ctx,
+    pdf_document *document)
+{
+    int encrypted = 0;
+    int signed_field = 0;
+    int caught_code = FZ_ERROR_NONE;
+
+    if (ctx == NULL || document == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    fz_var(encrypted);
+    fz_var(signed_field);
+    fz_var(caught_code);
+    fz_try(ctx)
+    {
+        pdf_obj *trailer = pdf_trailer(ctx, document);
+        encrypted = extractpdf_pdf_trim_dict_has_key(
+            ctx, trailer, PDF_NAME(Encrypt));
+        if (!encrypted)
+            signed_field = extractpdf_pdf_trim_has_signed_field(ctx, document);
+    }
+    fz_catch(ctx)
+    {
+        caught_code = fz_caught(ctx);
+        fz_report_error(ctx);
+    }
+
+    if (caught_code != FZ_ERROR_NONE)
+        return extractpdf_status_from_mupdf(caught_code);
+    if (encrypted || signed_field)
+        return EXTRACTPDF_ERROR_UNSUPPORTED;
+    return EXTRACTPDF_OK;
+}
+
+static int extractpdf_pdf_trim_finite_public_rect(extractpdf_rect rect)
+{
+    return isfinite(rect.x0) && isfinite(rect.y0) &&
+        isfinite(rect.x1) && isfinite(rect.y1);
+}
+
+static int extractpdf_pdf_trim_public_equal(
+    extractpdf_rect left,
+    extractpdf_rect right)
+{
+    return left.x0 == right.x0 && left.y0 == right.y0 &&
+        left.x1 == right.x1 && left.y1 == right.y1;
+}
+
+static int extractpdf_pdf_trim_public_inside(
+    extractpdf_rect inner,
+    extractpdf_rect outer)
+{
+    return inner.x0 >= outer.x0 && inner.y0 >= outer.y0 &&
+        inner.x1 <= outer.x1 && inner.y1 <= outer.y1;
+}
+
+static int extractpdf_pdf_trim_raw_inside(fz_rect inner, fz_rect outer)
+{
+    return inner.x0 >= outer.x0 && inner.y0 >= outer.y0 &&
+        inner.x1 <= outer.x1 && inner.y1 <= outer.y1;
+}
+
+static int extractpdf_pdf_trim_raw_equal(fz_rect left, fz_rect right)
+{
+    return left.x0 == right.x0 && left.y0 == right.y0 &&
+        left.x1 == right.x1 && left.y1 == right.y1;
+}
+
+static fz_rect extractpdf_pdf_trim_intersection(fz_rect left, fz_rect right)
+{
+    fz_rect result;
+
+    result.x0 = fmaxf(left.x0, right.x0);
+    result.y0 = fmaxf(left.y0, right.y0);
+    result.x1 = fminf(left.x1, right.x1);
+    result.y1 = fminf(left.y1, right.y1);
+    return result;
+}
+
+static int extractpdf_pdf_trim_positive_raw(fz_rect rect)
+{
+    return isfinite(rect.x0) && isfinite(rect.y0) &&
+        isfinite(rect.x1) && isfinite(rect.y1) &&
+        rect.x0 < rect.x1 && rect.y0 < rect.y1;
+}
+
+extractpdf_status extractpdf_pdf_trim_build_plan(
+    fz_context *ctx,
+    pdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_pdf_trim_plan *plans,
+    int *out_any_changed)
+{
+    const size_t minimum_size =
+        offsetof(extractpdf_page_trim, bounds) + sizeof(extractpdf_rect);
+    size_t index;
+
+    if (out_any_changed != NULL)
+        *out_any_changed = 0;
+    if (ctx == NULL || document == NULL || trims == NULL ||
+        trim_count == 0 || plans == NULL || out_any_changed == NULL)
+        return EXTRACTPDF_ERROR_ARGUMENT;
+
+    for (index = 0; index < trim_count; ++index) {
+        extractpdf_pdf_page_box_view view;
+        fz_rect public_rect;
+        fz_rect requested_media_pdf;
+        fz_matrix public_to_pdf;
+        extractpdf_status status;
+        size_t prior;
+
+        if (trims[index].struct_size < minimum_size)
+            return EXTRACTPDF_ERROR_ARGUMENT;
+        if (!extractpdf_pdf_trim_finite_public_rect(trims[index].bounds) ||
+            !(trims[index].bounds.x0 < trims[index].bounds.x1) ||
+            !(trims[index].bounds.y0 < trims[index].bounds.y1))
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        for (prior = 0; prior < index; ++prior) {
+            if (trims[prior].page_index == trims[index].page_index)
+                return EXTRACTPDF_ERROR_ARGUMENT;
+        }
+
+        status = extractpdf_pdf_page_box_resolve(
+            ctx, document, trims[index].page_index, &view);
+        if (status != EXTRACTPDF_OK)
+            return status;
+        if (!extractpdf_pdf_trim_public_inside(
+                trims[index].bounds, view.media_public))
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        public_rect.x0 = trims[index].bounds.x0;
+        public_rect.y0 = trims[index].bounds.y0;
+        public_rect.x1 = trims[index].bounds.x1;
+        public_rect.y1 = trims[index].bounds.y1;
+        public_to_pdf = fz_invert_matrix(view.pdf_to_public);
+        requested_media_pdf = fz_transform_rect(public_rect, public_to_pdf);
+        requested_media_pdf.x0 = fminf(
+            requested_media_pdf.x0, requested_media_pdf.x1);
+        requested_media_pdf.y0 = fminf(
+            requested_media_pdf.y0, requested_media_pdf.y1);
+        requested_media_pdf.x1 = fmaxf(
+            requested_media_pdf.x0, requested_media_pdf.x1);
+        requested_media_pdf.y1 = fmaxf(
+            requested_media_pdf.y0, requested_media_pdf.y1);
+
+        if (!extractpdf_pdf_trim_positive_raw(requested_media_pdf) ||
+            !extractpdf_pdf_trim_raw_inside(
+                requested_media_pdf, view.media_pdf))
+            return EXTRACTPDF_ERROR_ARGUMENT;
+
+        plans[index].page_index = trims[index].page_index;
+        plans[index].requested_public = trims[index].bounds;
+        plans[index].requested_media_pdf = requested_media_pdf;
+        plans[index].changed = !extractpdf_pdf_trim_public_equal(
+            trims[index].bounds, view.media_public);
+
+        if (view.has_explicit_crop) {
+            plans[index].output_visible_pdf = extractpdf_pdf_trim_intersection(
+                requested_media_pdf, view.crop_pdf);
+        }
+        else {
+            plans[index].output_visible_pdf = requested_media_pdf;
+        }
+
+        if (!extractpdf_pdf_trim_positive_raw(
+                plans[index].output_visible_pdf))
+            return plans[index].changed ?
+                EXTRACTPDF_ERROR_ARGUMENT : EXTRACTPDF_ERROR_FORMAT;
+
+        plans[index].frame_changed = !extractpdf_pdf_trim_raw_equal(
+            plans[index].output_visible_pdf, view.visible_pdf);
+        if (plans[index].changed)
+            *out_any_changed = 1;
+    }
+
+    return EXTRACTPDF_OK;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -333,3 +333,10 @@ if(WIN32 AND BUILD_SHARED_LIBS)
       $<TARGET_FILE_DIR:extractpdf_test_pdf_crop>
     VERBATIM)
 endif()
+
+add_executable(extractpdf_test_pdf_trim test_pdf_trim.c)
+target_link_libraries(extractpdf_test_pdf_trim PRIVATE ExtractPDF::ExtractPDF)
+target_compile_definitions(extractpdf_test_pdf_trim PRIVATE
+  TRIM_INTERACTIVE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/trim-interactive.pdf")
+add_test(NAME extractpdf.pdf_trim COMMAND extractpdf_test_pdf_trim)
+set_tests_properties(extractpdf.pdf_trim PROPERTIES TIMEOUT 60)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -340,3 +340,11 @@ target_compile_definitions(extractpdf_test_pdf_trim PRIVATE
   TRIM_INTERACTIVE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/trim-interactive.pdf")
 add_test(NAME extractpdf.pdf_trim COMMAND extractpdf_test_pdf_trim)
 set_tests_properties(extractpdf.pdf_trim PROPERTIES TIMEOUT 60)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_custom_command(TARGET extractpdf_test_pdf_trim POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:extractpdf>
+      $<TARGET_FILE_DIR:extractpdf_test_pdf_trim>
+    VERBATIM)
+endif()

--- a/tests/fixtures/trim-default-boxes.pdf
+++ b/tests/fixtures/trim-default-boxes.pdf
@@ -1,0 +1,26 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 400 300] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /BleedBox [10 10 390 290] /TrimBox [20 20 380 280] /ArtBox [30 30 370 270] >>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000021 00000 n 
+0000000070 00000 n 
+0000000157 00000 n 
+0000000204 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+326
+%%EOF

--- a/tests/fixtures/trim-interactive.pdf
+++ b/tests/fixtures/trim-interactive.pdf
@@ -1,0 +1,84 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Outlines 11 0 R /AcroForm 14 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 400 300] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R >> >> /Contents 7 0 R /Annots [8 0 R 9 0 R 10 0 R 15 0 R] >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /Contents 16 0 R >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode /Length 7 >>
+stream
+FF0000>
+endstream
+endobj
+7 0 obj
+<< /Length 75 >>
+stream
+BT /F1 18 Tf 100 220 Td (TRIM-TEXT) Tj ET
+q 60 0 0 40 180 120 cm /Im1 Do Q
+endstream
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /Link /Rect [120 180 240 205] /Border [0 0 0] /A << /S /URI /URI (https://example.com/trim) >> >>
+endobj
+9 0 obj
+<< /Type /Annot /Subtype /Link /Rect [120 145 250 170] /Border [0 0 0] /Dest [4 0 R /XYZ 100 200 0] >>
+endobj
+10 0 obj
+<< /Type /Annot /Subtype /Square /Rect [20 230 90 290] /F 4 /Contents (TRIM-ANNOT) >>
+endobj
+11 0 obj
+<< /Type /Outlines /First 12 0 R /Last 12 0 R /Count 1 >>
+endobj
+12 0 obj
+<< /Title (Trim target) /Parent 11 0 R /Dest [4 0 R /XYZ 100 200 0] >>
+endobj
+13 0 obj
+<< /T (trim) /Kids [15 0 R] >>
+endobj
+14 0 obj
+<< /Fields [13 0 R] /NeedAppearances false >>
+endobj
+15 0 obj
+<< /Type /Annot /Subtype /Widget /T (text) /FT /Tx /V (TRIM-VALUE) /Rect [250 80 340 110] /Parent 13 0 R /P 3 0 R /F 4 >>
+endobj
+16 0 obj
+<< /Length 44 >>
+stream
+BT /F1 18 Tf 100 200 Td (TRIM-TARGET) Tj ET
+endstream
+endobj
+xref
+0 17
+0000000000 65535 f 
+0000000021 00000 n 
+0000000104 00000 n 
+0000000191 00000 n 
+0000000355 00000 n 
+0000000458 00000 n 
+0000000528 00000 n 
+0000000701 00000 n 
+0000000825 00000 n 
+0000000963 00000 n 
+0000001081 00000 n 
+0000001183 00000 n 
+0000001257 00000 n 
+0000001344 00000 n 
+0000001391 00000 n 
+0000001453 00000 n 
+0000001591 00000 n 
+trailer
+<< /Size 17 /Root 1 0 R >>
+startxref
+1685
+%%EOF

--- a/tests/fixtures/trim-malformed-box.pdf
+++ b/tests/fixtures/trim-malformed-box.pdf
@@ -1,0 +1,26 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 400 300] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400] >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /CropBox [0 0 300 /Bad] >>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000021 00000 n 
+0000000070 00000 n 
+0000000157 00000 n 
+0000000224 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+295
+%%EOF

--- a/tests/fixtures/trim-malformed-rotate.pdf
+++ b/tests/fixtures/trim-malformed-rotate.pdf
@@ -1,0 +1,22 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 400 300] /Rotate 45 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000021 00000 n 
+0000000070 00000 n 
+0000000162 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+209
+%%EOF

--- a/tests/fixtures/trim-malformed-userunit.pdf
+++ b/tests/fixtures/trim-malformed-userunit.pdf
@@ -1,0 +1,22 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 400 300] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /UserUnit 0 >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000021 00000 n 
+0000000070 00000 n 
+0000000151 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+210
+%%EOF

--- a/tests/fixtures/trim-preserved-crop.pdf
+++ b/tests/fixtures/trim-preserved-crop.pdf
@@ -1,0 +1,26 @@
+%PDF-1.7
+%EPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 400 300] /CropBox [50 40 350 260] /Rotate 0 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000186 00000 n 
+0000000233 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+280
+%%EOF

--- a/tests/fixtures/trim-rotate-90.pdf
+++ b/tests/fixtures/trim-rotate-90.pdf
@@ -1,0 +1,37 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 300] /Rotate 90 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R /Annots [6 0 R] >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT /F1 18 Tf 100 200 Td (TRIM-ROTATE) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Square /Rect [20 20 80 60] /F 4 /Contents (TRIM-ROTATE-ANNOT) >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000021 00000 n 
+0000000070 00000 n 
+0000000127 00000 n 
+0000000280 00000 n 
+0000000350 00000 n 
+0000000443 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+549
+%%EOF

--- a/tests/fixtures/trim-userunit.pdf
+++ b/tests/fixtures/trim-userunit.pdf
@@ -1,0 +1,37 @@
+%PDF-1.7
+%ExtractPDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 150] /UserUnit 2 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R /Annots [6 0 R] >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 41 >>
+stream
+BT /F1 18 Tf 50 100 Td (TRIM-UNIT) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Link /Rect [20 20 80 60] /Border [0 0 0] /A << /S /URI /URI (https://example.com/trim-unit) >> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000021 00000 n 
+0000000070 00000 n 
+0000000127 00000 n 
+0000000281 00000 n 
+0000000351 00000 n 
+0000000441 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+580
+%%EOF

--- a/tests/test_pdf_trim.c
+++ b/tests/test_pdf_trim.c
@@ -1,41 +1,246 @@
 #include <extractpdf/extractpdf.h>
 
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.01f;
+}
+
+static void check_rect_close(extractpdf_rect actual, extractpdf_rect expected)
+{
+    CHECK(close_float(actual.x0, expected.x0));
+    CHECK(close_float(actual.y0, expected.y0));
+    CHECK(close_float(actual.x1, expected.x1));
+    CHECK(close_float(actual.y1, expected.y1));
+}
+
+static extractpdf_output *output_sentinel(void)
+{
+    return (extractpdf_output *)(uintptr_t)1;
+}
+
+static extractpdf_page_trim make_trim(
+    int page_index,
+    float x0,
+    float y0,
+    float x1,
+    float y1)
+{
+    extractpdf_page_trim trim;
+
+    trim.struct_size = sizeof(trim);
+    trim.page_index = page_index;
+    trim.bounds.x0 = x0;
+    trim.bounds.y0 = y0;
+    trim.bounds.x1 = x1;
+    trim.bounds.y1 = y1;
+    return trim;
+}
+
+static extractpdf_document *open_document(const char *path, const char *password)
+{
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_open(path, password, &document) == EXTRACTPDF_OK);
+    CHECK(document != NULL);
+    return document;
+}
+
+static void expect_trim_error(
+    extractpdf_document *document,
+    const extractpdf_page_trim *trims,
+    size_t trim_count,
+    extractpdf_status expected)
+{
+    extractpdf_output *output = output_sentinel();
+
+    CHECK(extractpdf_trim_pages(document, trims, trim_count, &output) == expected);
+    CHECK(output == NULL);
+}
+
+static extractpdf_rect page_box(
+    extractpdf_document *document,
+    int page_index,
+    extractpdf_page_box box)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_box_bounds(page, box, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static void test_noop_determinism(
+    extractpdf_document *document,
+    extractpdf_rect source_media)
+{
+    extractpdf_page_trim full = make_trim(
+        0,
+        source_media.x0,
+        source_media.y0,
+        source_media.x1,
+        source_media.y1);
+    extractpdf_output *first = NULL;
+    extractpdf_output *second = NULL;
+    const unsigned char *first_data = NULL;
+    const unsigned char *second_data = NULL;
+    size_t first_size = 0;
+    size_t second_size = 0;
+    extractpdf_rect after;
+
+    CHECK(extractpdf_trim_pages(document, &full, 1, &first) == EXTRACTPDF_OK);
+    CHECK(first != NULL);
+    CHECK(extractpdf_trim_pages(document, &full, 1, &second) == EXTRACTPDF_OK);
+    CHECK(second != NULL);
+    CHECK(extractpdf_output_data(first, &first_data, &first_size) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(second, &second_data, &second_size) == EXTRACTPDF_OK);
+    CHECK(first_data != NULL && second_data != NULL);
+    CHECK(first_size != 0);
+    CHECK(second_size == first_size);
+    CHECK(memcmp(first_data, second_data, first_size) == 0);
+
+    after = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    check_rect_close(after, source_media);
+
+    extractpdf_drop_output(second);
+    extractpdf_drop_output(first);
+}
 
 int main(void)
 {
     extractpdf_document *document = NULL;
-    extractpdf_output *output = NULL;
+    extractpdf_document *other = NULL;
+    extractpdf_output *output = output_sentinel();
+    extractpdf_rect source_media;
     extractpdf_page_trim trim;
+    extractpdf_page_trim bad;
+    extractpdf_page_trim pair[2];
 
-    if (extractpdf_open(TRIM_INTERACTIVE_PDF, NULL, &document) != EXTRACTPDF_OK ||
-        document == NULL) {
-        fprintf(stderr, "open trim fixture failed\n");
-        return 1;
-    }
+    document = open_document(TRIM_INTERACTIVE_PDF, NULL);
+    source_media = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    check_rect_close(
+        source_media,
+        (extractpdf_rect){0.0f, 0.0f, 400.0f, 300.0f});
+    trim = make_trim(0, 40.0f, 30.0f, 360.0f, 270.0f);
 
-    memset(&trim, 0, sizeof(trim));
-    trim.struct_size = sizeof(trim);
-    trim.page_index = 0;
-    trim.bounds.x0 = 40.0f;
-    trim.bounds.y0 = 30.0f;
-    trim.bounds.x1 = 360.0f;
-    trim.bounds.y1 = 270.0f;
+    CHECK(extractpdf_trim_pages(document, &trim, 1, NULL) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    expect_trim_error(NULL, &trim, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    expect_trim_error(document, NULL, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    expect_trim_error(document, &trim, 0, EXTRACTPDF_ERROR_ARGUMENT);
 
-    if (extractpdf_trim_pages(document, &trim, 1, &output) != EXTRACTPDF_OK) {
+    bad = trim;
+    bad.struct_size =
+        offsetof(extractpdf_page_trim, bounds) + sizeof(extractpdf_rect) - 1;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+
+    bad = trim;
+    bad.page_index = -1;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    bad = trim;
+    bad.page_index = 2;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+
+    pair[0] = trim;
+    pair[1] = make_trim(0, 50.0f, 40.0f, 350.0f, 260.0f);
+    expect_trim_error(document, pair, 2, EXTRACTPDF_ERROR_ARGUMENT);
+
+    bad = trim;
+    bad.bounds.x0 = NAN;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    bad = trim;
+    bad.bounds.y0 = INFINITY;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    bad = trim;
+    bad.bounds.x1 = -INFINITY;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+
+    bad = trim;
+    bad.bounds.x1 = bad.bounds.x0;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    bad = trim;
+    bad.bounds.y1 = bad.bounds.y0;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    bad = trim;
+    bad.bounds.x0 = 370.0f;
+    bad.bounds.x1 = 360.0f;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+
+    bad = trim;
+    bad.bounds.x0 = source_media.x0 - 1.0f;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+    bad = trim;
+    bad.bounds.x1 = source_media.x1 + 1.0f;
+    expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
+
+    other = open_document(NON_PDF, NULL);
+    bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_UNSUPPORTED);
+    extractpdf_close(other);
+    other = NULL;
+
+    other = open_document(ENCRYPTED_PDF, "user-pass");
+    bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_UNSUPPORTED);
+    extractpdf_close(other);
+    other = NULL;
+
+    other = open_document(SIGNED_PDF, NULL);
+    bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_UNSUPPORTED);
+    extractpdf_close(other);
+    other = NULL;
+
+    other = open_document(TRIM_MALFORMED_BOX_PDF, NULL);
+    bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
+    bad = make_trim(1, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
+    extractpdf_close(other);
+    other = NULL;
+
+    other = open_document(TRIM_MALFORMED_ROTATE_PDF, NULL);
+    bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
+    extractpdf_close(other);
+    other = NULL;
+
+    other = open_document(TRIM_MALFORMED_USERUNIT_PDF, NULL);
+    bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
+    expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
+    extractpdf_close(other);
+    other = NULL;
+
+    test_noop_determinism(document, source_media);
+
+    output = output_sentinel();
+    if (extractpdf_trim_pages(document, &trim, 1, &output) != EXTRACTPDF_OK ||
+        output == NULL) {
         fprintf(stderr, "valid trim failed\n");
+        CHECK(output == NULL);
         extractpdf_close(document);
-        return 1;
-    }
-
-    if (output == NULL) {
-        fprintf(stderr, "valid trim returned null output\n");
-        extractpdf_close(document);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     extractpdf_drop_output(output);
     extractpdf_close(document);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/tests/test_pdf_trim.c
+++ b/tests/test_pdf_trim.c
@@ -52,6 +52,26 @@ static extractpdf_page_trim make_trim(
     return trim;
 }
 
+static void sibling_fixture_path(
+    const char *name,
+    char *out_path,
+    size_t capacity)
+{
+    const char *slash = strrchr(TRIM_INTERACTIVE_PDF, '/');
+    const char *backslash = strrchr(TRIM_INTERACTIVE_PDF, '\\');
+    const char *separator = slash;
+    size_t prefix;
+    size_t name_size = strlen(name);
+
+    if (backslash != NULL && (separator == NULL || backslash > separator))
+        separator = backslash;
+    CHECK(separator != NULL);
+    prefix = (size_t)(separator - TRIM_INTERACTIVE_PDF) + 1;
+    CHECK(prefix + name_size + 1 <= capacity);
+    memcpy(out_path, TRIM_INTERACTIVE_PDF, prefix);
+    memcpy(out_path + prefix, name, name_size + 1);
+}
+
 static extractpdf_document *open_document(const char *path, const char *password)
 {
     extractpdf_document *document = NULL;
@@ -133,6 +153,19 @@ int main(void)
     extractpdf_page_trim trim;
     extractpdf_page_trim bad;
     extractpdf_page_trim pair[2];
+    char non_pdf[1024];
+    char encrypted_pdf[1024];
+    char signed_pdf[1024];
+    char malformed_box_pdf[1024];
+    char malformed_rotate_pdf[1024];
+    char malformed_userunit_pdf[1024];
+
+    sibling_fixture_path("composition-non-pdf.txt", non_pdf, sizeof(non_pdf));
+    sibling_fixture_path("encrypted-one-page.pdf", encrypted_pdf, sizeof(encrypted_pdf));
+    sibling_fixture_path("annotation-mutation-signed.pdf", signed_pdf, sizeof(signed_pdf));
+    sibling_fixture_path("trim-malformed-box.pdf", malformed_box_pdf, sizeof(malformed_box_pdf));
+    sibling_fixture_path("trim-malformed-rotate.pdf", malformed_rotate_pdf, sizeof(malformed_rotate_pdf));
+    sibling_fixture_path("trim-malformed-userunit.pdf", malformed_userunit_pdf, sizeof(malformed_userunit_pdf));
 
     document = open_document(TRIM_INTERACTIVE_PDF, NULL);
     source_media = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
@@ -191,25 +224,25 @@ int main(void)
     bad.bounds.x1 = source_media.x1 + 1.0f;
     expect_trim_error(document, &bad, 1, EXTRACTPDF_ERROR_ARGUMENT);
 
-    other = open_document(NON_PDF, NULL);
+    other = open_document(non_pdf, NULL);
     bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
     expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_UNSUPPORTED);
     extractpdf_close(other);
     other = NULL;
 
-    other = open_document(ENCRYPTED_PDF, "user-pass");
+    other = open_document(encrypted_pdf, "user-pass");
     bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
     expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_UNSUPPORTED);
     extractpdf_close(other);
     other = NULL;
 
-    other = open_document(SIGNED_PDF, NULL);
+    other = open_document(signed_pdf, NULL);
     bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
     expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_UNSUPPORTED);
     extractpdf_close(other);
     other = NULL;
 
-    other = open_document(TRIM_MALFORMED_BOX_PDF, NULL);
+    other = open_document(malformed_box_pdf, NULL);
     bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
     expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
     bad = make_trim(1, 0.0f, 0.0f, 100.0f, 100.0f);
@@ -217,13 +250,13 @@ int main(void)
     extractpdf_close(other);
     other = NULL;
 
-    other = open_document(TRIM_MALFORMED_ROTATE_PDF, NULL);
+    other = open_document(malformed_rotate_pdf, NULL);
     bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
     expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
     extractpdf_close(other);
     other = NULL;
 
-    other = open_document(TRIM_MALFORMED_USERUNIT_PDF, NULL);
+    other = open_document(malformed_userunit_pdf, NULL);
     bad = make_trim(0, 0.0f, 0.0f, 100.0f, 100.0f);
     expect_trim_error(other, &bad, 1, EXTRACTPDF_ERROR_FORMAT);
     extractpdf_close(other);

--- a/tests/test_pdf_trim.c
+++ b/tests/test_pdf_trim.c
@@ -1,0 +1,41 @@
+#include <extractpdf/extractpdf.h>
+
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    extractpdf_document *document = NULL;
+    extractpdf_output *output = NULL;
+    extractpdf_page_trim trim;
+
+    if (extractpdf_open(TRIM_INTERACTIVE_PDF, NULL, &document) != EXTRACTPDF_OK ||
+        document == NULL) {
+        fprintf(stderr, "open trim fixture failed\n");
+        return 1;
+    }
+
+    memset(&trim, 0, sizeof(trim));
+    trim.struct_size = sizeof(trim);
+    trim.page_index = 0;
+    trim.bounds.x0 = 40.0f;
+    trim.bounds.y0 = 30.0f;
+    trim.bounds.x1 = 360.0f;
+    trim.bounds.y1 = 270.0f;
+
+    if (extractpdf_trim_pages(document, &trim, 1, &output) != EXTRACTPDF_OK) {
+        fprintf(stderr, "valid trim failed\n");
+        extractpdf_close(document);
+        return 1;
+    }
+
+    if (output == NULL) {
+        fprintf(stderr, "valid trim returned null output\n");
+        extractpdf_close(document);
+        return 1;
+    }
+
+    extractpdf_drop_output(output);
+    extractpdf_close(document);
+    return 0;
+}

--- a/tests/test_pdf_trim_batch.c
+++ b/tests/test_pdf_trim_batch.c
@@ -1,0 +1,214 @@
+#include <extractpdf/extractpdf.h>
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static extractpdf_output *output_sentinel(void)
+{
+    return (extractpdf_output *)(uintptr_t)1;
+}
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.01f;
+}
+
+static void check_rect_close(extractpdf_rect actual, extractpdf_rect expected)
+{
+    CHECK(close_float(actual.x0, expected.x0));
+    CHECK(close_float(actual.y0, expected.y0));
+    CHECK(close_float(actual.x1, expected.x1));
+    CHECK(close_float(actual.y1, expected.y1));
+}
+
+static extractpdf_document *open_document(const char *path)
+{
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(document != NULL);
+    return document;
+}
+
+static extractpdf_rect page_media(
+    extractpdf_document *document,
+    int page_index)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_box_bounds(
+              page, EXTRACTPDF_PAGE_BOX_MEDIA, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_page_trim make_trim(int page_index, extractpdf_rect bounds)
+{
+    extractpdf_page_trim trim;
+
+    trim.struct_size = sizeof(trim);
+    trim.page_index = page_index;
+    trim.bounds = bounds;
+    return trim;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+int trim_run_batch_tests(void)
+{
+    static const float changed0_raw[4] = {40, 30, 360, 270};
+    static const float changed1_raw[4] = {20, 30, 380, 270};
+    const char *output_path = "trim-batch-output.pdf";
+    extractpdf_document *document = open_document(TRIM_INTERACTIVE_PDF);
+    extractpdf_document *reopened = NULL;
+    extractpdf_output *noop_a = NULL;
+    extractpdf_output *noop_b = NULL;
+    extractpdf_output *mixed = NULL;
+    extractpdf_output *changed_a = NULL;
+    extractpdf_output *changed_b = NULL;
+    extractpdf_output *lifetime = NULL;
+    extractpdf_output *failed = output_sentinel();
+    const unsigned char *noop_a_data = NULL;
+    const unsigned char *noop_b_data = NULL;
+    const unsigned char *mixed_data = NULL;
+    const unsigned char *changed_a_data = NULL;
+    const unsigned char *changed_b_data = NULL;
+    const unsigned char *lifetime_data = NULL;
+    size_t noop_a_size = 0;
+    size_t noop_b_size = 0;
+    size_t mixed_size = 0;
+    size_t changed_a_size = 0;
+    size_t changed_b_size = 0;
+    size_t lifetime_size = 0;
+    extractpdf_rect source0 = page_media(document, 0);
+    extractpdf_rect source1 = page_media(document, 1);
+    extractpdf_page_trim noops[2];
+    extractpdf_page_trim mixed_trims[2];
+    extractpdf_page_trim changed[2];
+    extractpdf_page_trim invalid[2];
+
+    check_rect_close(source0, (extractpdf_rect){0, 0, 400, 300});
+    check_rect_close(source1, source0);
+
+    noops[0] = make_trim(0, source0);
+    noops[1] = make_trim(1, source1);
+    CHECK(extractpdf_trim_pages(document, noops, 2, &noop_a) == EXTRACTPDF_OK);
+    CHECK(extractpdf_trim_pages(document, noops, 2, &noop_b) == EXTRACTPDF_OK);
+    CHECK(noop_a != NULL && noop_b != NULL);
+    CHECK(extractpdf_output_data(noop_a, &noop_a_data, &noop_a_size) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(noop_b, &noop_b_data, &noop_b_size) ==
+          EXTRACTPDF_OK);
+    CHECK(noop_a_data != NULL && noop_a_size != 0);
+    CHECK(noop_b_data != NULL && noop_b_size == noop_a_size);
+    CHECK(memcmp(noop_a_data, noop_b_data, noop_a_size) == 0);
+    CHECK(trim_raw_expect_local_mediabox(
+              noop_a_data, noop_a_size, 0, 0, NULL));
+    CHECK(trim_raw_expect_local_mediabox(
+              noop_a_data, noop_a_size, 1, 0, NULL));
+
+    mixed_trims[0] = noops[0];
+    mixed_trims[1] = make_trim(
+        1, (extractpdf_rect){20, 30, 380, 270});
+    CHECK(extractpdf_trim_pages(document, mixed_trims, 2, &mixed) ==
+          EXTRACTPDF_OK);
+    CHECK(mixed != NULL);
+    CHECK(extractpdf_output_data(mixed, &mixed_data, &mixed_size) ==
+          EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_local_mediabox(
+              mixed_data, mixed_size, 0, 0, NULL));
+    CHECK(trim_raw_expect_local_mediabox(
+              mixed_data, mixed_size, 1, 1, changed1_raw));
+    CHECK(trim_raw_expect_preserved_graph(
+              noop_a_data, noop_a_size, mixed_data, mixed_size));
+
+    changed[0] = make_trim(
+        0, (extractpdf_rect){40, 30, 360, 270});
+    changed[1] = make_trim(
+        1, (extractpdf_rect){20, 30, 380, 270});
+    CHECK(extractpdf_trim_pages(document, changed, 2, &changed_a) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_trim_pages(document, changed, 2, &changed_b) ==
+          EXTRACTPDF_OK);
+    CHECK(changed_a != NULL && changed_b != NULL);
+    CHECK(extractpdf_output_data(
+              changed_a, &changed_a_data, &changed_a_size) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(
+              changed_b, &changed_b_data, &changed_b_size) == EXTRACTPDF_OK);
+    CHECK(changed_a_data != NULL && changed_a_size != 0);
+    CHECK(changed_b_data != NULL && changed_b_size == changed_a_size);
+    CHECK(memcmp(changed_a_data, changed_b_data, changed_a_size) == 0);
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_a_data, changed_a_size, 0, 1, changed0_raw));
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_a_data, changed_a_size, 1, 1, changed1_raw));
+    CHECK(trim_raw_expect_preserved_graph(
+              noop_a_data, noop_a_size, changed_a_data, changed_a_size));
+
+    invalid[0] = changed[0];
+    invalid[1] = noops[1];
+    invalid[1].bounds.x1 = source1.x1 + 1.0f;
+    failed = output_sentinel();
+    CHECK(extractpdf_trim_pages(document, invalid, 2, &failed) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(failed == NULL);
+    check_rect_close(page_media(document, 0), source0);
+    check_rect_close(page_media(document, 1), source1);
+
+    CHECK(extractpdf_trim_pages(document, changed, 2, &lifetime) ==
+          EXTRACTPDF_OK);
+    CHECK(lifetime != NULL);
+    extractpdf_close(document);
+    document = NULL;
+    CHECK(extractpdf_output_data(lifetime, &lifetime_data, &lifetime_size) ==
+          EXTRACTPDF_OK);
+    CHECK(lifetime_data != NULL && lifetime_size != 0);
+    CHECK(lifetime_size == changed_a_size);
+    CHECK(memcmp(lifetime_data, changed_a_data, lifetime_size) == 0);
+
+    (void)remove(output_path);
+    CHECK(write_bytes(output_path, lifetime_data, lifetime_size));
+    reopened = open_document(output_path);
+    check_rect_close(
+        page_media(reopened, 0), (extractpdf_rect){0, 0, 320, 240});
+    check_rect_close(
+        page_media(reopened, 1), (extractpdf_rect){0, 0, 360, 240});
+    extractpdf_close(reopened);
+    reopened = NULL;
+    (void)remove(output_path);
+
+    extractpdf_drop_output(lifetime);
+    extractpdf_drop_output(changed_b);
+    extractpdf_drop_output(changed_a);
+    extractpdf_drop_output(mixed);
+    extractpdf_drop_output(noop_b);
+    extractpdf_drop_output(noop_a);
+    return 1;
+}

--- a/tests/test_pdf_trim_boxes.c
+++ b/tests/test_pdf_trim_boxes.c
@@ -1,0 +1,140 @@
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <mupdf/fitz.h>
+#include <mupdf/pdf.h>
+#include <stddef.h>
+
+static pdf_document *open_pdf_bytes(
+    fz_context *ctx,
+    const unsigned char *data,
+    size_t size)
+{
+    fz_stream *stream = NULL;
+    pdf_document *document = NULL;
+
+    fz_var(stream);
+    fz_var(document);
+    fz_try(ctx)
+    {
+        stream = fz_open_memory(ctx, data, size);
+        document = pdf_open_document_with_stream(ctx, stream);
+    }
+    fz_always(ctx)
+    {
+        fz_drop_stream(ctx, stream);
+    }
+    fz_catch(ctx)
+    {
+        pdf_drop_document(ctx, document);
+        fz_rethrow(ctx);
+    }
+    return document;
+}
+
+static int local_value(
+    fz_context *ctx,
+    pdf_obj *dictionary,
+    pdf_obj *key,
+    pdf_obj **out_value)
+{
+    int count;
+    int index;
+
+    if (out_value != NULL)
+        *out_value = NULL;
+    if (!pdf_is_dict(ctx, dictionary))
+        return 0;
+
+    count = pdf_dict_len(ctx, dictionary);
+    for (index = 0; index < count; ++index) {
+        if (pdf_name_eq(ctx, pdf_dict_get_key(ctx, dictionary, index), key)) {
+            if (out_value != NULL)
+                *out_value = pdf_dict_get_val(ctx, dictionary, index);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int box_matches(
+    fz_context *ctx,
+    pdf_obj *box,
+    const float expected[4])
+{
+    int index;
+
+    if (expected == NULL || !pdf_is_array(ctx, box) ||
+        pdf_array_len(ctx, box) != 4)
+        return 0;
+    for (index = 0; index < 4; ++index) {
+        pdf_obj *item = pdf_array_get(ctx, box, index);
+        if (!pdf_is_number(ctx, item) ||
+            fabsf(pdf_to_real(ctx, item) - expected[index]) >= 0.001f)
+            return 0;
+    }
+    return 1;
+}
+
+static int key_matches(
+    fz_context *ctx,
+    pdf_obj *page,
+    pdf_obj *key,
+    int expect_present,
+    const float expected[4])
+{
+    pdf_obj *value = NULL;
+    int present = local_value(ctx, page, key, &value);
+
+    if (present != expect_present)
+        return 0;
+    if (!expect_present)
+        return 1;
+    return box_matches(ctx, value, expected);
+}
+
+int trim_raw_expect_production_boxes(
+    const unsigned char *data,
+    size_t size,
+    int page_index,
+    int expect_bleed,
+    const float bleed[4],
+    int expect_trim,
+    const float trim[4],
+    int expect_art,
+    const float art[4])
+{
+    fz_context *ctx = NULL;
+    pdf_document *document = NULL;
+    int ok = 0;
+
+    if (data == NULL || size == 0 || page_index < 0)
+        return 0;
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return 0;
+
+    fz_var(document);
+    fz_var(ok);
+    fz_try(ctx)
+    {
+        pdf_obj *page;
+
+        document = open_pdf_bytes(ctx, data, size);
+        page = pdf_lookup_page_obj(ctx, document, page_index);
+        ok = key_matches(
+                 ctx, page, PDF_NAME(BleedBox), expect_bleed, bleed) &&
+            key_matches(
+                 ctx, page, PDF_NAME(TrimBox), expect_trim, trim) &&
+            key_matches(
+                 ctx, page, PDF_NAME(ArtBox), expect_art, art);
+    }
+    fz_catch(ctx)
+    {
+        ok = 0;
+    }
+
+    pdf_drop_document(ctx, document);
+    fz_drop_context(ctx);
+    return ok;
+}

--- a/tests/test_pdf_trim_internal.h
+++ b/tests/test_pdf_trim_internal.h
@@ -1,0 +1,26 @@
+#ifndef EXTRACTPDF_TEST_PDF_TRIM_INTERNAL_H
+#define EXTRACTPDF_TEST_PDF_TRIM_INTERNAL_H
+
+#include <stddef.h>
+
+int trim_raw_expect_local_mediabox(
+    const unsigned char *data,
+    size_t size,
+    int page_index,
+    int expect_present,
+    const float expected[4]);
+
+int trim_raw_expect_preserved_cropbox(
+    const unsigned char *before,
+    size_t before_size,
+    const unsigned char *after,
+    size_t after_size,
+    int page_index);
+
+int trim_raw_expect_preserved_graph(
+    const unsigned char *before,
+    size_t before_size,
+    const unsigned char *after,
+    size_t after_size);
+
+#endif

--- a/tests/test_pdf_trim_internal.h
+++ b/tests/test_pdf_trim_internal.h
@@ -36,5 +36,6 @@ int trim_raw_expect_production_boxes(
 
 int trim_run_frame_mode_tests(void);
 int trim_run_policy_tests(void);
+int trim_run_batch_tests(void);
 
 #endif

--- a/tests/test_pdf_trim_internal.h
+++ b/tests/test_pdf_trim_internal.h
@@ -23,4 +23,6 @@ int trim_raw_expect_preserved_graph(
     const unsigned char *after,
     size_t after_size);
 
+int trim_run_frame_mode_tests(void);
+
 #endif

--- a/tests/test_pdf_trim_internal.h
+++ b/tests/test_pdf_trim_internal.h
@@ -23,6 +23,18 @@ int trim_raw_expect_preserved_graph(
     const unsigned char *after,
     size_t after_size);
 
+int trim_raw_expect_production_boxes(
+    const unsigned char *data,
+    size_t size,
+    int page_index,
+    int expect_bleed,
+    const float bleed[4],
+    int expect_trim,
+    const float trim[4],
+    int expect_art,
+    const float art[4]);
+
 int trim_run_frame_mode_tests(void);
+int trim_run_policy_tests(void);
 
 #endif

--- a/tests/test_pdf_trim_internal.h
+++ b/tests/test_pdf_trim_internal.h
@@ -37,5 +37,6 @@ int trim_raw_expect_production_boxes(
 int trim_run_frame_mode_tests(void);
 int trim_run_policy_tests(void);
 int trim_run_batch_tests(void);
+int trim_run_outside_crop_test(void);
 
 #endif

--- a/tests/test_pdf_trim_main.c
+++ b/tests/test_pdf_trim_main.c
@@ -6,5 +6,7 @@ int main(void)
 {
     if (!trim_run_frame_mode_tests())
         return 1;
+    if (!trim_run_policy_tests())
+        return 1;
     return extractpdf_pdf_trim_base_main();
 }

--- a/tests/test_pdf_trim_main.c
+++ b/tests/test_pdf_trim_main.c
@@ -8,5 +8,7 @@ int main(void)
         return 1;
     if (!trim_run_policy_tests())
         return 1;
+    if (!trim_run_batch_tests())
+        return 1;
     return extractpdf_pdf_trim_base_main();
 }

--- a/tests/test_pdf_trim_main.c
+++ b/tests/test_pdf_trim_main.c
@@ -10,5 +10,7 @@ int main(void)
         return 1;
     if (!trim_run_batch_tests())
         return 1;
+    if (!trim_run_outside_crop_test())
+        return 1;
     return extractpdf_pdf_trim_base_main();
 }

--- a/tests/test_pdf_trim_main.c
+++ b/tests/test_pdf_trim_main.c
@@ -1,0 +1,10 @@
+#include "test_pdf_trim_internal.h"
+
+int extractpdf_pdf_trim_base_main(void);
+
+int main(void)
+{
+    if (!trim_run_frame_mode_tests())
+        return 1;
+    return extractpdf_pdf_trim_base_main();
+}

--- a/tests/test_pdf_trim_outside_crop.c
+++ b/tests/test_pdf_trim_outside_crop.c
@@ -1,0 +1,273 @@
+#include <extractpdf/extractpdf.h>
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <mupdf/fitz.h>
+#include <mupdf/pdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.01f;
+}
+
+static void check_rect_close(extractpdf_rect actual, extractpdf_rect expected)
+{
+    CHECK(close_float(actual.x0, expected.x0));
+    CHECK(close_float(actual.y0, expected.y0));
+    CHECK(close_float(actual.x1, expected.x1));
+    CHECK(close_float(actual.y1, expected.y1));
+}
+
+static void sibling_fixture_path(
+    const char *name,
+    char *out_path,
+    size_t capacity)
+{
+    const char *slash = strrchr(TRIM_INTERACTIVE_PDF, '/');
+    const char *backslash = strrchr(TRIM_INTERACTIVE_PDF, '\\');
+    const char *separator = slash;
+    size_t prefix;
+    size_t name_size = strlen(name);
+
+    if (backslash != NULL && (separator == NULL || backslash > separator))
+        separator = backslash;
+    CHECK(separator != NULL);
+    prefix = (size_t)(separator - TRIM_INTERACTIVE_PDF) + 1;
+    CHECK(prefix + name_size + 1 <= capacity);
+    memcpy(out_path, TRIM_INTERACTIVE_PDF, prefix);
+    memcpy(out_path + prefix, name, name_size + 1);
+}
+
+static extractpdf_document *open_document(const char *path)
+{
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(document != NULL);
+    return document;
+}
+
+static extractpdf_rect page_box(
+    extractpdf_document *document,
+    extractpdf_page_box box)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_box_bounds(page, box, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_rect page_bounds(extractpdf_document *document)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_page_trim make_trim(extractpdf_rect bounds)
+{
+    extractpdf_page_trim trim;
+
+    trim.struct_size = sizeof(trim);
+    trim.page_index = 0;
+    trim.bounds = bounds;
+    return trim;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static int raw_box_matches(
+    fz_context *ctx,
+    pdf_obj *box,
+    const float expected[4])
+{
+    int index;
+
+    if (!pdf_is_array(ctx, box) || pdf_array_len(ctx, box) != 4)
+        return 0;
+    for (index = 0; index < 4; ++index) {
+        pdf_obj *value = pdf_array_get(ctx, box, index);
+        if (!pdf_is_number(ctx, value) ||
+            fabsf(pdf_to_real(ctx, value) - expected[index]) >= 0.001f)
+            return 0;
+    }
+    return 1;
+}
+
+static int raw_expect_outside_relation(
+    const unsigned char *data,
+    size_t size,
+    const float expected_media[4],
+    const float expected_crop[4])
+{
+    fz_context *ctx = NULL;
+    fz_stream *stream = NULL;
+    pdf_document *document = NULL;
+    int ok = 0;
+
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return 0;
+
+    fz_var(stream);
+    fz_var(document);
+    fz_var(ok);
+    fz_try(ctx)
+    {
+        pdf_obj *page;
+        pdf_obj *media;
+        pdf_obj *crop;
+        float mx0;
+        float my0;
+        float mx1;
+        float my1;
+        float cx0;
+        float cy0;
+        float cx1;
+        float cy1;
+
+        stream = fz_open_memory(ctx, data, size);
+        document = pdf_open_document_with_stream(ctx, stream);
+        page = pdf_lookup_page_obj(ctx, document, 0);
+        media = pdf_dict_get_inheritable(ctx, page, PDF_NAME(MediaBox));
+        crop = pdf_dict_get_inheritable(ctx, page, PDF_NAME(CropBox));
+        if (!raw_box_matches(ctx, media, expected_media) ||
+            !raw_box_matches(ctx, crop, expected_crop))
+            break;
+
+        mx0 = fminf(pdf_to_real(ctx, pdf_array_get(ctx, media, 0)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, media, 2)));
+        my0 = fminf(pdf_to_real(ctx, pdf_array_get(ctx, media, 1)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, media, 3)));
+        mx1 = fmaxf(pdf_to_real(ctx, pdf_array_get(ctx, media, 0)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, media, 2)));
+        my1 = fmaxf(pdf_to_real(ctx, pdf_array_get(ctx, media, 1)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, media, 3)));
+        cx0 = fminf(pdf_to_real(ctx, pdf_array_get(ctx, crop, 0)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, crop, 2)));
+        cy0 = fminf(pdf_to_real(ctx, pdf_array_get(ctx, crop, 1)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, crop, 3)));
+        cx1 = fmaxf(pdf_to_real(ctx, pdf_array_get(ctx, crop, 0)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, crop, 2)));
+        cy1 = fmaxf(pdf_to_real(ctx, pdf_array_get(ctx, crop, 1)),
+                    pdf_to_real(ctx, pdf_array_get(ctx, crop, 3)));
+
+        ok = (cx0 < mx0 || cy0 < my0 || cx1 > mx1 || cy1 > my1) &&
+            fmaxf(mx0, cx0) < fminf(mx1, cx1) &&
+            fmaxf(my0, cy0) < fminf(my1, cy1);
+    }
+    fz_always(ctx)
+    {
+        pdf_drop_document(ctx, document);
+        fz_drop_stream(ctx, stream);
+    }
+    fz_catch(ctx)
+    {
+        ok = 0;
+    }
+
+    fz_drop_context(ctx);
+    return ok;
+}
+
+int trim_run_outside_crop_test(void)
+{
+    static const float source_media_raw[4] = {0, 0, 300, 200};
+    static const float crop_raw[4] = {-20, -10, 280, 190};
+    static const float changed_media_raw[4] = {10, 10, 290, 190};
+    char path[1024];
+    const char *output_path = "trim-outside-crop-output.pdf";
+    extractpdf_document *document;
+    extractpdf_document *reopened;
+    extractpdf_output *baseline = NULL;
+    extractpdf_output *changed = NULL;
+    const unsigned char *baseline_data = NULL;
+    const unsigned char *changed_data = NULL;
+    size_t baseline_size = 0;
+    size_t changed_size = 0;
+    extractpdf_rect source_media;
+    extractpdf_rect source_visible;
+    extractpdf_page_trim noop;
+    extractpdf_page_trim trim;
+
+    sibling_fixture_path("crop-cropbox-outside-media.pdf", path, sizeof(path));
+    document = open_document(path);
+    source_media = page_box(document, EXTRACTPDF_PAGE_BOX_MEDIA);
+    source_visible = page_bounds(document);
+    check_rect_close(source_media, (extractpdf_rect){0, -10, 300, 190});
+    check_rect_close(source_visible, (extractpdf_rect){0, 0, 280, 190});
+
+    noop = make_trim(source_media);
+    CHECK(extractpdf_trim_pages(document, &noop, 1, &baseline) == EXTRACTPDF_OK);
+    CHECK(baseline != NULL);
+    CHECK(extractpdf_output_data(
+              baseline, &baseline_data, &baseline_size) == EXTRACTPDF_OK);
+    CHECK(raw_expect_outside_relation(
+              baseline_data, baseline_size, source_media_raw, crop_raw));
+
+    trim = make_trim((extractpdf_rect){10, 0, 290, 180});
+    CHECK(extractpdf_trim_pages(document, &trim, 1, &changed) == EXTRACTPDF_OK);
+    CHECK(changed != NULL);
+    CHECK(extractpdf_output_data(
+              changed, &changed_data, &changed_size) == EXTRACTPDF_OK);
+    CHECK(raw_expect_outside_relation(
+              changed_data, changed_size, changed_media_raw, crop_raw));
+    CHECK(trim_raw_expect_preserved_cropbox(
+              baseline_data, baseline_size, changed_data, changed_size, 0));
+    CHECK(trim_raw_expect_preserved_graph(
+              baseline_data, baseline_size, changed_data, changed_size));
+
+    check_rect_close(
+        page_box(document, EXTRACTPDF_PAGE_BOX_MEDIA), source_media);
+    check_rect_close(page_bounds(document), source_visible);
+
+    (void)remove(output_path);
+    CHECK(write_bytes(output_path, changed_data, changed_size));
+    reopened = open_document(output_path);
+    check_rect_close(page_bounds(reopened), (extractpdf_rect){0, 0, 270, 180});
+    check_rect_close(
+        page_box(reopened, EXTRACTPDF_PAGE_BOX_CROP),
+        (extractpdf_rect){0, 0, 270, 180});
+    check_rect_close(
+        page_box(reopened, EXTRACTPDF_PAGE_BOX_MEDIA),
+        (extractpdf_rect){0, 0, 280, 180});
+    extractpdf_close(reopened);
+    (void)remove(output_path);
+
+    extractpdf_drop_output(changed);
+    extractpdf_drop_output(baseline);
+    extractpdf_close(document);
+    return 1;
+}

--- a/tests/test_pdf_trim_policy.c
+++ b/tests/test_pdf_trim_policy.c
@@ -1,0 +1,268 @@
+#include <extractpdf/extractpdf.h>
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.01f;
+}
+
+static void check_rect_close(extractpdf_rect actual, extractpdf_rect expected)
+{
+    CHECK(close_float(actual.x0, expected.x0));
+    CHECK(close_float(actual.y0, expected.y0));
+    CHECK(close_float(actual.x1, expected.x1));
+    CHECK(close_float(actual.y1, expected.y1));
+}
+
+static void sibling_fixture_path(
+    const char *name,
+    char *out_path,
+    size_t capacity)
+{
+    const char *slash = strrchr(TRIM_INTERACTIVE_PDF, '/');
+    const char *backslash = strrchr(TRIM_INTERACTIVE_PDF, '\\');
+    const char *separator = slash;
+    size_t prefix;
+    size_t name_size = strlen(name);
+
+    if (backslash != NULL && (separator == NULL || backslash > separator))
+        separator = backslash;
+    CHECK(separator != NULL);
+    prefix = (size_t)(separator - TRIM_INTERACTIVE_PDF) + 1;
+    CHECK(prefix + name_size + 1 <= capacity);
+    memcpy(out_path, TRIM_INTERACTIVE_PDF, prefix);
+    memcpy(out_path + prefix, name, name_size + 1);
+}
+
+static extractpdf_document *open_document(const char *path)
+{
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(document != NULL);
+    return document;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static extractpdf_rect page_box(
+    extractpdf_document *document,
+    int page_index,
+    extractpdf_page_box box)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_box_bounds(page, box, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_rect page_bounds(
+    extractpdf_document *document,
+    int page_index)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_page_trim make_trim(int page_index, extractpdf_rect bounds)
+{
+    extractpdf_page_trim trim;
+
+    trim.struct_size = sizeof(trim);
+    trim.page_index = page_index;
+    trim.bounds = bounds;
+    return trim;
+}
+
+static void run_transformed_case(
+    const char *fixture_name,
+    float inset_x,
+    float inset_y,
+    const float expected_raw[4])
+{
+    char path[1024];
+    char output_path[128];
+    extractpdf_document *document;
+    extractpdf_document *reopened;
+    extractpdf_output *baseline = NULL;
+    extractpdf_output *changed = NULL;
+    const unsigned char *baseline_data = NULL;
+    const unsigned char *changed_data = NULL;
+    size_t baseline_size = 0;
+    size_t changed_size = 0;
+    extractpdf_rect source_media;
+    extractpdf_rect source_after;
+    extractpdf_rect requested;
+    extractpdf_page_trim full;
+    extractpdf_page_trim trim;
+
+    sibling_fixture_path(fixture_name, path, sizeof(path));
+    snprintf(output_path, sizeof(output_path), "trim-policy-%s", fixture_name);
+    document = open_document(path);
+    source_media = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    CHECK(source_media.x1 - source_media.x0 > 2.0f * inset_x);
+    CHECK(source_media.y1 - source_media.y0 > 2.0f * inset_y);
+
+    full = make_trim(0, source_media);
+    requested = (extractpdf_rect){
+        source_media.x0 + inset_x,
+        source_media.y0 + inset_y,
+        source_media.x1 - inset_x,
+        source_media.y1 - inset_y};
+    trim = make_trim(0, requested);
+
+    CHECK(extractpdf_trim_pages(document, &full, 1, &baseline) == EXTRACTPDF_OK);
+    CHECK(baseline != NULL);
+    CHECK(extractpdf_output_data(
+              baseline, &baseline_data, &baseline_size) == EXTRACTPDF_OK);
+    CHECK(baseline_data != NULL && baseline_size != 0);
+
+    CHECK(extractpdf_trim_pages(document, &trim, 1, &changed) == EXTRACTPDF_OK);
+    CHECK(changed != NULL);
+    CHECK(extractpdf_output_data(
+              changed, &changed_data, &changed_size) == EXTRACTPDF_OK);
+    CHECK(changed_data != NULL && changed_size != 0);
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_data, changed_size, 0, 1, expected_raw));
+    CHECK(trim_raw_expect_preserved_cropbox(
+              baseline_data, baseline_size, changed_data, changed_size, 0));
+    CHECK(trim_raw_expect_preserved_graph(
+              baseline_data, baseline_size, changed_data, changed_size));
+
+    source_after = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    check_rect_close(source_after, source_media);
+
+    (void)remove(output_path);
+    CHECK(write_bytes(output_path, changed_data, changed_size));
+    reopened = open_document(output_path);
+    check_rect_close(
+        page_bounds(reopened, 0),
+        (extractpdf_rect){
+            0.0f,
+            0.0f,
+            requested.x1 - requested.x0,
+            requested.y1 - requested.y0});
+    check_rect_close(
+        page_box(reopened, 0, EXTRACTPDF_PAGE_BOX_MEDIA),
+        page_bounds(reopened, 0));
+    check_rect_close(
+        page_box(reopened, 0, EXTRACTPDF_PAGE_BOX_CROP),
+        page_bounds(reopened, 0));
+
+    extractpdf_close(reopened);
+    extractpdf_drop_output(changed);
+    extractpdf_drop_output(baseline);
+    extractpdf_close(document);
+    (void)remove(output_path);
+}
+
+static void test_default_boxes(void)
+{
+    static const float bleed[4] = {10, 10, 390, 290};
+    static const float trim_box[4] = {20, 20, 380, 280};
+    static const float art[4] = {30, 30, 370, 270};
+    static const float changed0[4] = {20, 20, 380, 280};
+    static const float changed1[4] = {40, 30, 360, 270};
+    char path[1024];
+    extractpdf_document *document;
+    extractpdf_output *baseline = NULL;
+    extractpdf_output *changed = NULL;
+    const unsigned char *baseline_data = NULL;
+    const unsigned char *changed_data = NULL;
+    size_t baseline_size = 0;
+    size_t changed_size = 0;
+    extractpdf_rect media0;
+    extractpdf_rect media1;
+    extractpdf_page_trim noops[2];
+    extractpdf_page_trim trims[2];
+
+    sibling_fixture_path("trim-default-boxes.pdf", path, sizeof(path));
+    document = open_document(path);
+    media0 = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    media1 = page_box(document, 1, EXTRACTPDF_PAGE_BOX_MEDIA);
+    check_rect_close(media0, (extractpdf_rect){0, 0, 400, 300});
+    check_rect_close(media1, media0);
+
+    noops[0] = make_trim(0, media0);
+    noops[1] = make_trim(1, media1);
+    CHECK(extractpdf_trim_pages(document, noops, 2, &baseline) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(
+              baseline, &baseline_data, &baseline_size) == EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_production_boxes(
+              baseline_data, baseline_size, 0,
+              0, NULL, 0, NULL, 0, NULL));
+    CHECK(trim_raw_expect_production_boxes(
+              baseline_data, baseline_size, 1,
+              1, bleed, 1, trim_box, 1, art));
+
+    trims[0] = make_trim(0, (extractpdf_rect){20, 20, 380, 280});
+    trims[1] = make_trim(1, (extractpdf_rect){40, 30, 360, 270});
+    CHECK(extractpdf_trim_pages(document, trims, 2, &changed) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(
+              changed, &changed_data, &changed_size) == EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_data, changed_size, 0, 1, changed0));
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_data, changed_size, 1, 1, changed1));
+    CHECK(trim_raw_expect_production_boxes(
+              changed_data, changed_size, 0,
+              0, NULL, 0, NULL, 0, NULL));
+    CHECK(trim_raw_expect_production_boxes(
+              changed_data, changed_size, 1,
+              1, bleed, 1, trim_box, 1, art));
+    CHECK(trim_raw_expect_preserved_graph(
+              baseline_data, baseline_size, changed_data, changed_size));
+
+    check_rect_close(page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA), media0);
+    check_rect_close(page_box(document, 1, EXTRACTPDF_PAGE_BOX_MEDIA), media1);
+
+    extractpdf_drop_output(changed);
+    extractpdf_drop_output(baseline);
+    extractpdf_close(document);
+}
+
+int trim_run_policy_tests(void)
+{
+    static const float rotate_raw[4] = {20, 20, 380, 280};
+    static const float userunit_raw[4] = {10, 10, 190, 140};
+
+    run_transformed_case("trim-rotate-90.pdf", 20.0f, 20.0f, rotate_raw);
+    run_transformed_case("trim-userunit.pdf", 20.0f, 20.0f, userunit_raw);
+    test_default_boxes();
+    return 1;
+}

--- a/tests/test_pdf_trim_raw.c
+++ b/tests/test_pdf_trim_raw.c
@@ -1,0 +1,356 @@
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <mupdf/fitz.h>
+#include <mupdf/pdf.h>
+#include <stddef.h>
+
+static pdf_document *open_pdf_bytes(
+    fz_context *ctx,
+    const unsigned char *data,
+    size_t size)
+{
+    fz_stream *stream = NULL;
+    pdf_document *document = NULL;
+
+    fz_var(stream);
+    fz_var(document);
+    fz_try(ctx)
+    {
+        stream = fz_open_memory(ctx, data, size);
+        document = pdf_open_document_with_stream(ctx, stream);
+    }
+    fz_always(ctx)
+    {
+        fz_drop_stream(ctx, stream);
+    }
+    fz_catch(ctx)
+    {
+        pdf_drop_document(ctx, document);
+        fz_rethrow(ctx);
+    }
+    return document;
+}
+
+static int dict_has_local_key(
+    fz_context *ctx,
+    pdf_obj *dictionary,
+    pdf_obj *key,
+    pdf_obj **out_value)
+{
+    int count;
+    int index;
+
+    if (out_value != NULL)
+        *out_value = NULL;
+    if (!pdf_is_dict(ctx, dictionary))
+        return 0;
+
+    count = pdf_dict_len(ctx, dictionary);
+    for (index = 0; index < count; ++index) {
+        if (pdf_name_eq(ctx, pdf_dict_get_key(ctx, dictionary, index), key)) {
+            if (out_value != NULL)
+                *out_value = pdf_dict_get_val(ctx, dictionary, index);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.001f;
+}
+
+static int box_matches(
+    fz_context *ctx,
+    pdf_obj *box,
+    const float expected[4])
+{
+    int index;
+
+    if (expected == NULL || !pdf_is_array(ctx, box) ||
+        pdf_array_len(ctx, box) != 4)
+        return 0;
+    for (index = 0; index < 4; ++index) {
+        pdf_obj *item = pdf_array_get(ctx, box, index);
+        if (!pdf_is_number(ctx, item) ||
+            !close_float(pdf_to_real(ctx, item), expected[index]))
+            return 0;
+    }
+    return 1;
+}
+
+int trim_raw_expect_local_mediabox(
+    const unsigned char *data,
+    size_t size,
+    int page_index,
+    int expect_present,
+    const float expected[4])
+{
+    fz_context *ctx = NULL;
+    pdf_document *document = NULL;
+    int ok = 0;
+
+    if (data == NULL || size == 0 || page_index < 0)
+        return 0;
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return 0;
+
+    fz_var(document);
+    fz_var(ok);
+    fz_try(ctx)
+    {
+        pdf_obj *page;
+        pdf_obj *box = NULL;
+        int present;
+
+        document = open_pdf_bytes(ctx, data, size);
+        page = pdf_lookup_page_obj(ctx, document, page_index);
+        present = dict_has_local_key(ctx, page, PDF_NAME(MediaBox), &box);
+        if (present != expect_present)
+            ok = 0;
+        else if (!expect_present)
+            ok = 1;
+        else
+            ok = box_matches(ctx, box, expected);
+    }
+    fz_catch(ctx)
+    {
+        ok = 0;
+    }
+
+    pdf_drop_document(ctx, document);
+    fz_drop_context(ctx);
+    return ok;
+}
+
+static int obj_equal_deep_or_both_missing(
+    fz_context *ctx,
+    pdf_obj *left,
+    pdf_obj *right)
+{
+    if (left == NULL || pdf_is_null(ctx, left))
+        return right == NULL || pdf_is_null(ctx, right);
+    if (right == NULL || pdf_is_null(ctx, right))
+        return 0;
+    return pdf_objcmp_deep(ctx, left, right) == 0;
+}
+
+int trim_raw_expect_preserved_cropbox(
+    const unsigned char *before,
+    size_t before_size,
+    const unsigned char *after,
+    size_t after_size,
+    int page_index)
+{
+    fz_context *ctx = NULL;
+    pdf_document *before_doc = NULL;
+    pdf_document *after_doc = NULL;
+    int ok = 0;
+
+    if (before == NULL || before_size == 0 || after == NULL ||
+        after_size == 0 || page_index < 0)
+        return 0;
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return 0;
+
+    fz_var(before_doc);
+    fz_var(after_doc);
+    fz_var(ok);
+    fz_try(ctx)
+    {
+        pdf_obj *before_page;
+        pdf_obj *after_page;
+        pdf_obj *before_crop;
+        pdf_obj *after_crop;
+        int before_local;
+        int after_local;
+
+        before_doc = open_pdf_bytes(ctx, before, before_size);
+        after_doc = open_pdf_bytes(ctx, after, after_size);
+        before_page = pdf_lookup_page_obj(ctx, before_doc, page_index);
+        after_page = pdf_lookup_page_obj(ctx, after_doc, page_index);
+        before_local = dict_has_local_key(
+            ctx, before_page, PDF_NAME(CropBox), NULL);
+        after_local = dict_has_local_key(
+            ctx, after_page, PDF_NAME(CropBox), NULL);
+        before_crop = pdf_dict_get_inheritable(
+            ctx, before_page, PDF_NAME(CropBox));
+        after_crop = pdf_dict_get_inheritable(
+            ctx, after_page, PDF_NAME(CropBox));
+        ok = before_local == after_local &&
+            obj_equal_deep_or_both_missing(ctx, before_crop, after_crop);
+    }
+    fz_catch(ctx)
+    {
+        ok = 0;
+    }
+
+    pdf_drop_document(ctx, after_doc);
+    pdf_drop_document(ctx, before_doc);
+    fz_drop_context(ctx);
+    return ok;
+}
+
+static int compare_page_payload(
+    fz_context *ctx,
+    pdf_document *before,
+    pdf_document *after,
+    int page_index)
+{
+    pdf_obj *left = pdf_lookup_page_obj(ctx, before, page_index);
+    pdf_obj *right = pdf_lookup_page_obj(ctx, after, page_index);
+
+    if (!pdf_is_dict(ctx, left) || !pdf_is_dict(ctx, right))
+        return 0;
+    if (!obj_equal_deep_or_both_missing(
+            ctx,
+            pdf_dict_get(ctx, left, PDF_NAME(Contents)),
+            pdf_dict_get(ctx, right, PDF_NAME(Contents))))
+        return 0;
+    if (!obj_equal_deep_or_both_missing(
+            ctx,
+            pdf_dict_get(ctx, left, PDF_NAME(Resources)),
+            pdf_dict_get(ctx, right, PDF_NAME(Resources))))
+        return 0;
+
+    {
+        pdf_obj *left_annots = pdf_dict_get(ctx, left, PDF_NAME(Annots));
+        pdf_obj *right_annots = pdf_dict_get(ctx, right, PDF_NAME(Annots));
+        int left_count = pdf_array_len(ctx, left_annots);
+        int right_count = pdf_array_len(ctx, right_annots);
+        int index;
+
+        if (left_count != right_count)
+            return 0;
+        for (index = 0; index < left_count; ++index) {
+            pdf_obj *left_annot = pdf_array_get(ctx, left_annots, index);
+            pdf_obj *right_annot = pdf_array_get(ctx, right_annots, index);
+            static pdf_obj *keys[] = {
+                PDF_NAME(Subtype), PDF_NAME(Rect), PDF_NAME(F),
+                PDF_NAME(Contents), PDF_NAME(A), PDF_NAME(Dest),
+                PDF_NAME(AS), NULL
+            };
+            int key_index;
+
+            if (!pdf_is_dict(ctx, left_annot) || !pdf_is_dict(ctx, right_annot))
+                return 0;
+            for (key_index = 0; keys[key_index] != NULL; ++key_index) {
+                if (!obj_equal_deep_or_both_missing(
+                        ctx,
+                        pdf_dict_get(ctx, left_annot, keys[key_index]),
+                        pdf_dict_get(ctx, right_annot, keys[key_index])))
+                    return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+static int compare_root_semantics(
+    fz_context *ctx,
+    pdf_document *before,
+    pdf_document *after)
+{
+    pdf_obj *left_root = pdf_dict_get(
+        ctx, pdf_trailer(ctx, before), PDF_NAME(Root));
+    pdf_obj *right_root = pdf_dict_get(
+        ctx, pdf_trailer(ctx, after), PDF_NAME(Root));
+    pdf_obj *left_acroform;
+    pdf_obj *right_acroform;
+    pdf_obj *left_outlines;
+    pdf_obj *right_outlines;
+
+    if (!pdf_is_dict(ctx, left_root) || !pdf_is_dict(ctx, right_root))
+        return 0;
+
+    left_acroform = pdf_dict_get(ctx, left_root, PDF_NAME(AcroForm));
+    right_acroform = pdf_dict_get(ctx, right_root, PDF_NAME(AcroForm));
+    if (!obj_equal_deep_or_both_missing(ctx, left_acroform, right_acroform)) {
+        if ((left_acroform == NULL) != (right_acroform == NULL))
+            return 0;
+        if (left_acroform != NULL) {
+            pdf_obj *left_fields = pdf_dict_get(
+                ctx, left_acroform, PDF_NAME(Fields));
+            pdf_obj *right_fields = pdf_dict_get(
+                ctx, right_acroform, PDF_NAME(Fields));
+            if (pdf_array_len(ctx, left_fields) !=
+                pdf_array_len(ctx, right_fields))
+                return 0;
+        }
+    }
+
+    left_outlines = pdf_dict_get(ctx, left_root, PDF_NAME(Outlines));
+    right_outlines = pdf_dict_get(ctx, right_root, PDF_NAME(Outlines));
+    if ((left_outlines == NULL) != (right_outlines == NULL))
+        return 0;
+    if (left_outlines != NULL) {
+        pdf_obj *left_first = pdf_dict_get(
+            ctx, left_outlines, PDF_NAME(First));
+        pdf_obj *right_first = pdf_dict_get(
+            ctx, right_outlines, PDF_NAME(First));
+        static pdf_obj *keys[] = {
+            PDF_NAME(Title), PDF_NAME(Dest), PDF_NAME(A), NULL
+        };
+        int index;
+
+        if (!pdf_is_dict(ctx, left_first) || !pdf_is_dict(ctx, right_first))
+            return 0;
+        for (index = 0; keys[index] != NULL; ++index) {
+            if (!obj_equal_deep_or_both_missing(
+                    ctx,
+                    pdf_dict_get(ctx, left_first, keys[index]),
+                    pdf_dict_get(ctx, right_first, keys[index])))
+                return 0;
+        }
+    }
+    return 1;
+}
+
+int trim_raw_expect_preserved_graph(
+    const unsigned char *before,
+    size_t before_size,
+    const unsigned char *after,
+    size_t after_size)
+{
+    fz_context *ctx = NULL;
+    pdf_document *before_doc = NULL;
+    pdf_document *after_doc = NULL;
+    int ok = 0;
+
+    if (before == NULL || before_size == 0 || after == NULL || after_size == 0)
+        return 0;
+    ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
+    if (ctx == NULL)
+        return 0;
+
+    fz_var(before_doc);
+    fz_var(after_doc);
+    fz_var(ok);
+    fz_try(ctx)
+    {
+        int page_count;
+        int index;
+
+        before_doc = open_pdf_bytes(ctx, before, before_size);
+        after_doc = open_pdf_bytes(ctx, after, after_size);
+        page_count = pdf_count_pages(ctx, before_doc);
+        ok = page_count == pdf_count_pages(ctx, after_doc);
+        for (index = 0; ok && index < page_count; ++index)
+            ok = compare_page_payload(ctx, before_doc, after_doc, index);
+        if (ok)
+            ok = compare_root_semantics(ctx, before_doc, after_doc);
+    }
+    fz_catch(ctx)
+    {
+        ok = 0;
+    }
+
+    pdf_drop_document(ctx, after_doc);
+    pdf_drop_document(ctx, before_doc);
+    fz_drop_context(ctx);
+    return ok;
+}

--- a/tests/test_pdf_trim_raw.c
+++ b/tests/test_pdf_trim_raw.c
@@ -195,6 +195,26 @@ int trim_raw_expect_preserved_cropbox(
     return ok;
 }
 
+static int compare_dict_keys(
+    fz_context *ctx,
+    pdf_obj *left,
+    pdf_obj *right,
+    pdf_obj *const *keys)
+{
+    int index;
+
+    if (!pdf_is_dict(ctx, left) || !pdf_is_dict(ctx, right))
+        return 0;
+    for (index = 0; keys[index] != NULL; ++index) {
+        if (!obj_equal_deep_or_both_missing(
+                ctx,
+                pdf_dict_get(ctx, left, keys[index]),
+                pdf_dict_get(ctx, right, keys[index])))
+            return 0;
+    }
+    return 1;
+}
+
 static int compare_page_payload(
     fz_context *ctx,
     pdf_document *before,
@@ -203,6 +223,10 @@ static int compare_page_payload(
 {
     pdf_obj *left = pdf_lookup_page_obj(ctx, before, page_index);
     pdf_obj *right = pdf_lookup_page_obj(ctx, after, page_index);
+    pdf_obj *left_annots;
+    pdf_obj *right_annots;
+    int count;
+    int index;
 
     if (!pdf_is_dict(ctx, left) || !pdf_is_dict(ctx, right))
         return 0;
@@ -217,34 +241,87 @@ static int compare_page_payload(
             pdf_dict_get(ctx, right, PDF_NAME(Resources))))
         return 0;
 
-    {
-        pdf_obj *left_annots = pdf_dict_get(ctx, left, PDF_NAME(Annots));
-        pdf_obj *right_annots = pdf_dict_get(ctx, right, PDF_NAME(Annots));
-        int left_count = pdf_array_len(ctx, left_annots);
-        int right_count = pdf_array_len(ctx, right_annots);
-        int index;
+    left_annots = pdf_dict_get(ctx, left, PDF_NAME(Annots));
+    right_annots = pdf_dict_get(ctx, right, PDF_NAME(Annots));
+    if ((left_annots == NULL) != (right_annots == NULL))
+        return 0;
+    if (left_annots == NULL)
+        return 1;
+    count = pdf_array_len(ctx, left_annots);
+    if (count != pdf_array_len(ctx, right_annots))
+        return 0;
 
-        if (left_count != right_count)
+    for (index = 0; index < count; ++index) {
+        static pdf_obj *keys[] = {
+            PDF_NAME(Subtype), PDF_NAME(Rect), PDF_NAME(F),
+            PDF_NAME(Contents), PDF_NAME(A), PDF_NAME(Dest),
+            PDF_NAME(AS), PDF_NAME(T), PDF_NAME(FT), PDF_NAME(V), NULL
+        };
+        pdf_obj *left_annot = pdf_array_get(ctx, left_annots, index);
+        pdf_obj *right_annot = pdf_array_get(ctx, right_annots, index);
+        if (!compare_dict_keys(ctx, left_annot, right_annot, keys))
             return 0;
-        for (index = 0; index < left_count; ++index) {
-            pdf_obj *left_annot = pdf_array_get(ctx, left_annots, index);
-            pdf_obj *right_annot = pdf_array_get(ctx, right_annots, index);
-            static pdf_obj *keys[] = {
-                PDF_NAME(Subtype), PDF_NAME(Rect), PDF_NAME(F),
-                PDF_NAME(Contents), PDF_NAME(A), PDF_NAME(Dest),
-                PDF_NAME(AS), NULL
-            };
-            int key_index;
+    }
+    return 1;
+}
 
-            if (!pdf_is_dict(ctx, left_annot) || !pdf_is_dict(ctx, right_annot))
+static int compare_acroform(
+    fz_context *ctx,
+    pdf_obj *left_root,
+    pdf_obj *right_root)
+{
+    pdf_obj *left_form = pdf_dict_get(ctx, left_root, PDF_NAME(AcroForm));
+    pdf_obj *right_form = pdf_dict_get(ctx, right_root, PDF_NAME(AcroForm));
+    pdf_obj *left_fields;
+    pdf_obj *right_fields;
+    int count;
+    int index;
+
+    if ((left_form == NULL) != (right_form == NULL))
+        return 0;
+    if (left_form == NULL)
+        return 1;
+    if (!obj_equal_deep_or_both_missing(
+            ctx,
+            pdf_dict_get(ctx, left_form, PDF_NAME(NeedAppearances)),
+            pdf_dict_get(ctx, right_form, PDF_NAME(NeedAppearances))))
+        return 0;
+
+    left_fields = pdf_dict_get(ctx, left_form, PDF_NAME(Fields));
+    right_fields = pdf_dict_get(ctx, right_form, PDF_NAME(Fields));
+    count = pdf_array_len(ctx, left_fields);
+    if (count != pdf_array_len(ctx, right_fields))
+        return 0;
+
+    for (index = 0; index < count; ++index) {
+        static pdf_obj *field_keys[] = {
+            PDF_NAME(FT), PDF_NAME(T), PDF_NAME(V), PDF_NAME(Ff), NULL
+        };
+        pdf_obj *left_field = pdf_array_get(ctx, left_fields, index);
+        pdf_obj *right_field = pdf_array_get(ctx, right_fields, index);
+        pdf_obj *left_kids;
+        pdf_obj *right_kids;
+        int kid_count;
+        int kid_index;
+
+        if (!compare_dict_keys(ctx, left_field, right_field, field_keys))
+            return 0;
+        left_kids = pdf_dict_get(ctx, left_field, PDF_NAME(Kids));
+        right_kids = pdf_dict_get(ctx, right_field, PDF_NAME(Kids));
+        kid_count = pdf_array_len(ctx, left_kids);
+        if (kid_count != pdf_array_len(ctx, right_kids))
+            return 0;
+        for (kid_index = 0; kid_index < kid_count; ++kid_index) {
+            static pdf_obj *kid_keys[] = {
+                PDF_NAME(Subtype), PDF_NAME(Rect), PDF_NAME(F),
+                PDF_NAME(FT), PDF_NAME(T), PDF_NAME(V), PDF_NAME(Ff), NULL
+            };
+            if (!compare_dict_keys(
+                    ctx,
+                    pdf_array_get(ctx, left_kids, kid_index),
+                    pdf_array_get(ctx, right_kids, kid_index),
+                    kid_keys))
                 return 0;
-            for (key_index = 0; keys[key_index] != NULL; ++key_index) {
-                if (!obj_equal_deep_or_both_missing(
-                        ctx,
-                        pdf_dict_get(ctx, left_annot, keys[key_index]),
-                        pdf_dict_get(ctx, right_annot, keys[key_index])))
-                    return 0;
-            }
         }
     }
     return 1;
@@ -259,53 +336,28 @@ static int compare_root_semantics(
         ctx, pdf_trailer(ctx, before), PDF_NAME(Root));
     pdf_obj *right_root = pdf_dict_get(
         ctx, pdf_trailer(ctx, after), PDF_NAME(Root));
-    pdf_obj *left_acroform;
-    pdf_obj *right_acroform;
     pdf_obj *left_outlines;
     pdf_obj *right_outlines;
 
     if (!pdf_is_dict(ctx, left_root) || !pdf_is_dict(ctx, right_root))
         return 0;
-
-    left_acroform = pdf_dict_get(ctx, left_root, PDF_NAME(AcroForm));
-    right_acroform = pdf_dict_get(ctx, right_root, PDF_NAME(AcroForm));
-    if (!obj_equal_deep_or_both_missing(ctx, left_acroform, right_acroform)) {
-        if ((left_acroform == NULL) != (right_acroform == NULL))
-            return 0;
-        if (left_acroform != NULL) {
-            pdf_obj *left_fields = pdf_dict_get(
-                ctx, left_acroform, PDF_NAME(Fields));
-            pdf_obj *right_fields = pdf_dict_get(
-                ctx, right_acroform, PDF_NAME(Fields));
-            if (pdf_array_len(ctx, left_fields) !=
-                pdf_array_len(ctx, right_fields))
-                return 0;
-        }
-    }
+    if (!compare_acroform(ctx, left_root, right_root))
+        return 0;
 
     left_outlines = pdf_dict_get(ctx, left_root, PDF_NAME(Outlines));
     right_outlines = pdf_dict_get(ctx, right_root, PDF_NAME(Outlines));
     if ((left_outlines == NULL) != (right_outlines == NULL))
         return 0;
     if (left_outlines != NULL) {
+        static pdf_obj *keys[] = {
+            PDF_NAME(Title), PDF_NAME(Dest), PDF_NAME(A), NULL
+        };
         pdf_obj *left_first = pdf_dict_get(
             ctx, left_outlines, PDF_NAME(First));
         pdf_obj *right_first = pdf_dict_get(
             ctx, right_outlines, PDF_NAME(First));
-        static pdf_obj *keys[] = {
-            PDF_NAME(Title), PDF_NAME(Dest), PDF_NAME(A), NULL
-        };
-        int index;
-
-        if (!pdf_is_dict(ctx, left_first) || !pdf_is_dict(ctx, right_first))
+        if (!compare_dict_keys(ctx, left_first, right_first, keys))
             return 0;
-        for (index = 0; keys[index] != NULL; ++index) {
-            if (!obj_equal_deep_or_both_missing(
-                    ctx,
-                    pdf_dict_get(ctx, left_first, keys[index]),
-                    pdf_dict_get(ctx, right_first, keys[index])))
-                return 0;
-        }
     }
     return 1;
 }

--- a/tests/test_pdf_trim_required.c
+++ b/tests/test_pdf_trim_required.c
@@ -1,0 +1,229 @@
+#include <extractpdf/extractpdf.h>
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.01f;
+}
+
+static void check_point_close(extractpdf_point actual, extractpdf_point expected)
+{
+    CHECK(close_float(actual.x, expected.x));
+    CHECK(close_float(actual.y, expected.y));
+}
+
+static extractpdf_point shifted_point(extractpdf_point point, float x, float y)
+{
+    point.x -= x;
+    point.y -= y;
+    return point;
+}
+
+static void sibling_fixture_path(
+    const char *name,
+    char *out_path,
+    size_t capacity)
+{
+    const char *slash = strrchr(TRIM_INTERACTIVE_PDF, '/');
+    const char *backslash = strrchr(TRIM_INTERACTIVE_PDF, '\\');
+    const char *separator = slash;
+    size_t prefix;
+    size_t name_size = strlen(name);
+
+    if (backslash != NULL && (separator == NULL || backslash > separator))
+        separator = backslash;
+    CHECK(separator != NULL);
+    prefix = (size_t)(separator - TRIM_INTERACTIVE_PDF) + 1;
+    CHECK(prefix + name_size + 1 <= capacity);
+    memcpy(out_path, TRIM_INTERACTIVE_PDF, prefix);
+    memcpy(out_path + prefix, name, name_size + 1);
+}
+
+static extractpdf_document *open_document(const char *path)
+{
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(document != NULL);
+    return document;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static extractpdf_page_trim make_trim(
+    int page_index,
+    float x0,
+    float y0,
+    float x1,
+    float y1)
+{
+    extractpdf_page_trim trim;
+
+    trim.struct_size = sizeof(trim);
+    trim.page_index = page_index;
+    trim.bounds = (extractpdf_rect){x0, y0, x1, y1};
+    return trim;
+}
+
+static extractpdf_point internal_link_target(extractpdf_document *document)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_link_page *links = NULL;
+    extractpdf_point result = {0};
+    size_t count = 0;
+    size_t index;
+    int found = 0;
+
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_extract_links(page, &links) == EXTRACTPDF_OK);
+    CHECK(extractpdf_link_count(links, &count) == EXTRACTPDF_OK);
+    for (index = 0; index < count; ++index) {
+        extractpdf_link_info info = {0};
+        info.struct_size = sizeof(info);
+        CHECK(extractpdf_link_get_info(links, index, &info) == EXTRACTPDF_OK);
+        if (info.kind == EXTRACTPDF_LINK_INTERNAL) {
+            CHECK(info.target_page == 1);
+            result = info.target;
+            found = 1;
+            break;
+        }
+    }
+    CHECK(found);
+    extractpdf_drop_link_page(links);
+    extractpdf_drop_page(page);
+    return result;
+}
+
+static extractpdf_point outline_target(extractpdf_document *document)
+{
+    extractpdf_outline *outline = NULL;
+    extractpdf_outline_info info = {0};
+    size_t count = 0;
+
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+    CHECK(extractpdf_outline_count(outline, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    info.struct_size = sizeof(info);
+    CHECK(extractpdf_outline_get_info(outline, 0, &info) == EXTRACTPDF_OK);
+    CHECK(info.destination_kind == EXTRACTPDF_OUTLINE_DESTINATION_INTERNAL);
+    CHECK(info.target_page == 1);
+    extractpdf_drop_outline(outline);
+    return info.target;
+}
+
+static void check_render_dimensions(
+    extractpdf_document *document,
+    int page_index,
+    int expected_width,
+    int expected_height)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_bitmap *bitmap = NULL;
+    int width = 0;
+    int height = 0;
+    int stride = 0;
+    int components = 0;
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_render_page(page, &bitmap) == EXTRACTPDF_OK);
+    CHECK(bitmap != NULL);
+    CHECK(extractpdf_bitmap_dimensions(
+              bitmap, &width, &height, &stride, &components) == EXTRACTPDF_OK);
+    CHECK(width == expected_width);
+    CHECK(height == expected_height);
+    CHECK(stride > 0);
+    CHECK(components == 3 || components == 4);
+    extractpdf_drop_bitmap(bitmap);
+    extractpdf_drop_page(page);
+}
+
+static void test_render_and_trimmed_destinations(void)
+{
+    const char *output_path = "trim-required-output.pdf";
+    extractpdf_document *document = open_document(TRIM_INTERACTIVE_PDF);
+    extractpdf_document *reopened = NULL;
+    extractpdf_output *output = NULL;
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    extractpdf_point source_link = internal_link_target(document);
+    extractpdf_point source_outline = outline_target(document);
+    extractpdf_page_trim trims[2];
+
+    check_render_dimensions(document, 0, 400, 300);
+    trims[0] = make_trim(0, 40, 30, 360, 270);
+    trims[1] = make_trim(1, 20, 30, 380, 270);
+
+    CHECK(extractpdf_trim_pages(document, trims, 2, &output) == EXTRACTPDF_OK);
+    CHECK(output != NULL);
+    CHECK(extractpdf_output_data(output, &data, &size) == EXTRACTPDF_OK);
+    CHECK(data != NULL && size != 0);
+    (void)remove(output_path);
+    CHECK(write_bytes(output_path, data, size));
+
+    reopened = open_document(output_path);
+    check_render_dimensions(reopened, 0, 320, 240);
+    check_point_close(
+        internal_link_target(reopened), shifted_point(source_link, 20, 30));
+    check_point_close(
+        outline_target(reopened), shifted_point(source_outline, 20, 30));
+    extractpdf_close(reopened);
+    reopened = NULL;
+    (void)remove(output_path);
+
+    check_render_dimensions(document, 0, 400, 300);
+    check_point_close(internal_link_target(document), source_link);
+    check_point_close(outline_target(document), source_outline);
+
+    extractpdf_drop_output(output);
+    extractpdf_close(document);
+}
+
+static void test_empty_post_trim_intersection_rejected(void)
+{
+    char path[1024];
+    extractpdf_document *document;
+    extractpdf_output *output = (extractpdf_output *)(uintptr_t)1;
+    extractpdf_page_trim trim;
+
+    sibling_fixture_path("trim-preserved-crop.pdf", path, sizeof(path));
+    document = open_document(path);
+    trim = make_trim(0, -50, -40, -10, -5);
+    CHECK(extractpdf_trim_pages(document, &trim, 1, &output) ==
+          EXTRACTPDF_ERROR_ARGUMENT);
+    CHECK(output == NULL);
+    extractpdf_close(document);
+}
+
+int trim_run_required_observation_tests(void)
+{
+    test_render_and_trimmed_destinations();
+    test_empty_post_trim_intersection_rejected();
+    return 1;
+}

--- a/tests/test_pdf_trim_transforms.c
+++ b/tests/test_pdf_trim_transforms.c
@@ -1,0 +1,590 @@
+#include <extractpdf/extractpdf.h>
+#include "test_pdf_trim_internal.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct trim_observation {
+    extractpdf_rect page_bounds;
+    extractpdf_rect media_bounds;
+    extractpdf_rect crop_bounds;
+    extractpdf_rect text_bounds;
+    extractpdf_quad image_quad;
+    extractpdf_rect uri_hotspot;
+    char uri[128];
+    extractpdf_rect internal_hotspot;
+    int internal_target_page;
+    extractpdf_point internal_target;
+    extractpdf_annotation_info annotation;
+    char annotation_contents[128];
+    extractpdf_form_field_info field;
+    char field_name[128];
+    char field_value[128];
+    extractpdf_form_widget_info widget;
+    extractpdf_outline_info outline;
+    char outline_title[128];
+} trim_observation;
+
+static void check_impl(int ok, const char *expr, int line)
+{
+    if (!ok) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expr);
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) check_impl((x), #x, __LINE__)
+
+static int close_float(float left, float right)
+{
+    return fabsf(left - right) < 0.01f;
+}
+
+static void check_rect_close(extractpdf_rect actual, extractpdf_rect expected)
+{
+    CHECK(close_float(actual.x0, expected.x0));
+    CHECK(close_float(actual.y0, expected.y0));
+    CHECK(close_float(actual.x1, expected.x1));
+    CHECK(close_float(actual.y1, expected.y1));
+}
+
+static void check_point_close(extractpdf_point actual, extractpdf_point expected)
+{
+    CHECK(close_float(actual.x, expected.x));
+    CHECK(close_float(actual.y, expected.y));
+}
+
+static extractpdf_rect shifted_rect(extractpdf_rect rect, float x, float y)
+{
+    rect.x0 -= x;
+    rect.x1 -= x;
+    rect.y0 -= y;
+    rect.y1 -= y;
+    return rect;
+}
+
+static extractpdf_point shifted_point(extractpdf_point point, float x, float y)
+{
+    point.x -= x;
+    point.y -= y;
+    return point;
+}
+
+static void check_quad_shifted(
+    extractpdf_quad actual,
+    extractpdf_quad source,
+    float x,
+    float y)
+{
+    check_point_close(actual.ul, shifted_point(source.ul, x, y));
+    check_point_close(actual.ur, shifted_point(source.ur, x, y));
+    check_point_close(actual.ll, shifted_point(source.ll, x, y));
+    check_point_close(actual.lr, shifted_point(source.lr, x, y));
+}
+
+static void copy_text(
+    char *destination,
+    size_t capacity,
+    const char *source,
+    size_t size)
+{
+    CHECK(destination != NULL);
+    CHECK(capacity != 0);
+    CHECK(source != NULL);
+    CHECK(size < capacity);
+    memcpy(destination, source, size);
+    destination[size] = '\0';
+}
+
+static void sibling_fixture_path(
+    const char *name,
+    char *out_path,
+    size_t capacity)
+{
+    const char *slash = strrchr(TRIM_INTERACTIVE_PDF, '/');
+    const char *backslash = strrchr(TRIM_INTERACTIVE_PDF, '\\');
+    const char *separator = slash;
+    size_t prefix;
+    size_t name_size = strlen(name);
+
+    if (backslash != NULL && (separator == NULL || backslash > separator))
+        separator = backslash;
+    CHECK(separator != NULL);
+    prefix = (size_t)(separator - TRIM_INTERACTIVE_PDF) + 1;
+    CHECK(prefix + name_size + 1 <= capacity);
+    memcpy(out_path, TRIM_INTERACTIVE_PDF, prefix);
+    memcpy(out_path + prefix, name, name_size + 1);
+}
+
+static extractpdf_document *open_document(const char *path)
+{
+    extractpdf_document *document = NULL;
+
+    CHECK(extractpdf_open(path, NULL, &document) == EXTRACTPDF_OK);
+    CHECK(document != NULL);
+    return document;
+}
+
+static int write_bytes(const char *path, const unsigned char *data, size_t size)
+{
+    FILE *file = fopen(path, "wb");
+
+    if (file == NULL)
+        return 0;
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fclose(file);
+        return 0;
+    }
+    return fclose(file) == 0;
+}
+
+static extractpdf_rect page_box(
+    extractpdf_document *document,
+    int page_index,
+    extractpdf_page_box box)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_box_bounds(page, box, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_rect page_bounds(
+    extractpdf_document *document,
+    int page_index)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_rect bounds = {0};
+
+    CHECK(extractpdf_load_page(document, page_index, &page) == EXTRACTPDF_OK);
+    CHECK(page != NULL);
+    CHECK(extractpdf_page_bounds(page, &bounds) == EXTRACTPDF_OK);
+    extractpdf_drop_page(page);
+    return bounds;
+}
+
+static extractpdf_rect find_text_bounds(
+    extractpdf_page *page,
+    const char *needle)
+{
+    extractpdf_text_page *text = NULL;
+    size_t block_count = 0;
+    size_t block_index;
+    extractpdf_rect result = {0};
+    int found = 0;
+
+    CHECK(extractpdf_extract_structured_text(page, &text) == EXTRACTPDF_OK);
+    CHECK(text != NULL);
+    CHECK(extractpdf_text_block_count(text, &block_count) == EXTRACTPDF_OK);
+    for (block_index = 0; block_index < block_count && !found; ++block_index) {
+        size_t line_count = 0;
+        size_t line_index;
+        CHECK(extractpdf_text_line_count(text, block_index, &line_count) ==
+              EXTRACTPDF_OK);
+        for (line_index = 0; line_index < line_count && !found; ++line_index) {
+            size_t span_count = 0;
+            size_t span_index;
+            CHECK(extractpdf_text_span_count(
+                      text, block_index, line_index, &span_count) ==
+                  EXTRACTPDF_OK);
+            for (span_index = 0; span_index < span_count; ++span_index) {
+                const char *span_text = NULL;
+                size_t span_size = 0;
+                extractpdf_text_span_info info = {0};
+
+                CHECK(extractpdf_text_span_text(
+                          text, block_index, line_index, span_index,
+                          &span_text, &span_size) == EXTRACTPDF_OK);
+                if (span_text == NULL || strstr(span_text, needle) == NULL)
+                    continue;
+                info.struct_size = sizeof(info);
+                CHECK(extractpdf_text_get_span_info(
+                          text, block_index, line_index, span_index, &info) ==
+                      EXTRACTPDF_OK);
+                result = info.bounds;
+                found = 1;
+                break;
+            }
+        }
+    }
+    extractpdf_drop_text_page(text);
+    CHECK(found);
+    return result;
+}
+
+static void capture_observation(
+    extractpdf_document *document,
+    trim_observation *observation)
+{
+    extractpdf_page *page = NULL;
+    extractpdf_image_page *images = NULL;
+    extractpdf_link_page *links = NULL;
+    extractpdf_annotation_page *annotations = NULL;
+    extractpdf_form *form = NULL;
+    extractpdf_outline *outline = NULL;
+    size_t count = 0;
+    size_t index;
+    int saw_uri = 0;
+    int saw_internal = 0;
+
+    memset(observation, 0, sizeof(*observation));
+    observation->annotation.struct_size = sizeof(observation->annotation);
+    observation->field.struct_size = sizeof(observation->field);
+    observation->widget.struct_size = sizeof(observation->widget);
+    observation->outline.struct_size = sizeof(observation->outline);
+
+    CHECK(extractpdf_load_page(document, 0, &page) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_bounds(page, &observation->page_bounds) == EXTRACTPDF_OK);
+    CHECK(extractpdf_page_box_bounds(
+              page, EXTRACTPDF_PAGE_BOX_MEDIA, &observation->media_bounds) ==
+          EXTRACTPDF_OK);
+    CHECK(extractpdf_page_box_bounds(
+              page, EXTRACTPDF_PAGE_BOX_CROP, &observation->crop_bounds) ==
+          EXTRACTPDF_OK);
+    observation->text_bounds = find_text_bounds(page, "TRIM-TEXT");
+
+    CHECK(extractpdf_extract_images(page, &images) == EXTRACTPDF_OK);
+    CHECK(extractpdf_image_count(images, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    {
+        extractpdf_image_info info = {0};
+        info.struct_size = sizeof(info);
+        CHECK(extractpdf_image_get_info(images, 0, &info) == EXTRACTPDF_OK);
+        observation->image_quad = info.quad;
+    }
+
+    CHECK(extractpdf_extract_links(page, &links) == EXTRACTPDF_OK);
+    CHECK(extractpdf_link_count(links, &count) == EXTRACTPDF_OK);
+    CHECK(count == 2);
+    for (index = 0; index < count; ++index) {
+        extractpdf_link_info info = {0};
+        info.struct_size = sizeof(info);
+        CHECK(extractpdf_link_get_info(links, index, &info) == EXTRACTPDF_OK);
+        if (info.kind == EXTRACTPDF_LINK_URI) {
+            const char *uri = NULL;
+            size_t uri_size = 0;
+            CHECK(extractpdf_link_uri(links, index, &uri, &uri_size) ==
+                  EXTRACTPDF_OK);
+            observation->uri_hotspot = info.hotspot;
+            copy_text(observation->uri, sizeof(observation->uri), uri, uri_size);
+            saw_uri = 1;
+        }
+        else if (info.kind == EXTRACTPDF_LINK_INTERNAL) {
+            observation->internal_hotspot = info.hotspot;
+            observation->internal_target_page = info.target_page;
+            observation->internal_target = info.target;
+            saw_internal = 1;
+        }
+    }
+    CHECK(saw_uri && saw_internal);
+
+    CHECK(extractpdf_extract_annotations(page, &annotations) == EXTRACTPDF_OK);
+    CHECK(extractpdf_annotation_count(annotations, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(extractpdf_annotation_get_info(
+              annotations, 0, &observation->annotation) == EXTRACTPDF_OK);
+    {
+        const char *contents = NULL;
+        size_t contents_size = 0;
+        CHECK(extractpdf_annotation_contents(
+                  annotations, 0, &contents, &contents_size) == EXTRACTPDF_OK);
+        copy_text(
+            observation->annotation_contents,
+            sizeof(observation->annotation_contents),
+            contents,
+            contents_size);
+    }
+
+    CHECK(extractpdf_document_form(document, &form) == EXTRACTPDF_OK);
+    CHECK(form != NULL);
+    CHECK(extractpdf_form_field_count(form, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(extractpdf_form_field_get_info(form, 0, &observation->field) ==
+          EXTRACTPDF_OK);
+    {
+        const char *name = NULL;
+        size_t name_size = 0;
+        extractpdf_form_value_info value_info = {0};
+        const char *value = NULL;
+        size_t value_size = 0;
+
+        CHECK(extractpdf_form_field_name(form, 0, &name, &name_size) ==
+              EXTRACTPDF_OK);
+        copy_text(observation->field_name, sizeof(observation->field_name),
+                  name, name_size);
+        CHECK(observation->field.value_count == 1);
+        value_info.struct_size = sizeof(value_info);
+        CHECK(extractpdf_form_field_value_get_info(
+                  form, 0, 0, &value_info) == EXTRACTPDF_OK);
+        CHECK(value_info.kind == EXTRACTPDF_FORM_VALUE_UTF8);
+        CHECK(extractpdf_form_field_value_utf8(
+                  form, 0, 0, &value, &value_size) == EXTRACTPDF_OK);
+        copy_text(observation->field_value, sizeof(observation->field_value),
+                  value, value_size);
+    }
+    CHECK(extractpdf_form_widget_count(form, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(extractpdf_form_widget_get_info(form, 0, &observation->widget) ==
+          EXTRACTPDF_OK);
+
+    CHECK(extractpdf_document_outline(document, &outline) == EXTRACTPDF_OK);
+    CHECK(outline != NULL);
+    CHECK(extractpdf_outline_count(outline, &count) == EXTRACTPDF_OK);
+    CHECK(count == 1);
+    CHECK(extractpdf_outline_get_info(outline, 0, &observation->outline) ==
+          EXTRACTPDF_OK);
+    {
+        const char *title = NULL;
+        size_t title_size = 0;
+        CHECK(extractpdf_outline_title(outline, 0, &title, &title_size) ==
+              EXTRACTPDF_OK);
+        copy_text(observation->outline_title, sizeof(observation->outline_title),
+                  title, title_size);
+    }
+
+    extractpdf_drop_outline(outline);
+    extractpdf_drop_form(form);
+    extractpdf_drop_annotation_page(annotations);
+    extractpdf_drop_link_page(links);
+    extractpdf_drop_image_page(images);
+    extractpdf_drop_page(page);
+}
+
+static void expect_source_same(
+    const trim_observation *actual,
+    const trim_observation *source)
+{
+    check_rect_close(actual->page_bounds, source->page_bounds);
+    check_rect_close(actual->media_bounds, source->media_bounds);
+    check_rect_close(actual->crop_bounds, source->crop_bounds);
+    check_rect_close(actual->text_bounds, source->text_bounds);
+    check_quad_shifted(actual->image_quad, source->image_quad, 0, 0);
+    check_rect_close(actual->uri_hotspot, source->uri_hotspot);
+    CHECK(strcmp(actual->uri, source->uri) == 0);
+    check_rect_close(actual->internal_hotspot, source->internal_hotspot);
+    CHECK(actual->internal_target_page == source->internal_target_page);
+    check_point_close(actual->internal_target, source->internal_target);
+    CHECK(actual->annotation.type == source->annotation.type);
+    CHECK(actual->annotation.flags == source->annotation.flags);
+    check_rect_close(actual->annotation.bounds, source->annotation.bounds);
+    CHECK(strcmp(actual->annotation_contents, source->annotation_contents) == 0);
+    CHECK(actual->field.type == source->field.type);
+    CHECK(actual->field.flags == source->field.flags);
+    CHECK(strcmp(actual->field_name, source->field_name) == 0);
+    CHECK(strcmp(actual->field_value, source->field_value) == 0);
+    CHECK(actual->widget.field_index == source->widget.field_index);
+    CHECK(actual->widget.page_index == source->widget.page_index);
+    CHECK(actual->widget.flags == source->widget.flags);
+    check_rect_close(actual->widget.bounds, source->widget.bounds);
+    CHECK(actual->outline.destination_kind == source->outline.destination_kind);
+    CHECK(actual->outline.target_page == source->outline.target_page);
+    check_point_close(actual->outline.target, source->outline.target);
+    CHECK(strcmp(actual->outline_title, source->outline_title) == 0);
+}
+
+static void expect_no_crop_trimmed(
+    const trim_observation *actual,
+    const trim_observation *source)
+{
+    check_rect_close(actual->page_bounds,
+                     (extractpdf_rect){0, 0, 320, 240});
+    check_rect_close(actual->media_bounds, actual->page_bounds);
+    check_rect_close(actual->crop_bounds, actual->page_bounds);
+    check_rect_close(actual->text_bounds,
+                     shifted_rect(source->text_bounds, 40, 30));
+    check_quad_shifted(actual->image_quad, source->image_quad, 40, 30);
+    check_rect_close(actual->uri_hotspot,
+                     shifted_rect(source->uri_hotspot, 40, 30));
+    CHECK(strcmp(actual->uri, source->uri) == 0);
+    check_rect_close(actual->internal_hotspot,
+                     shifted_rect(source->internal_hotspot, 40, 30));
+    CHECK(actual->internal_target_page == source->internal_target_page);
+    check_point_close(actual->internal_target, source->internal_target);
+    CHECK(actual->annotation.type == source->annotation.type);
+    CHECK(actual->annotation.flags == source->annotation.flags);
+    check_rect_close(actual->annotation.bounds,
+                     shifted_rect(source->annotation.bounds, 40, 30));
+    CHECK(strcmp(actual->annotation_contents, source->annotation_contents) == 0);
+    CHECK(actual->field.type == source->field.type);
+    CHECK(actual->field.flags == source->field.flags);
+    CHECK(strcmp(actual->field_name, "trim.text") == 0);
+    CHECK(strcmp(actual->field_name, source->field_name) == 0);
+    CHECK(strcmp(actual->field_value, "TRIM-VALUE") == 0);
+    CHECK(strcmp(actual->field_value, source->field_value) == 0);
+    CHECK(actual->widget.field_index == source->widget.field_index);
+    CHECK(actual->widget.page_index == source->widget.page_index);
+    CHECK(actual->widget.flags == source->widget.flags);
+    check_rect_close(actual->widget.bounds,
+                     shifted_rect(source->widget.bounds, 40, 30));
+    CHECK(actual->outline.destination_kind == source->outline.destination_kind);
+    CHECK(actual->outline.target_page == source->outline.target_page);
+    check_point_close(actual->outline.target, source->outline.target);
+    CHECK(strcmp(actual->outline_title, source->outline_title) == 0);
+}
+
+static extractpdf_page_trim make_trim(
+    int page_index,
+    extractpdf_rect bounds)
+{
+    extractpdf_page_trim trim;
+    trim.struct_size = sizeof(trim);
+    trim.page_index = page_index;
+    trim.bounds = bounds;
+    return trim;
+}
+
+static void test_no_crop_interactive(void)
+{
+    extractpdf_document *document = open_document(TRIM_INTERACTIVE_PDF);
+    extractpdf_output *seed = NULL;
+    extractpdf_output *changed = NULL;
+    const unsigned char *seed_data = NULL;
+    const unsigned char *changed_data = NULL;
+    size_t seed_size = 0;
+    size_t changed_size = 0;
+    extractpdf_rect media = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    extractpdf_page_trim full = make_trim(0, media);
+    extractpdf_page_trim trim = make_trim(
+        0, (extractpdf_rect){40, 30, 360, 270});
+    trim_observation source;
+    trim_observation source_after;
+    trim_observation output_observation;
+    const float expected_raw[4] = {40, 30, 360, 270};
+    const char *output_path = "trim-interactive-output.pdf";
+    extractpdf_document *reopened;
+
+    capture_observation(document, &source);
+    CHECK(strcmp(source.uri, "https://example.com/trim") == 0);
+    CHECK(strcmp(source.annotation_contents, "TRIM-ANNOT") == 0);
+    CHECK(strcmp(source.field_name, "trim.text") == 0);
+    CHECK(strcmp(source.field_value, "TRIM-VALUE") == 0);
+
+    CHECK(extractpdf_trim_pages(document, &full, 1, &seed) == EXTRACTPDF_OK);
+    CHECK(seed != NULL);
+    CHECK(extractpdf_output_data(seed, &seed_data, &seed_size) == EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_local_mediabox(seed_data, seed_size, 0, 0, NULL));
+
+    CHECK(extractpdf_trim_pages(document, &trim, 1, &changed) == EXTRACTPDF_OK);
+    CHECK(changed != NULL);
+    capture_observation(document, &source_after);
+    expect_source_same(&source_after, &source);
+
+    extractpdf_close(document);
+    document = NULL;
+
+    CHECK(extractpdf_output_data(changed, &changed_data, &changed_size) ==
+          EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_data, changed_size, 0, 1, expected_raw));
+    CHECK(trim_raw_expect_preserved_cropbox(
+              seed_data, seed_size, changed_data, changed_size, 0));
+    CHECK(trim_raw_expect_preserved_graph(
+              seed_data, seed_size, changed_data, changed_size));
+    CHECK(write_bytes(output_path, changed_data, changed_size));
+
+    reopened = open_document(output_path);
+    capture_observation(reopened, &output_observation);
+    expect_no_crop_trimmed(&output_observation, &source);
+    extractpdf_close(reopened);
+    remove(output_path);
+
+    extractpdf_drop_output(changed);
+    extractpdf_drop_output(seed);
+}
+
+static void test_preserved_crop_frames(void)
+{
+    char path[1024];
+    const char *output_path = "trim-preserved-output.pdf";
+    extractpdf_document *document;
+    extractpdf_document *reopened;
+    extractpdf_output *seed = NULL;
+    extractpdf_output *changed = NULL;
+    const unsigned char *seed_data = NULL;
+    const unsigned char *changed_data = NULL;
+    size_t seed_size = 0;
+    size_t changed_size = 0;
+    extractpdf_rect media0;
+    extractpdf_rect media1;
+    extractpdf_rect visible0;
+    extractpdf_page_trim full;
+    extractpdf_page_trim trims[2];
+    const float physical_raw[4] = {20, 20, 380, 280};
+    const float clipped_raw[4] = {80, 60, 380, 280};
+
+    sibling_fixture_path("trim-preserved-crop.pdf", path, sizeof(path));
+    document = open_document(path);
+    media0 = page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA);
+    media1 = page_box(document, 1, EXTRACTPDF_PAGE_BOX_MEDIA);
+    visible0 = page_bounds(document, 0);
+    check_rect_close(media0, (extractpdf_rect){-50, -40, 350, 260});
+    check_rect_close(media1, media0);
+    check_rect_close(visible0, (extractpdf_rect){0, 0, 300, 220});
+
+    full = make_trim(0, media0);
+    CHECK(extractpdf_trim_pages(document, &full, 1, &seed) == EXTRACTPDF_OK);
+    CHECK(extractpdf_output_data(seed, &seed_data, &seed_size) == EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_local_mediabox(seed_data, seed_size, 0, 0, NULL));
+
+    trims[0] = make_trim(0, (extractpdf_rect){
+        media0.x0 + 20, media0.y0 + 20,
+        media0.x1 - 20, media0.y1 - 20});
+    trims[1] = make_trim(1, (extractpdf_rect){
+        media1.x0 + 80, media1.y0 + 20,
+        media1.x1 - 20, media1.y1 - 60});
+
+    CHECK(extractpdf_trim_pages(document, trims, 2, &changed) == EXTRACTPDF_OK);
+    CHECK(changed != NULL);
+    CHECK(extractpdf_output_data(changed, &changed_data, &changed_size) ==
+          EXTRACTPDF_OK);
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_data, changed_size, 0, 1, physical_raw));
+    CHECK(trim_raw_expect_local_mediabox(
+              changed_data, changed_size, 1, 1, clipped_raw));
+    CHECK(trim_raw_expect_preserved_cropbox(
+              seed_data, seed_size, changed_data, changed_size, 0));
+    CHECK(trim_raw_expect_preserved_cropbox(
+              seed_data, seed_size, changed_data, changed_size, 1));
+    CHECK(trim_raw_expect_preserved_graph(
+              seed_data, seed_size, changed_data, changed_size));
+
+    check_rect_close(
+        page_box(document, 0, EXTRACTPDF_PAGE_BOX_MEDIA), media0);
+    check_rect_close(
+        page_box(document, 1, EXTRACTPDF_PAGE_BOX_MEDIA), media1);
+
+    CHECK(write_bytes(output_path, changed_data, changed_size));
+    reopened = open_document(output_path);
+
+    check_rect_close(page_bounds(reopened, 0),
+                     (extractpdf_rect){0, 0, 300, 220});
+    check_rect_close(page_box(reopened, 0, EXTRACTPDF_PAGE_BOX_CROP),
+                     (extractpdf_rect){0, 0, 300, 220});
+    check_rect_close(page_box(reopened, 0, EXTRACTPDF_PAGE_BOX_MEDIA),
+                     (extractpdf_rect){-30, -20, 330, 240});
+
+    check_rect_close(page_bounds(reopened, 1),
+                     (extractpdf_rect){0, 0, 270, 200});
+    check_rect_close(page_box(reopened, 1, EXTRACTPDF_PAGE_BOX_CROP),
+                     (extractpdf_rect){0, 0, 270, 200});
+    check_rect_close(page_box(reopened, 1, EXTRACTPDF_PAGE_BOX_MEDIA),
+                     (extractpdf_rect){0, -20, 300, 200});
+
+    extractpdf_close(reopened);
+    remove(output_path);
+    extractpdf_drop_output(changed);
+    extractpdf_drop_output(seed);
+    extractpdf_close(document);
+}
+
+int trim_run_frame_mode_tests(void)
+{
+    test_no_crop_interactive();
+    test_preserved_crop_frames();
+    return 1;
+}


### PR DESCRIPTION
Tracks #51. Child of #48 / #2.

Implements the approved MediaBox Physical Trim V1 design and its page-frame correction:

- `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-design.md`
- `docs/superpowers/specs/2026-08-29-extractpdf-mediabox-trim-frame-correction.md`
- `docs/superpowers/plans/2026-08-29-extractpdf-mediabox-trim.md`

Frozen candidate: `b6848783e621f2b081bd2b1007d1d684852b3af4`

Contract:
- immutable full-document MediaBox physical trim
- public trim rectangles use current ExtractPDF/Fitz MediaBox page-space observation
- page-local `/MediaBox` is the sole semantic dictionary write
- real local/inherited `/CropBox` is preserved raw; page-frame change is classified by effective visible intersection before/after trim
- physical-only trim leaves effective visible intersection/public frame unchanged
- clipping trim re-anchors output frame to the new effective MediaBox/CropBox intersection
- BleedBox/TrimBox/ArtBox are opaque preservation state: no write/materialization/repair/trim-specific validation
- no page graft, content-stream rewrite, per-object geometry rewrite, annotation/form mutation, appearance regeneration, or JavaScript/form-runtime execution
- Rotate/UserUnit use shared strict page-box mapping
- encrypted/already-signed PDFs fail closed
- deterministic output, failure-atomic batches, source immutability, output lifetime independence

Exact-head proof:
- workflow #374 / run `33260296740` on `b6848783e621f2b081bd2b1007d1d684852b3af4`: Linux static + ASan/UBSan succeeded
- `full-ci` workflow #375 / run `33263229974` on the same frozen PR head:
  - Linux static 23/23
  - Linux ASan/UBSan 23/23
  - macOS ARM64 23/23
  - Windows DLL build succeeded; `extractpdf.dll`, `extractpdf_test_pdf_crop.exe`, and `extractpdf_test_pdf_trim.exe` built; 23/23 CTests passed

Final scope / forbidden-surface review:
- no Critical/Important blocker found
- no workflow file changes
- `src/pdf_page_box_common.c` and `src/pdf_trim_preflight.c` are read-only
- `src/pdf_trim.c` has exactly one semantic dictionary write: `/MediaBox`
- no submitted reviews or inline review threads
- master remains `3fc48b5fb0f7a07926f7942fc4a4a3fb5e93a753`

Task 8 is complete. PR intentionally remains DRAFT. Do not mark ready, merge, close #51, update Phase 6 as integrated, or start poster split without explicit integration authorization.