### PR TITLE
feat: add deterministic lossless PDF rewrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(QuantaPDF VERSION 2.0.0 LANGUAGES C CXX)
+project(QuantaPDF VERSION 2.1.0 LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 
@@ -54,6 +54,7 @@ add_library(quantapdf
   src/pdf_crop.c
   src/pdf_trim.c
   src/pdf_poster.c
+  src/pdf_rewrite.c
   src/pdf_export.c
   src/pdf_range.c
   src/pdf_merge.c

--- a/README.md
+++ b/README.md
@@ -203,10 +203,11 @@ does not deduplicate distinct reachable objects. Repeated calls on identical
 input—and rewriting a reopened result—produce byte-identical output.
 
 This API is deliberately strict. It does not repair damaged PDFs, recompress
-images, flatten interactive content, or change encryption. Inputs requiring
-structural recovery return `QUANTAPDF_ERROR_FORMAT`; encrypted or already
-signed inputs return `QUANTAPDF_ERROR_UNSUPPORTED`. The returned output owns
-its bytes independently of the source document.
+images, or flatten interactive content. It neither preserves nor creates
+encryption: encrypted input is rejected with `QUANTAPDF_ERROR_UNSUPPORTED`.
+Inputs requiring structural recovery return `QUANTAPDF_ERROR_FORMAT`, and
+already signed inputs return `QUANTAPDF_ERROR_UNSUPPORTED`. The returned
+output owns its bytes independently of the source document.
 
 ## Dependency model
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The current supported surface includes:
 - URI/internal links, annotations, document metadata, and outlines
 - immutable AcroForm snapshots and isolated PDF edit sessions
 - page export/range export, output merging, and file saving
-- immutable CropBox crop, MediaBox trim, and poster-split transforms
+- immutable CropBox crop, MediaBox trim, poster-split, and lossless rewrite/GC
+  transforms
 - stable status strings and one allocator-matched `quantapdf_free()` entry point
 
 ## API contract
@@ -184,6 +185,29 @@ quantapdf_render_thumbnail(page, max_width, max_height, &bitmap);
 
 renders opaque RGB while preserving the page aspect ratio. The result fits inside the requested pixel box and never upscales beyond the page's 72-DPI size. Thumbnail rendering derives a DPI and reuses the same renderer rather than maintaining a separate raster path.
 
+## Lossless rewrite and garbage collection
+
+```c
+quantapdf_output *rewritten = NULL;
+
+if (quantapdf_rewrite_lossless(doc, &rewritten) == QUANTAPDF_OK) {
+    quantapdf_output_save_file(rewritten, "canonical.pdf");
+    quantapdf_drop_output(rewritten);
+}
+```
+
+`quantapdf_rewrite_lossless()` performs a deterministic full rewrite with a
+fixed policy. It removes indirect objects unreachable from the trailer graph,
+rebuilds the cross-reference state, preserves existing stream encodings, and
+does not deduplicate distinct reachable objects. Repeated calls on identical
+input—and rewriting a reopened result—produce byte-identical output.
+
+This API is deliberately strict. It does not repair damaged PDFs, recompress
+images, flatten interactive content, or change encryption. Inputs requiring
+structural recovery return `QUANTAPDF_ERROR_FORMAT`; encrypted or already
+signed inputs return `QUANTAPDF_ERROR_UNSUPPORTED`. The returned output owns
+its bytes independently of the source document.
+
 ## Dependency model
 
 The backend foundation has two pinned dependency paths:
@@ -251,7 +275,7 @@ The test build stages `quantapdf.dll` beside every Windows test executable. Cons
 
 ## Tests
 
-CTest covers the document lifecycle plus Page + Render contracts, including invalid arguments, page geometry, MediaBox/CropBox coordinates, RGB/RGBA output, versioned render options, DPI, rotation, clipping, thumbnails, encrypted PDFs, malformed input, repeated lifecycle stress, interleaved handles, and UTF-8 paths.
+CTest covers the document lifecycle plus Page + Render contracts, including invalid arguments, page geometry, MediaBox/CropBox coordinates, RGB/RGBA output, versioned render options, DPI, rotation, clipping, thumbnails, encrypted PDFs, malformed input, repeated lifecycle stress, interleaved handles, UTF-8 paths, and deterministic lossless rewrite/GC semantics.
 
 Linux additionally runs AddressSanitizer and UndefinedBehaviorSanitizer.
 

--- a/abi/quantapdf-v2.exports
+++ b/abi/quantapdf-v2.exports
@@ -71,6 +71,7 @@ quantapdf_poster_split_pages
 quantapdf_render_page
 quantapdf_render_page_with_options
 quantapdf_render_thumbnail
+quantapdf_rewrite_lossless
 quantapdf_status_string
 quantapdf_text_block_count
 quantapdf_text_get_block_info

--- a/docs/superpowers/plans/2026-09-01-quantapdf-lossless-rewrite.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-lossless-rewrite.md
@@ -260,4 +260,3 @@ git commit -m "docs: describe lossless PDF rewrite"
 
 Push `feat/lossless-rewrite`, create a PR closing #56, add `full-ci`, and require
 Linux release/sanitizer, macOS, and Windows success on the exact final SHA.
-

--- a/docs/superpowers/plans/2026-09-01-quantapdf-lossless-rewrite.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-lossless-rewrite.md
@@ -1,0 +1,263 @@
+# QuantaPDF Lossless Rewrite / GC V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic, immutable, strict lossless PDF rewrite that removes unreachable objects and preserves reachable semantics.
+
+**Architecture:** A small C facade publishes an owning `quantapdf_output`; a private QPDF bridge reparses source bytes with recovery disabled, performs security/signature preflight, and writes with one fixed canonical policy. Public and raw-graph tests prove GC, semantic preservation, determinism, idempotence, ownership, and failure atomicity.
+
+**Tech Stack:** C11 public ABI, C++20 QPDF 12.4 bridge, PDFium observation/rendering backend, CMake/CTest.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-quantapdf-lossless-rewrite-design.md`
+
+## Global Constraints
+
+- Public release version becomes 2.1.0; ABI version and shared-library major remain 2.
+- The public ABI adds only `quantapdf_rewrite_lossless`; existing declarations and numeric values do not change.
+- The rewrite never performs lossy recompression, appearance generation, flattening, encryption changes, repair, or object deduplication.
+- Encrypted and signed documents fail with `QUANTAPDF_ERROR_UNSUPPORTED`.
+- Output publication is failure-atomic and output bytes outlive the source document.
+- Every production behavior is introduced by a witnessed RED test.
+
+---
+
+### Task 1: Public contract and append-only ABI
+
+**Files:**
+- Create: `tests/test_pdf_rewrite_lossless.c`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `include/quantapdf/quantapdf.h`
+- Create: `src/pdf_rewrite.c`
+- Modify: `CMakeLists.txt`
+- Modify: `abi/quantapdf-v2.exports`
+- Modify: `tests/test_version.c`
+
+**Interfaces:**
+- Consumes: `quantapdf_document`, `quantapdf_output`, `quantapdf_status`.
+- Produces: `quantapdf_status quantapdf_rewrite_lossless(quantapdf_document *, quantapdf_output **)`.
+
+- [ ] **Step 1: Write the compile and argument-contract test**
+
+Add a test that calls the wished-for public API and asserts:
+
+```c
+quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+CHECK(quantapdf_rewrite_lossless(NULL, &output) == QUANTAPDF_ERROR_ARGUMENT);
+CHECK(output == NULL);
+CHECK(quantapdf_rewrite_lossless(NULL, NULL) == QUANTAPDF_ERROR_ARGUMENT);
+```
+
+Register `quantapdf.pdf_rewrite_lossless` and compile the target against
+`QuantaPDF::QuantaPDF`.
+
+- [ ] **Step 2: Run the target and verify RED**
+
+Run:
+
+```powershell
+cmake --build --preset win-release-user --target quantapdf_test_pdf_rewrite_lossless
+```
+
+Expected: compilation fails because `quantapdf_rewrite_lossless` is undeclared.
+
+- [ ] **Step 3: Add the minimal public shell**
+
+Append the declaration to the transform section of the public header. Add
+`src/pdf_rewrite.c` with strict argument handling and NULL output reset. Until
+the backend is introduced, a valid document returns
+`QUANTAPDF_ERROR_UNSUPPORTED`; invalid calls pass the contract test.
+
+Add the source to `quantapdf`, append the sorted symbol to the v2 export
+baseline, change CMake project version and public macros to 2.1.0, and update
+the version test to expect minor version 1.
+
+- [ ] **Step 4: Build and run the focused tests**
+
+Run:
+
+```powershell
+cmake --fresh --preset win-release-user
+cmake --build --preset win-release-user --target quantapdf_test_pdf_rewrite_lossless quantapdf_test_version
+ctest --preset win-release-user -R "quantapdf.(version|abi_exports|pdf_rewrite_lossless)" --output-on-failure
+```
+
+Expected: version, exact export, and argument tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add CMakeLists.txt abi/quantapdf-v2.exports include/quantapdf/quantapdf.h src/pdf_rewrite.c tests/CMakeLists.txt tests/test_pdf_rewrite_lossless.c tests/test_version.c
+git commit -m "feat: publish the lossless rewrite contract"
+```
+
+### Task 2: Strict canonical writer and garbage collection
+
+**Files:**
+- Modify: `tests/test_pdf_rewrite_lossless.c`
+- Create: `tests/rewrite_test_helpers.cpp`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `src/pdf_rewrite.c`
+- Modify: `src/backend/qpdf_document.h`
+- Modify: `src/backend/qpdf_document.cpp`
+
+**Interfaces:**
+- Consumes: the Task 1 public function and source bytes owned by `quantapdf_document`.
+- Produces: `quantapdf_qpdf_rewrite_lossless(quantapdf_qpdf_document *, unsigned char **, size_t *)` plus test-only raw fixture helpers.
+
+- [ ] **Step 1: Add a real GC fixture and runtime RED**
+
+The C++ helper creates a PDF containing:
+
+```cpp
+auto garbage = pdf->makeIndirectObject(
+    QPDFObjectHandle::parse("<< /QuantaPDFGarbage true >>"));
+auto reachable = pdf->makeIndirectObject(
+    QPDFObjectHandle::parse("<< /QuantaPDFReachable true >>"));
+pdf->getRoot().replaceKey("/QuantaPDFReachable", reachable);
+writer.setPreserveUnreferencedObjects(true);
+```
+
+The public test opens that file, calls `quantapdf_rewrite_lossless`, and asserts
+success, source immutability, two repeated byte-identical outputs, removal of
+the garbage marker, and preservation of the reachable marker.
+
+- [ ] **Step 2: Run and verify runtime RED**
+
+Run the focused CTest. Expected: the valid-document call returns
+`QUANTAPDF_ERROR_UNSUPPORTED` from the Task 1 shell.
+
+- [ ] **Step 3: Implement strict parse, preflight, and writer**
+
+The private bridge must:
+
+```cpp
+auto pdf = QPDF::create();
+pdf->setSuppressWarnings(true);
+pdf->setAttemptRecovery(false);
+pdf->processMemoryFile("quantapdf-lossless-rewrite", source, size, password);
+(void)pdf->getAllPages();
+(void)pdf->getAllObjects();
+if (pdf->anyWarnings())
+    return QUANTAPDF_ERROR_FORMAT;
+```
+
+Reject encryption and signed field/catalog-permissions state, then use the
+existing fixed writer settings: deterministic ID, disabled object streams,
+preserved stream data, and discarded unreferenced objects. The C facade owns
+allocation and publishes only successful bytes.
+
+- [ ] **Step 4: Run focused tests GREEN**
+
+Build and run `quantapdf.pdf_rewrite_lossless` and `quantapdf.abi_exports`.
+Expected: GC, deterministic repeated calls, ownership, and export checks pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/pdf_rewrite.c src/backend/qpdf_document.h src/backend/qpdf_document.cpp tests/CMakeLists.txt tests/test_pdf_rewrite_lossless.c tests/rewrite_test_helpers.cpp
+git commit -m "feat: add deterministic lossless PDF rewrite"
+```
+
+### Task 3: Idempotence, semantics, and fail-closed matrix
+
+**Files:**
+- Modify: `tests/test_pdf_rewrite_lossless.c`
+- Modify: `tests/rewrite_test_helpers.cpp`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `src/backend/qpdf_document.cpp`
+
+**Interfaces:**
+- Consumes: the canonical writer from Task 2.
+- Produces: reopen-and-rewrite idempotence and explicit security/format boundaries.
+
+- [ ] **Step 1: Add idempotence and semantic RED assertions**
+
+Save the first output, close the source, reopen the output, rewrite it, and
+assert exact byte equality. Compare representative source/output page count,
+bounds, rendered bitmap bytes, text, metadata, outline, links, annotations,
+and form observations using literal fixtures and existing public APIs.
+
+- [ ] **Step 2: Add security and strict-format RED assertions**
+
+Create a catalog `/Perms /DocMDP` signature fixture, open the encrypted fixture
+with its known password, and open the repairable malformed fixture. Assert:
+
+```c
+expect_rewrite_error(encrypted, QUANTAPDF_ERROR_UNSUPPORTED);
+expect_rewrite_error(signed_pdf, QUANTAPDF_ERROR_UNSUPPORTED);
+expect_rewrite_error(repairable_bad, QUANTAPDF_ERROR_FORMAT);
+```
+
+Every failure must leave the sentinel output pointer NULL.
+
+- [ ] **Step 3: Run and classify RED**
+
+Run only `quantapdf.pdf_rewrite_lossless`. Expected failures must identify an
+unimplemented preflight branch or a non-idempotent writer policy, never fixture
+setup or an unrelated API failure.
+
+- [ ] **Step 4: Complete the minimal preflight/policy**
+
+Recognize effective signed fields and catalog permissions signatures without
+rejecting an unsigned empty signature field. Map malformed containers to
+`FORMAT`, signed/encrypted state to `UNSUPPORTED`, and adjust only the fixed
+writer policy if reopen idempotence proves false.
+
+- [ ] **Step 5: Run focused and full tests GREEN**
+
+Run the focused test, then all CTests. Expected: 29/29 pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/backend/qpdf_document.cpp tests/CMakeLists.txt tests/test_pdf_rewrite_lossless.c tests/rewrite_test_helpers.cpp
+git commit -m "test: prove lossless rewrite semantics"
+```
+
+### Task 4: Documentation and release verification
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: the completed 2.1.0 API.
+- Produces: user-facing transform contract and final verification evidence.
+
+- [ ] **Step 1: Document the supported transform**
+
+Add Lossless Rewrite/GC to the supported-surface list and document that it
+preserves stream encodings, discards unreachable objects, is deterministic and
+idempotent, and rejects encrypted/signed/recovery-requiring inputs.
+
+- [ ] **Step 2: Run fresh verification**
+
+Run:
+
+```powershell
+cmake --fresh --preset win-release-user
+cmake --build --preset win-release-user
+ctest --preset win-release-user --output-on-failure
+cmake --build --preset install-win-release-user
+```
+
+Expected: configure/build/install succeed and all 29 CTests pass.
+
+- [ ] **Step 3: Audit the installed ABI**
+
+Run the installed DLL through `cmake/CheckQuantaPDFExports.cmake`. Expected:
+exactly 84 named exports, including `quantapdf_rewrite_lossless`, with no
+unexpected or ordinal-only exports. Verify installed macros report 2.1.0 and
+ABI 2.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add README.md
+git commit -m "docs: describe lossless PDF rewrite"
+```
+
+- [ ] **Step 5: Push and open the PR**
+
+Push `feat/lossless-rewrite`, create a PR closing #56, add `full-ci`, and require
+Linux release/sanitizer, macOS, and Windows success on the exact final SHA.
+

--- a/docs/superpowers/specs/2026-09-01-quantapdf-lossless-rewrite-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-lossless-rewrite-design.md
@@ -1,0 +1,144 @@
+# QuantaPDF Lossless Rewrite / GC V1 Design
+
+**Status:** Approved for implementation by the continuing development request
+
+**Issue:** #56
+
+## Goal
+
+Add one immutable whole-document transform that emits a canonical full PDF,
+removes objects unreachable from the trailer graph, and preserves all reachable
+document semantics without lossy recompression or interactive-content changes.
+
+```c
+QUANTAPDF_API quantapdf_status quantapdf_rewrite_lossless(
+    quantapdf_document *document,
+    quantapdf_output **out_output);
+```
+
+This is a rewrite and garbage-collection primitive, not a generic optimizer.
+
+## Public contract
+
+- `document == NULL` or `out_output == NULL` returns
+  `QUANTAPDF_ERROR_ARGUMENT`.
+- Whenever `out_output` is non-NULL, `*out_output` is set to NULL before any
+  validation or backend work.
+- Success returns a new owning `quantapdf_output`. The output remains valid
+  after the source document is closed.
+- The source document and all of its public observations remain unchanged.
+- Encrypted input returns `QUANTAPDF_ERROR_UNSUPPORTED`, even when the caller
+  supplied a valid password to `quantapdf_open()`.
+- A document with an active signature field or catalog permissions signature
+  returns `QUANTAPDF_ERROR_UNSUPPORTED` because a full rewrite invalidates the
+  signature.
+- Structurally damaged input that requires backend recovery returns
+  `QUANTAPDF_ERROR_FORMAT`; this transform does not silently repair it.
+
+Adding this function is an append-only ABI v2 change. The release becomes
+2.1.0, `QUANTAPDF_ABI_VERSION` remains 2, and the shared-library major remains
+2. The v2 export baseline grows from 83 to 84 functions.
+
+## Rewrite policy
+
+The backend opens a fresh private QPDF graph from the source bytes and password.
+It disables parser recovery and suppresses warning output while retaining the
+ability to detect warnings. It forces the page and object graphs to load before
+writing. Any parse warning or exception is a format failure.
+
+The writer policy is fixed:
+
+- deterministic document ID;
+- conventional objects with object streams disabled;
+- source stream bytes and filter state preserved;
+- unreferenced objects discarded;
+- no content normalization;
+- no linearization;
+- no object deduplication;
+- no encryption preservation or creation.
+
+Disabling object streams is part of the canonical V1 representation. Preserving
+stream data avoids hidden image loss, filter changes, appearance regeneration,
+or platform-dependent recompression.
+
+## Reachability and garbage collection
+
+QPDF's writer traversal starts at the trailer and discards every indirect object
+not visited through that graph. Reachable sharing is preserved by indirect
+object identity. Distinct reachable objects are never merged merely because
+their serialized bytes match.
+
+V1 rejects a file that needs structural recovery even when the damaged object
+would otherwise be garbage. This intentionally favors a strict, reproducible
+kernel boundary over forensic repair behavior.
+
+## Signature preflight
+
+The preflight rejects:
+
+- an encrypted QPDF graph;
+- a reachable AcroForm field whose effective field type is `/Sig` and whose
+  value is non-null;
+- catalog `/Perms` entries `/DocMDP`, `/UR`, or `/UR3` when present.
+
+Malformed `/AcroForm`, `/Fields`, `/Kids`, or `/Perms` structures encountered
+by this preflight are format failures. Unsigned empty signature fields remain
+valid and are preserved.
+
+## Determinism and idempotence
+
+For identical source bytes, repeated calls must return byte-identical outputs.
+Reopening the first output and rewriting it again must also return the same
+bytes. This is enforced by the fixed writer policy and deterministic ID.
+
+If the pinned writer cannot satisfy reopen-and-rewrite idempotence, the feature
+must not ship with a weaker undocumented promise; implementation stops until
+the policy is corrected.
+
+## Semantic preservation
+
+Tests observe both raw graph behavior and public QuantaPDF behavior:
+
+- unreachable ordinary and stream objects disappear;
+- a reachable shared object remains reachable and shared;
+- page count, bounds, rendered pixels, extracted text, metadata, outline,
+  annotations, links, and AcroForm values remain unchanged on representative
+  fixtures;
+- the output reopens successfully after the source document is closed;
+- repeated and reopen-and-rewrite bytes are identical.
+
+## Failure atomicity
+
+The C facade allocates the output handle before calling the backend, but it does
+not publish it until the backend returns success. Every failure frees the shell
+and any backend buffer, leaving `*out_output == NULL`.
+
+All QPDF exceptions remain inside the C++ bridge and map to the established
+`quantapdf_status` values.
+
+## Non-goals
+
+- lossy image recompression or downsampling;
+- stream recompression or filter normalization;
+- annotation or Widget flattening;
+- page/content editing;
+- object deduplication;
+- linearization or incremental-save preservation;
+- encryption, decryption, or re-encryption;
+- signature preservation or removal;
+- generic damaged-file repair;
+- a public low-level PDF object API or writer options structure.
+
+## Files
+
+- `include/quantapdf/quantapdf.h`: append the public function and publish 2.1.0.
+- `src/pdf_rewrite.c`: owning C facade and failure-atomic output publication.
+- `src/backend/qpdf_document.h`: private rewrite bridge declaration.
+- `src/backend/qpdf_document.cpp`: strict preflight and fixed writer policy.
+- `tests/test_pdf_rewrite_lossless.c`: public contract, semantics, lifetime,
+  determinism, idempotence, and fail-closed tests.
+- `tests/rewrite_test_helpers.cpp`: fixture construction and raw GC assertions.
+- `tests/CMakeLists.txt`: one new `quantapdf.pdf_rewrite_lossless` test target.
+- `abi/quantapdf-v2.exports`: append the 84th v2 export.
+- `README.md`: document the transform and its strict boundaries.
+

--- a/docs/superpowers/specs/2026-09-01-quantapdf-lossless-rewrite-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-lossless-rewrite-design.md
@@ -141,4 +141,3 @@ All QPDF exceptions remain inside the C++ bridge and map to the established
 - `tests/CMakeLists.txt`: one new `quantapdf.pdf_rewrite_lossless` test target.
 - `abi/quantapdf-v2.exports`: append the 84th v2 export.
 - `README.md`: document the transform and its strict boundaries.
-

--- a/include/quantapdf/quantapdf.h
+++ b/include/quantapdf/quantapdf.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 #define QUANTAPDF_VERSION_MAJOR 2
-#define QUANTAPDF_VERSION_MINOR 0
+#define QUANTAPDF_VERSION_MINOR 1
 #define QUANTAPDF_VERSION_PATCH 0
 #define QUANTAPDF_ABI_VERSION 2
 
@@ -482,6 +482,10 @@ QUANTAPDF_API quantapdf_status quantapdf_poster_split_pages(
     quantapdf_document *document,
     const quantapdf_page_poster_split *splits,
     size_t split_count,
+    quantapdf_output **out_output);
+
+QUANTAPDF_API quantapdf_status quantapdf_rewrite_lossless(
+    quantapdf_document *document,
     quantapdf_output **out_output);
 
 QUANTAPDF_API quantapdf_status quantapdf_output_data(

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -657,6 +657,101 @@ static bool quantapdf_qpdf_rewrite_forbidden(QPDF& pdf)
     return false;
 }
 
+static quantapdf_status quantapdf_qpdf_lossless_field_preflight(
+    QPDFObjectHandle field,
+    std::string const& inherited_type,
+    size_t depth,
+    std::set<QPDFObjGen> *seen)
+{
+    if (depth > 256u || !field.isDictionary())
+        return QUANTAPDF_ERROR_FORMAT;
+    if (field.isIndirect() && !seen->insert(field.getObjGen()).second)
+        return QUANTAPDF_ERROR_FORMAT;
+
+    std::string field_type = inherited_type;
+    QPDFObjectHandle type = field.getKey("/FT");
+    if (!type.isNull()) {
+        if (!type.isName())
+            return QUANTAPDF_ERROR_FORMAT;
+        field_type = type.getName();
+    }
+    QPDFObjectHandle value = field.getKey("/V");
+    if (field_type == "/Sig" && !value.isNull()) {
+        if (!value.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        QPDFObjectHandle signature_type = value.getKey("/Type");
+        if (!signature_type.isNull() &&
+            (!signature_type.isName() ||
+             signature_type.getName() != "/Sig"))
+            return QUANTAPDF_ERROR_FORMAT;
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    }
+
+    QPDFObjectHandle kids = field.getKey("/Kids");
+    if (kids.isNull())
+        return QUANTAPDF_OK;
+    if (!kids.isArray())
+        return QUANTAPDF_ERROR_FORMAT;
+    int const count = kids.getArrayNItems();
+    for (int index = 0; index < count; ++index) {
+        quantapdf_status const status =
+            quantapdf_qpdf_lossless_field_preflight(
+                kids.getArrayItem(index), field_type, depth + 1u, seen);
+        if (status != QUANTAPDF_OK)
+            return status;
+    }
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_lossless_preflight(QPDF& pdf)
+{
+    if (pdf.isEncrypted())
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+
+    QPDFObjectHandle root = pdf.getRoot();
+    if (!root.isDictionary())
+        return QUANTAPDF_ERROR_FORMAT;
+    QPDFObjectHandle permissions = root.getKey("/Perms");
+    if (!permissions.isNull()) {
+        if (!permissions.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        for (char const *key : {"/DocMDP", "/UR", "/UR3"}) {
+            QPDFObjectHandle signature = permissions.getKey(key);
+            if (signature.isNull())
+                continue;
+            if (!signature.isDictionary())
+                return QUANTAPDF_ERROR_FORMAT;
+            QPDFObjectHandle type = signature.getKey("/Type");
+            if (!type.isNull() &&
+                (!type.isName() || type.getName() != "/Sig"))
+                return QUANTAPDF_ERROR_FORMAT;
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+        }
+    }
+
+    QPDFObjectHandle acroform = root.getKey("/AcroForm");
+    if (acroform.isNull())
+        return QUANTAPDF_OK;
+    if (!acroform.isDictionary())
+        return QUANTAPDF_ERROR_FORMAT;
+    QPDFObjectHandle fields = acroform.getKey("/Fields");
+    if (fields.isNull())
+        return QUANTAPDF_OK;
+    if (!fields.isArray())
+        return QUANTAPDF_ERROR_FORMAT;
+
+    std::set<QPDFObjGen> seen;
+    int const count = fields.getArrayNItems();
+    for (int index = 0; index < count; ++index) {
+        quantapdf_status const status =
+            quantapdf_qpdf_lossless_field_preflight(
+                fields.getArrayItem(index), std::string(), 1u, &seen);
+        if (status != QUANTAPDF_OK)
+            return status;
+    }
+    return QUANTAPDF_OK;
+}
+
 static quantapdf_status quantapdf_qpdf_public_crop_to_pdf(
     quantapdf_qpdf_page_geometry const& geometry,
     quantapdf_rect const& requested,
@@ -2809,8 +2904,10 @@ extern "C" quantapdf_status quantapdf_qpdf_rewrite_lossless(
         (void)pdf->getAllObjects();
         if (pdf->anyWarnings())
             return QUANTAPDF_ERROR_FORMAT;
-        if (pdf->isEncrypted())
-            return QUANTAPDF_ERROR_UNSUPPORTED;
+        quantapdf_status const preflight =
+            quantapdf_qpdf_lossless_preflight(*pdf);
+        if (preflight != QUANTAPDF_OK)
+            return preflight;
 
         quantapdf_status const status = quantapdf_qpdf_write_memory(
             *pdf, out_data, out_size);

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -2783,6 +2783,57 @@ extern "C" quantapdf_status quantapdf_qpdf_rewrite_memory(
     }
 }
 
+extern "C" quantapdf_status quantapdf_qpdf_rewrite_lossless(
+    quantapdf_qpdf_document *document,
+    unsigned char **out_data,
+    size_t *out_size)
+{
+    if (out_data == nullptr || out_size == nullptr)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    *out_data = nullptr;
+    *out_size = 0;
+    if (document == nullptr || document->pdf == nullptr ||
+        document->source_data == nullptr || document->source_size == 0)
+        return QUANTAPDF_ERROR_ARGUMENT;
+
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->setAttemptRecovery(false);
+        pdf->processMemoryFile(
+            "quantapdf-lossless-rewrite",
+            reinterpret_cast<char const *>(document->source_data),
+            document->source_size,
+            document->password.c_str());
+        (void)pdf->getAllPages();
+        (void)pdf->getAllObjects();
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+        if (pdf->isEncrypted())
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+
+        quantapdf_status const status = quantapdf_qpdf_write_memory(
+            *pdf, out_data, out_size);
+        if (status != QUANTAPDF_OK)
+            return status;
+        if (pdf->anyWarnings()) {
+            std::free(*out_data);
+            *out_data = nullptr;
+            *out_size = 0;
+            return QUANTAPDF_ERROR_FORMAT;
+        }
+        return QUANTAPDF_OK;
+    } catch (QPDFExc const& error) {
+        return quantapdf_status_from_qpdf(error);
+    } catch (std::bad_alloc const&) {
+        return QUANTAPDF_ERROR_NOMEM;
+    } catch (std::exception const&) {
+        return QUANTAPDF_ERROR_BACKEND;
+    } catch (...) {
+        return QUANTAPDF_ERROR_BACKEND;
+    }
+}
+
 static char const *quantapdf_qpdf_annotation_name(
     quantapdf_annotation_type type) noexcept
 {

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -659,13 +659,21 @@ static bool quantapdf_qpdf_rewrite_forbidden(QPDF& pdf)
 
 static quantapdf_status quantapdf_qpdf_lossless_field_preflight(
     QPDFObjectHandle field,
+    QPDFObjectHandle expected_parent,
     std::string const& inherited_type,
+    QPDFObjectHandle inherited_value,
     size_t depth,
     std::set<QPDFObjGen> *seen)
 {
     if (depth > 256u || !field.isDictionary())
         return QUANTAPDF_ERROR_FORMAT;
     if (field.isIndirect() && !seen->insert(field.getObjGen()).second)
+        return QUANTAPDF_ERROR_FORMAT;
+
+    QPDFObjectHandle actual_parent = field.getKey("/Parent");
+    if ((expected_parent.isNull() && !actual_parent.isNull()) ||
+        (!expected_parent.isNull() &&
+         !quantapdf_qpdf_same_object(expected_parent, actual_parent)))
         return QUANTAPDF_ERROR_FORMAT;
 
     std::string field_type = inherited_type;
@@ -676,6 +684,8 @@ static quantapdf_status quantapdf_qpdf_lossless_field_preflight(
         field_type = type.getName();
     }
     QPDFObjectHandle value = field.getKey("/V");
+    if (value.isNull())
+        value = inherited_value;
     if (field_type == "/Sig" && !value.isNull()) {
         if (!value.isDictionary())
             return QUANTAPDF_ERROR_FORMAT;
@@ -696,7 +706,8 @@ static quantapdf_status quantapdf_qpdf_lossless_field_preflight(
     for (int index = 0; index < count; ++index) {
         quantapdf_status const status =
             quantapdf_qpdf_lossless_field_preflight(
-                kids.getArrayItem(index), field_type, depth + 1u, seen);
+                kids.getArrayItem(index), field, field_type, value,
+                depth + 1u, seen);
         if (status != QUANTAPDF_OK)
             return status;
     }
@@ -745,7 +756,8 @@ static quantapdf_status quantapdf_qpdf_lossless_preflight(QPDF& pdf)
     for (int index = 0; index < count; ++index) {
         quantapdf_status const status =
             quantapdf_qpdf_lossless_field_preflight(
-                fields.getArrayItem(index), std::string(), 1u, &seen);
+                fields.getArrayItem(index), QPDFObjectHandle::newNull(),
+                std::string(), QPDFObjectHandle::newNull(), 1u, &seen);
         if (status != QUANTAPDF_OK)
             return status;
     }

--- a/src/backend/qpdf_document.h
+++ b/src/backend/qpdf_document.h
@@ -95,6 +95,11 @@ quantapdf_status quantapdf_qpdf_rewrite_memory(
     unsigned char **out_data,
     size_t *out_size);
 
+quantapdf_status quantapdf_qpdf_rewrite_lossless(
+    quantapdf_qpdf_document *document,
+    unsigned char **out_data,
+    size_t *out_size);
+
 void quantapdf_qpdf_close(quantapdf_qpdf_document *document);
 
 #ifdef __cplusplus

--- a/src/pdf_rewrite.c
+++ b/src/pdf_rewrite.c
@@ -1,0 +1,15 @@
+#include "internal.h"
+
+quantapdf_status quantapdf_rewrite_lossless(
+    quantapdf_document *document,
+    quantapdf_output **out_output)
+{
+    if (out_output == NULL)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+
+    if (document == NULL || document->qpdf_document == NULL)
+        return QUANTAPDF_ERROR_ARGUMENT;
+
+    return QUANTAPDF_ERROR_UNSUPPORTED;
+}

--- a/src/pdf_rewrite.c
+++ b/src/pdf_rewrite.c
@@ -1,9 +1,15 @@
 #include "internal.h"
+#include "backend/qpdf_document.h"
+
+#include <stdlib.h>
 
 quantapdf_status quantapdf_rewrite_lossless(
     quantapdf_document *document,
     quantapdf_output **out_output)
 {
+    quantapdf_output *output;
+    quantapdf_status status;
+
     if (out_output == NULL)
         return QUANTAPDF_ERROR_ARGUMENT;
     *out_output = NULL;
@@ -11,5 +17,20 @@ quantapdf_status quantapdf_rewrite_lossless(
     if (document == NULL || document->qpdf_document == NULL)
         return QUANTAPDF_ERROR_ARGUMENT;
 
-    return QUANTAPDF_ERROR_UNSUPPORTED;
+    output = (quantapdf_output *)calloc(1, sizeof(*output));
+    if (output == NULL)
+        return QUANTAPDF_ERROR_NOMEM;
+
+    status = quantapdf_qpdf_rewrite_lossless(
+        document->qpdf_document,
+        &output->data,
+        &output->size);
+    if (status != QUANTAPDF_OK) {
+        free(output->data);
+        free(output);
+        return status;
+    }
+
+    *out_output = output;
+    return QUANTAPDF_OK;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,9 +21,15 @@ target_link_libraries(quantapdf_test_version PRIVATE QuantaPDF::QuantaPDF)
 add_test(NAME quantapdf.version COMMAND quantapdf_test_version)
 
 add_executable(quantapdf_test_pdf_rewrite_lossless
-  test_pdf_rewrite_lossless.c)
+  test_pdf_rewrite_lossless.c
+  rewrite_test_helpers.cpp)
 target_link_libraries(quantapdf_test_pdf_rewrite_lossless PRIVATE
-  QuantaPDF::QuantaPDF)
+  QuantaPDF::QuantaPDF
+  qpdf::libqpdf)
+target_compile_features(quantapdf_test_pdf_rewrite_lossless PRIVATE cxx_std_20)
+target_compile_definitions(quantapdf_test_pdf_rewrite_lossless PRIVATE
+  ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
+  REWRITE_GC_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-gc-input.pdf")
 add_test(NAME quantapdf.pdf_rewrite_lossless
   COMMAND quantapdf_test_pdf_rewrite_lossless)
 set_tests_properties(quantapdf.pdf_rewrite_lossless PROPERTIES TIMEOUT 30)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,21 @@ target_link_libraries(quantapdf_test_pdf_rewrite_lossless PRIVATE
 target_compile_features(quantapdf_test_pdf_rewrite_lossless PRIVATE cxx_std_20)
 target_compile_definitions(quantapdf_test_pdf_rewrite_lossless PRIVATE
   ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
-  REWRITE_GC_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-gc-input.pdf")
+  TEXT_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/text-one-page.pdf"
+  OUTLINE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-tree.pdf"
+  LINKS_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/page-links.pdf"
+  ANNOTATIONS_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotations-mixed.pdf"
+  ACROFORM_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/acroform-choice.pdf"
+  ENCRYPTED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/encrypted-one-page.pdf"
+  SIGNED_FIELD_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-signed.pdf"
+  UNSIGNED_SIGNATURE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-unsigned-signature.pdf"
+  REPAIRABLE_BAD_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/outline-repairable-bad.pdf"
+  REWRITE_GC_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-gc-input.pdf"
+  REWRITE_OUTPUT_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-output.pdf"
+  REWRITE_SEMANTIC_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-semantic.pdf"
+  REWRITE_METADATA_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-metadata.pdf"
+  REWRITE_VALIDATED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-validated.pdf"
+  REWRITE_SIGNED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-signed.pdf")
 add_test(NAME quantapdf.pdf_rewrite_lossless
   COMMAND quantapdf_test_pdf_rewrite_lossless)
 set_tests_properties(quantapdf.pdf_rewrite_lossless PROPERTIES TIMEOUT 30)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,14 @@ add_executable(quantapdf_test_version test_version.c)
 target_link_libraries(quantapdf_test_version PRIVATE QuantaPDF::QuantaPDF)
 add_test(NAME quantapdf.version COMMAND quantapdf_test_version)
 
+add_executable(quantapdf_test_pdf_rewrite_lossless
+  test_pdf_rewrite_lossless.c)
+target_link_libraries(quantapdf_test_pdf_rewrite_lossless PRIVATE
+  QuantaPDF::QuantaPDF)
+add_test(NAME quantapdf.pdf_rewrite_lossless
+  COMMAND quantapdf_test_pdf_rewrite_lossless)
+set_tests_properties(quantapdf.pdf_rewrite_lossless PROPERTIES TIMEOUT 30)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   find_program(QUANTAPDF_DUMPBIN_EXECUTABLE NAMES dumpbin REQUIRED)
   add_test(NAME quantapdf.abi_exports

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,8 @@ add_executable(quantapdf_test_pdf_rewrite_lossless
   rewrite_test_helpers.cpp)
 target_link_libraries(quantapdf_test_pdf_rewrite_lossless PRIVATE
   QuantaPDF::QuantaPDF
-  qpdf::libqpdf)
+  qpdf::libqpdf
+  ZLIB::ZLIB)
 target_compile_features(quantapdf_test_pdf_rewrite_lossless PRIVATE cxx_std_20)
 target_compile_definitions(quantapdf_test_pdf_rewrite_lossless PRIVATE
   ONE_PAGE_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
@@ -43,7 +44,10 @@ target_compile_definitions(quantapdf_test_pdf_rewrite_lossless PRIVATE
   REWRITE_SEMANTIC_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-semantic.pdf"
   REWRITE_METADATA_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-metadata.pdf"
   REWRITE_VALIDATED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-validated.pdf"
-  REWRITE_SIGNED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-signed.pdf")
+  REWRITE_SIGNED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-signed.pdf"
+  REWRITE_POLICY_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-policy.pdf"
+  REWRITE_ROOT_PARENT_SIGNED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-root-parent-signed.pdf"
+  REWRITE_PARENT_MISMATCH_SIGNED_PDF="${CMAKE_CURRENT_BINARY_DIR}/rewrite-parent-mismatch-signed.pdf")
 add_test(NAME quantapdf.pdf_rewrite_lossless
   COMMAND quantapdf_test_pdf_rewrite_lossless)
 set_tests_properties(quantapdf.pdf_rewrite_lossless PROPERTIES TIMEOUT 30)

--- a/tests/fake_dumpbin.c
+++ b/tests/fake_dumpbin.c
@@ -13,8 +13,8 @@ int main(int argc, char **argv)
     if (baseline == NULL)
         return 3;
 
-    puts("  85 number of functions");
-    puts("  84 number of names");
+    puts("  86 number of functions");
+    puts("  85 number of names");
     puts("    ordinal hint RVA      name");
     while (fgets(symbol, sizeof(symbol), baseline) != NULL) {
         size_t length = strcspn(symbol, "\r\n");

--- a/tests/rewrite_test_helpers.cpp
+++ b/tests/rewrite_test_helpers.cpp
@@ -1,0 +1,69 @@
+#include <qpdf/QPDF.hh>
+#include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFWriter.hh>
+
+#include <string>
+
+extern "C" int rewrite_create_gc_fixture(
+    const char *source_path,
+    const char *output_path)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+
+        QPDFObjectHandle garbage = pdf->makeIndirectObject(
+            QPDFObjectHandle::parse("<< /QuantaPDFGarbage true >>"));
+        QPDFObjectHandle garbage_stream = pdf->newStream("dead-stream");
+        garbage_stream.getDict().replaceKey(
+            "/QuantaPDFGarbageStream",
+            QPDFObjectHandle::newBool(true));
+        QPDFObjectHandle reachable = pdf->makeIndirectObject(
+            QPDFObjectHandle::parse("<< /QuantaPDFReachable true >>"));
+        pdf->getRoot().replaceKey("/QuantaPDFReachable", reachable);
+        (void)garbage;
+
+        QPDFWriter writer(*pdf, output_path);
+        writer.setDeterministicID(true);
+        writer.setObjectStreamMode(qpdf_o_disable);
+        writer.setStreamDataMode(qpdf_s_preserve);
+        writer.setPreserveUnreferencedObjects(true);
+        writer.write();
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+extern "C" int rewrite_marker_mask(
+    const unsigned char *data,
+    size_t size)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processMemoryFile(
+            "rewrite-marker-check",
+            reinterpret_cast<char const *>(data),
+            size);
+        int mask = 0;
+        for (QPDFObjectHandle object : pdf->getAllObjects()) {
+            QPDFObjectHandle dictionary = object.isStream()
+                ? object.getDict()
+                : object;
+            if (!dictionary.isDictionary())
+                continue;
+            if (dictionary.getKey("/QuantaPDFGarbage").isBool() &&
+                dictionary.getKey("/QuantaPDFGarbage").getBoolValue())
+                mask |= 1;
+            if (dictionary.getKey("/QuantaPDFGarbageStream").isBool() &&
+                dictionary.getKey("/QuantaPDFGarbageStream").getBoolValue())
+                mask |= 2;
+            if (dictionary.getKey("/QuantaPDFReachable").isBool() &&
+                dictionary.getKey("/QuantaPDFReachable").getBoolValue())
+                mask |= 4;
+        }
+        return mask;
+    } catch (...) {
+        return -1;
+    }
+}

--- a/tests/rewrite_test_helpers.cpp
+++ b/tests/rewrite_test_helpers.cpp
@@ -2,7 +2,155 @@
 #include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFWriter.hh>
 
+#include <zlib.h>
+
+#include <stdexcept>
 #include <string>
+#include <vector>
+
+static void rewrite_write_fixture(QPDF& pdf, const char *output_path)
+{
+    QPDFWriter writer(pdf, output_path);
+    writer.setDeterministicID(true);
+    writer.setObjectStreamMode(qpdf_o_disable);
+    writer.setStreamDataMode(qpdf_s_preserve);
+    writer.write();
+}
+
+static QPDFObjectHandle rewrite_signature(QPDF& pdf)
+{
+    return pdf.makeIndirectObject(QPDFObjectHandle::newDictionary({
+        {"/Type", QPDFObjectHandle::newName("/Sig")},
+        {"/ByteRange", QPDFObjectHandle::parse("[0 1 2 3]")},
+        {"/Contents", QPDFObjectHandle::newString("signed")}}));
+}
+
+extern "C" int rewrite_create_policy_fixture(
+    const char *source_path,
+    const char *output_path,
+    int kind)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+        QPDFObjectHandle root = pdf->getRoot();
+        QPDFObjectHandle signature = rewrite_signature(*pdf);
+
+        if (kind == 1 || kind == 2) {
+            QPDFObjectHandle permissions = QPDFObjectHandle::newDictionary();
+            permissions.replaceKey(kind == 1 ? "/UR" : "/UR3", signature);
+            root.replaceKey("/Perms", permissions);
+        } else if (kind == 3) {
+            root.replaceKey("/Perms", QPDFObjectHandle::newName("/Bad"));
+        } else if (kind == 4) {
+            root.replaceKey(
+                "/AcroForm",
+                QPDFObjectHandle::newDictionary({
+                    {"/Fields", QPDFObjectHandle::newName("/Bad")}}));
+        } else if (kind == 5) {
+            QPDFObjectHandle field = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Kids", QPDFObjectHandle::newName("/Bad")}}));
+            QPDFObjectHandle fields = QPDFObjectHandle::newArray();
+            fields.appendItem(field);
+            root.replaceKey(
+                "/AcroForm",
+                QPDFObjectHandle::newDictionary({{"/Fields", fields}}));
+        } else if (kind == 6 || kind == 7) {
+            QPDFObjectHandle parent = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary());
+            QPDFObjectHandle child_dictionary =
+                QPDFObjectHandle::newDictionary({{"/Parent", parent}});
+            if (kind == 6) {
+                parent.replaceKey("/FT", QPDFObjectHandle::newName("/Sig"));
+                child_dictionary.replaceKey("/V", signature);
+            } else {
+                parent.replaceKey("/V", signature);
+                child_dictionary.replaceKey(
+                    "/FT", QPDFObjectHandle::newName("/Sig"));
+            }
+            QPDFObjectHandle child = pdf->makeIndirectObject(child_dictionary);
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(child);
+            parent.replaceKey("/Kids", kids);
+            QPDFObjectHandle fields = QPDFObjectHandle::newArray();
+            fields.appendItem(parent);
+            root.replaceKey(
+                "/AcroForm",
+                QPDFObjectHandle::newDictionary({{"/Fields", fields}}));
+        } else {
+            return 0;
+        }
+
+        rewrite_write_fixture(*pdf, output_path);
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+extern "C" int rewrite_create_root_parent_signature_fixture(
+    const char *source_path,
+    const char *output_path)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+        QPDFObjectHandle signature = rewrite_signature(*pdf);
+        QPDFObjectHandle external_parent = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/FT", QPDFObjectHandle::newName("/Sig")},
+                {"/V", signature}}));
+        QPDFObjectHandle root_field = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/T", QPDFObjectHandle::newUnicodeString("root")},
+                {"/Parent", external_parent}}));
+        QPDFObjectHandle fields = QPDFObjectHandle::newArray();
+        fields.appendItem(root_field);
+        pdf->getRoot().replaceKey(
+            "/AcroForm",
+            QPDFObjectHandle::newDictionary({{"/Fields", fields}}));
+        rewrite_write_fixture(*pdf, output_path);
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+extern "C" int rewrite_create_mismatched_parent_signature_fixture(
+    const char *source_path,
+    const char *output_path)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+        QPDFObjectHandle signature = rewrite_signature(*pdf);
+        QPDFObjectHandle external_parent = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/FT", QPDFObjectHandle::newName("/Sig")},
+                {"/V", signature}}));
+        QPDFObjectHandle child = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/T", QPDFObjectHandle::newUnicodeString("child")},
+                {"/Parent", external_parent}}));
+        QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+        kids.appendItem(child);
+        QPDFObjectHandle traversed_parent = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/T", QPDFObjectHandle::newUnicodeString("parent")},
+                {"/FT", QPDFObjectHandle::newName("/Tx")},
+                {"/Kids", kids}}));
+        QPDFObjectHandle fields = QPDFObjectHandle::newArray();
+        fields.appendItem(traversed_parent);
+        pdf->getRoot().replaceKey(
+            "/AcroForm",
+            QPDFObjectHandle::newDictionary({{"/Fields", fields}}));
+        rewrite_write_fixture(*pdf, output_path);
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
 
 extern "C" int rewrite_create_gc_fixture(
     const char *source_path,
@@ -21,6 +169,30 @@ extern "C" int rewrite_create_gc_fixture(
         QPDFObjectHandle reachable = pdf->makeIndirectObject(
             QPDFObjectHandle::parse("<< /QuantaPDFReachable true >>"));
         pdf->getRoot().replaceKey("/QuantaPDFReachable", reachable);
+        QPDFObjectHandle shared = pdf->makeIndirectObject(
+            QPDFObjectHandle::parse("<< /QuantaPDFShared true >>"));
+        pdf->getRoot().replaceKey("/QuantaPDFSharedA", shared);
+        pdf->getRoot().replaceKey("/QuantaPDFSharedB", shared);
+
+        char const stream_plaintext[] = "preserve-this-encoded-stream";
+        uLongf encoded_size = compressBound(sizeof(stream_plaintext) - 1u);
+        std::vector<unsigned char> encoded(encoded_size);
+        if (compress2(
+                encoded.data(), &encoded_size,
+                reinterpret_cast<Bytef const *>(stream_plaintext),
+                sizeof(stream_plaintext) - 1u,
+                Z_BEST_COMPRESSION) != Z_OK)
+            return 0;
+        encoded.resize(encoded_size);
+        QPDFObjectHandle reachable_stream = pdf->newStream();
+        reachable_stream.replaceStreamData(
+            std::string(
+                reinterpret_cast<char const *>(encoded.data()),
+                encoded.size()),
+            QPDFObjectHandle::newName("/FlateDecode"),
+            QPDFObjectHandle::parse("<< /Predictor 1 >>"));
+        pdf->getRoot().replaceKey(
+            "/QuantaPDFReachableStream", reachable_stream);
         (void)garbage;
 
         QPDFWriter writer(*pdf, output_path);
@@ -30,6 +202,61 @@ extern "C" int rewrite_create_gc_fixture(
         writer.setPreserveUnreferencedObjects(true);
         writer.write();
         return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+struct rewrite_graph_snapshot {
+    bool shared = false;
+    std::string filter;
+    std::string decode_parms;
+    std::string raw_stream;
+};
+
+static rewrite_graph_snapshot rewrite_capture_graph(
+    unsigned char const *data,
+    size_t size)
+{
+    auto pdf = QPDF::create();
+    pdf->processMemoryFile(
+        "rewrite-graph-check",
+        reinterpret_cast<char const *>(data),
+        size);
+    QPDFObjectHandle root = pdf->getRoot();
+    QPDFObjectHandle left = root.getKey("/QuantaPDFSharedA");
+    QPDFObjectHandle right = root.getKey("/QuantaPDFSharedB");
+    QPDFObjectHandle stream = root.getKey("/QuantaPDFReachableStream");
+    if (!left.isIndirect() || !right.isIndirect() ||
+        !left.isSameObjectAs(right) || !stream.isStream())
+        throw std::runtime_error("rewrite graph invariant missing");
+    std::shared_ptr<Buffer> raw = stream.getRawStreamData();
+    rewrite_graph_snapshot snapshot;
+    snapshot.shared = true;
+    snapshot.filter = stream.getDict().getKey("/Filter").unparseResolved();
+    snapshot.decode_parms =
+        stream.getDict().getKey("/DecodeParms").unparseResolved();
+    snapshot.raw_stream.assign(raw->data(), raw->size());
+    return snapshot;
+}
+
+extern "C" int rewrite_graph_invariants(
+    const unsigned char *before,
+    size_t before_size,
+    const unsigned char *after,
+    size_t after_size)
+{
+    try {
+        rewrite_graph_snapshot left =
+            rewrite_capture_graph(before, before_size);
+        rewrite_graph_snapshot right =
+            rewrite_capture_graph(after, after_size);
+        return left.shared && right.shared &&
+            left.filter == "/FlateDecode" &&
+            left.filter == right.filter &&
+            left.decode_parms == "<< /Predictor 1 >>" &&
+            left.decode_parms == right.decode_parms &&
+            left.raw_stream == right.raw_stream;
     } catch (...) {
         return 0;
     }

--- a/tests/rewrite_test_helpers.cpp
+++ b/tests/rewrite_test_helpers.cpp
@@ -67,3 +67,79 @@ extern "C" int rewrite_marker_mask(
         return -1;
     }
 }
+
+extern "C" int rewrite_create_catalog_signature_fixture(
+    const char *source_path,
+    const char *output_path)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+        QPDFObjectHandle signature = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/Type", QPDFObjectHandle::newName("/Sig")},
+                {"/ByteRange", QPDFObjectHandle::parse("[0 1 2 3]")},
+                {"/Contents", QPDFObjectHandle::newString("signed")}}));
+        QPDFObjectHandle permissions = QPDFObjectHandle::newDictionary();
+        permissions.replaceKey("/DocMDP", signature);
+        pdf->getRoot().replaceKey("/Perms", permissions);
+
+        QPDFWriter writer(*pdf, output_path);
+        writer.setDeterministicID(true);
+        writer.setObjectStreamMode(qpdf_o_disable);
+        writer.setStreamDataMode(qpdf_s_preserve);
+        writer.write();
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+extern "C" int rewrite_create_metadata_fixture(
+    const char *source_path,
+    const char *output_path)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+        QPDFObjectHandle info = pdf->makeIndirectObject(
+            QPDFObjectHandle::newDictionary({
+                {"/Title", QPDFObjectHandle::newUnicodeString(
+                    "QuantaPDF Rewrite")},
+                {"/Author", QPDFObjectHandle::newUnicodeString(
+                    "QuantaPDF")}}));
+        pdf->getTrailer().replaceKey("/Info", info);
+
+        QPDFWriter writer(*pdf, output_path);
+        writer.setDeterministicID(true);
+        writer.setObjectStreamMode(qpdf_o_disable);
+        writer.setStreamDataMode(qpdf_s_preserve);
+        writer.write();
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+extern "C" int rewrite_create_strict_fixture(
+    const char *source_path,
+    const char *output_path)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->processFile(source_path);
+        (void)pdf->getAllPages();
+        (void)pdf->getAllObjects();
+
+        QPDFWriter writer(*pdf, output_path);
+        writer.setDeterministicID(true);
+        writer.setObjectStreamMode(qpdf_o_disable);
+        writer.setStreamDataMode(qpdf_s_preserve);
+        writer.setPreserveUnreferencedObjects(false);
+        writer.write();
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}

--- a/tests/test_pdf_rewrite_lossless.c
+++ b/tests/test_pdf_rewrite_lossless.c
@@ -7,6 +7,15 @@
 
 int rewrite_create_gc_fixture(const char *source_path, const char *output_path);
 int rewrite_marker_mask(const unsigned char *data, size_t size);
+int rewrite_create_catalog_signature_fixture(
+    const char *source_path,
+    const char *output_path);
+int rewrite_create_metadata_fixture(
+    const char *source_path,
+    const char *output_path);
+int rewrite_create_strict_fixture(
+    const char *source_path,
+    const char *output_path);
 
 static void check_impl(int condition, const char *expression, int line)
 {
@@ -51,17 +60,289 @@ static unsigned char *read_file(const char *path, size_t *out_size)
     return data;
 }
 
+static void open_rewritten_pair(
+    const char *path,
+    quantapdf_document **out_source,
+    quantapdf_document **out_rewritten)
+{
+    quantapdf_output *output = NULL;
+    quantapdf_status status;
+
+    *out_source = NULL;
+    *out_rewritten = NULL;
+    CHECK(quantapdf_open(path, NULL, out_source) == QUANTAPDF_OK);
+    status = quantapdf_rewrite_lossless(*out_source, &output);
+    if (status != QUANTAPDF_OK)
+        fprintf(stderr, "rewrite failed for %s: %s\n",
+                path, quantapdf_status_string(status));
+    CHECK(status == QUANTAPDF_OK);
+    CHECK(output != NULL);
+    CHECK(quantapdf_output_save_file(output, REWRITE_SEMANTIC_PDF) ==
+          QUANTAPDF_OK);
+    quantapdf_drop_output(output);
+    CHECK(quantapdf_open(REWRITE_SEMANTIC_PDF, NULL, out_rewritten) ==
+          QUANTAPDF_OK);
+}
+
+typedef struct rendered_page {
+    unsigned char *data;
+    size_t size;
+    int width;
+    int height;
+    int stride;
+    int components;
+} rendered_page;
+
+static rendered_page capture_page(quantapdf_document *document)
+{
+    rendered_page capture = {0};
+    quantapdf_page *page = NULL;
+    quantapdf_bitmap *bitmap = NULL;
+    const unsigned char *borrowed = NULL;
+
+    CHECK(quantapdf_load_page(document, 0, &page) == QUANTAPDF_OK);
+    CHECK(quantapdf_render_page(page, &bitmap) == QUANTAPDF_OK);
+    CHECK(quantapdf_bitmap_dimensions(
+              bitmap, &capture.width, &capture.height,
+              &capture.stride, &capture.components) == QUANTAPDF_OK);
+    CHECK(quantapdf_bitmap_data(bitmap, &borrowed, &capture.size) ==
+          QUANTAPDF_OK);
+    capture.data = (unsigned char *)malloc(capture.size);
+    CHECK(capture.data != NULL);
+    memcpy(capture.data, borrowed, capture.size);
+    quantapdf_drop_bitmap(bitmap);
+    quantapdf_drop_page(page);
+    return capture;
+}
+
+static void test_render_text_and_page_semantics(void)
+{
+    quantapdf_document *source = NULL;
+    quantapdf_document *rewritten = NULL;
+    quantapdf_page *source_page = NULL;
+    quantapdf_page *rewritten_page = NULL;
+    quantapdf_rect source_bounds = {0};
+    quantapdf_rect rewritten_bounds = {0};
+    rendered_page source_render;
+    rendered_page rewritten_render;
+    char *source_text = NULL;
+    char *rewritten_text = NULL;
+    size_t source_text_size = 0;
+    size_t rewritten_text_size = 0;
+    int source_pages = 0;
+    int rewritten_pages = 0;
+
+    open_rewritten_pair(TEXT_PDF, &source, &rewritten);
+    CHECK(quantapdf_page_count(source, &source_pages) == QUANTAPDF_OK);
+    CHECK(quantapdf_page_count(rewritten, &rewritten_pages) == QUANTAPDF_OK);
+    CHECK(source_pages == rewritten_pages);
+    CHECK(quantapdf_load_page(source, 0, &source_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_load_page(rewritten, 0, &rewritten_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_page_bounds(source_page, &source_bounds) == QUANTAPDF_OK);
+    CHECK(quantapdf_page_bounds(rewritten_page, &rewritten_bounds) ==
+          QUANTAPDF_OK);
+    CHECK(memcmp(&source_bounds, &rewritten_bounds, sizeof(source_bounds)) == 0);
+    CHECK(quantapdf_extract_text(source_page, &source_text,
+                                 &source_text_size) == QUANTAPDF_OK);
+    CHECK(quantapdf_extract_text(rewritten_page, &rewritten_text,
+                                 &rewritten_text_size) == QUANTAPDF_OK);
+    CHECK(source_text_size == rewritten_text_size);
+    CHECK(memcmp(source_text, rewritten_text, source_text_size) == 0);
+    quantapdf_free(rewritten_text);
+    quantapdf_free(source_text);
+    quantapdf_drop_page(rewritten_page);
+    quantapdf_drop_page(source_page);
+
+    source_render = capture_page(source);
+    rewritten_render = capture_page(rewritten);
+    CHECK(source_render.width == rewritten_render.width);
+    CHECK(source_render.height == rewritten_render.height);
+    CHECK(source_render.stride == rewritten_render.stride);
+    CHECK(source_render.components == rewritten_render.components);
+    CHECK(source_render.size == rewritten_render.size);
+    CHECK(memcmp(source_render.data, rewritten_render.data,
+                 source_render.size) == 0);
+    free(rewritten_render.data);
+    free(source_render.data);
+    quantapdf_close(rewritten);
+    quantapdf_close(source);
+}
+
+static void test_snapshot_semantics(void)
+{
+    quantapdf_document *source = NULL;
+    quantapdf_document *rewritten = NULL;
+    quantapdf_outline *source_outline = NULL;
+    quantapdf_outline *rewritten_outline = NULL;
+    quantapdf_form *source_form = NULL;
+    quantapdf_form *rewritten_form = NULL;
+    quantapdf_page *source_page = NULL;
+    quantapdf_page *rewritten_page = NULL;
+    quantapdf_link_page *source_links = NULL;
+    quantapdf_link_page *rewritten_links = NULL;
+    quantapdf_annotation_page *source_annotations = NULL;
+    quantapdf_annotation_page *rewritten_annotations = NULL;
+    char *source_title = NULL;
+    char *rewritten_title = NULL;
+    size_t source_size = 0;
+    size_t rewritten_size = 0;
+    size_t source_count = 0;
+    size_t rewritten_count = 0;
+
+    CHECK(rewrite_create_metadata_fixture(
+        ONE_PAGE_PDF, REWRITE_METADATA_PDF));
+    open_rewritten_pair(REWRITE_METADATA_PDF, &source, &rewritten);
+    CHECK(quantapdf_document_metadata(source, QUANTAPDF_METADATA_TITLE,
+                                       &source_title, &source_size) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_document_metadata(rewritten, QUANTAPDF_METADATA_TITLE,
+                                       &rewritten_title, &rewritten_size) ==
+          QUANTAPDF_OK);
+    CHECK(source_size == rewritten_size);
+    CHECK(memcmp(source_title, rewritten_title, source_size) == 0);
+    quantapdf_free(rewritten_title);
+    quantapdf_free(source_title);
+    quantapdf_close(rewritten);
+    quantapdf_close(source);
+
+    CHECK(rewrite_create_strict_fixture(
+        OUTLINE_PDF, REWRITE_VALIDATED_PDF));
+    open_rewritten_pair(REWRITE_VALIDATED_PDF, &source, &rewritten);
+    CHECK(quantapdf_document_outline(source, &source_outline) == QUANTAPDF_OK);
+    CHECK(quantapdf_document_outline(rewritten, &rewritten_outline) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_outline_count(source_outline, &source_count) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_outline_count(rewritten_outline, &rewritten_count) ==
+          QUANTAPDF_OK);
+    CHECK(source_count == rewritten_count);
+    quantapdf_drop_outline(rewritten_outline);
+    quantapdf_drop_outline(source_outline);
+    quantapdf_close(rewritten);
+    quantapdf_close(source);
+
+    CHECK(rewrite_create_strict_fixture(
+        LINKS_PDF, REWRITE_VALIDATED_PDF));
+    open_rewritten_pair(REWRITE_VALIDATED_PDF, &source, &rewritten);
+    CHECK(quantapdf_load_page(source, 0, &source_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_load_page(rewritten, 0, &rewritten_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_extract_links(source_page, &source_links) == QUANTAPDF_OK);
+    CHECK(quantapdf_extract_links(rewritten_page, &rewritten_links) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_link_count(source_links, &source_count) == QUANTAPDF_OK);
+    CHECK(quantapdf_link_count(rewritten_links, &rewritten_count) ==
+          QUANTAPDF_OK);
+    CHECK(source_count == rewritten_count);
+    quantapdf_drop_link_page(rewritten_links);
+    quantapdf_drop_link_page(source_links);
+    quantapdf_drop_page(rewritten_page);
+    quantapdf_drop_page(source_page);
+    quantapdf_close(rewritten);
+    quantapdf_close(source);
+
+    CHECK(rewrite_create_strict_fixture(
+        ANNOTATIONS_PDF, REWRITE_VALIDATED_PDF));
+    open_rewritten_pair(REWRITE_VALIDATED_PDF, &source, &rewritten);
+    CHECK(quantapdf_load_page(source, 0, &source_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_load_page(rewritten, 0, &rewritten_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_extract_annotations(source_page, &source_annotations) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_extract_annotations(
+              rewritten_page, &rewritten_annotations) == QUANTAPDF_OK);
+    CHECK(quantapdf_annotation_count(source_annotations, &source_count) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_annotation_count(
+              rewritten_annotations, &rewritten_count) == QUANTAPDF_OK);
+    CHECK(source_count == rewritten_count);
+    quantapdf_drop_annotation_page(rewritten_annotations);
+    quantapdf_drop_annotation_page(source_annotations);
+    quantapdf_drop_page(rewritten_page);
+    quantapdf_drop_page(source_page);
+    quantapdf_close(rewritten);
+    quantapdf_close(source);
+
+    CHECK(rewrite_create_strict_fixture(
+        ACROFORM_PDF, REWRITE_VALIDATED_PDF));
+    open_rewritten_pair(REWRITE_VALIDATED_PDF, &source, &rewritten);
+    CHECK(quantapdf_document_form(source, &source_form) == QUANTAPDF_OK);
+    CHECK(quantapdf_document_form(rewritten, &rewritten_form) == QUANTAPDF_OK);
+    CHECK(quantapdf_form_field_count(source_form, &source_count) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_form_field_count(rewritten_form, &rewritten_count) ==
+          QUANTAPDF_OK);
+    CHECK(source_count == rewritten_count);
+    CHECK(quantapdf_form_widget_count(source_form, &source_count) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_form_widget_count(rewritten_form, &rewritten_count) ==
+          QUANTAPDF_OK);
+    CHECK(source_count == rewritten_count);
+    quantapdf_drop_form(rewritten_form);
+    quantapdf_drop_form(source_form);
+    quantapdf_close(rewritten);
+    quantapdf_close(source);
+}
+
+static void expect_rewrite_error(
+    const char *path,
+    const char *password,
+    quantapdf_status expected)
+{
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+    quantapdf_status status;
+
+    CHECK(quantapdf_open(path, password, &document) == QUANTAPDF_OK);
+    status = quantapdf_rewrite_lossless(document, &output);
+    if (status != expected)
+        fprintf(stderr, "rewrite policy mismatch for %s: expected %s, got %s\n",
+                path, quantapdf_status_string(expected),
+                quantapdf_status_string(status));
+    CHECK(status == expected);
+    CHECK(output == NULL);
+    quantapdf_close(document);
+}
+
+static void test_fail_closed_policy(void)
+{
+    quantapdf_document *unsigned_document = NULL;
+    quantapdf_output *unsigned_output = NULL;
+
+    CHECK(rewrite_create_catalog_signature_fixture(
+        ONE_PAGE_PDF, REWRITE_SIGNED_PDF));
+    expect_rewrite_error(
+        REWRITE_SIGNED_PDF, NULL, QUANTAPDF_ERROR_UNSUPPORTED);
+    expect_rewrite_error(
+        ENCRYPTED_PDF, "user-pass", QUANTAPDF_ERROR_UNSUPPORTED);
+    expect_rewrite_error(
+        SIGNED_FIELD_PDF, NULL, QUANTAPDF_ERROR_UNSUPPORTED);
+    expect_rewrite_error(
+        REPAIRABLE_BAD_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
+
+    CHECK(quantapdf_open(
+              UNSIGNED_SIGNATURE_PDF, NULL, &unsigned_document) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_rewrite_lossless(unsigned_document, &unsigned_output) ==
+          QUANTAPDF_OK);
+    CHECK(unsigned_output != NULL);
+    quantapdf_drop_output(unsigned_output);
+    quantapdf_close(unsigned_document);
+}
+
 static void test_gc_and_repeated_determinism(void)
 {
     quantapdf_document *document = NULL;
     quantapdf_output *first = NULL;
     quantapdf_output *second = NULL;
+    quantapdf_output *third = NULL;
+    quantapdf_document *rewritten_document = NULL;
     const unsigned char *first_data = NULL;
     const unsigned char *second_data = NULL;
     unsigned char *source_data;
     size_t source_size = 0;
     size_t first_size = 0;
     size_t second_size = 0;
+    const unsigned char *third_data = NULL;
+    size_t third_size = 0;
     int page_count = 0;
 
     CHECK(rewrite_create_gc_fixture(ONE_PAGE_PDF, REWRITE_GC_PDF));
@@ -86,12 +367,24 @@ static void test_gc_and_repeated_determinism(void)
     CHECK(rewrite_marker_mask(first_data, first_size) == 4);
     CHECK(quantapdf_page_count(document, &page_count) == QUANTAPDF_OK);
     CHECK(page_count == 1);
+    CHECK(quantapdf_output_save_file(first, REWRITE_OUTPUT_PDF) ==
+          QUANTAPDF_OK);
 
     quantapdf_close(document);
     document = NULL;
     CHECK(quantapdf_output_data(first, &first_data, &first_size) ==
           QUANTAPDF_OK);
     CHECK(first_data != NULL && first_size != 0);
+    CHECK(quantapdf_open(REWRITE_OUTPUT_PDF, NULL, &rewritten_document) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_rewrite_lossless(rewritten_document, &third) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_output_data(third, &third_data, &third_size) ==
+          QUANTAPDF_OK);
+    CHECK(first_size == third_size);
+    CHECK(memcmp(first_data, third_data, first_size) == 0);
+    quantapdf_drop_output(third);
+    quantapdf_close(rewritten_document);
     quantapdf_drop_output(second);
     quantapdf_drop_output(first);
 }
@@ -106,5 +399,8 @@ int main(void)
     CHECK(quantapdf_rewrite_lossless(NULL, NULL) ==
           QUANTAPDF_ERROR_ARGUMENT);
     test_gc_and_repeated_determinism();
+    test_render_text_and_page_semantics();
+    test_snapshot_semantics();
+    test_fail_closed_policy();
     return EXIT_SUCCESS;
 }

--- a/tests/test_pdf_rewrite_lossless.c
+++ b/tests/test_pdf_rewrite_lossless.c
@@ -7,6 +7,11 @@
 
 int rewrite_create_gc_fixture(const char *source_path, const char *output_path);
 int rewrite_marker_mask(const unsigned char *data, size_t size);
+int rewrite_graph_invariants(
+    const unsigned char *before,
+    size_t before_size,
+    const unsigned char *after,
+    size_t after_size);
 int rewrite_create_catalog_signature_fixture(
     const char *source_path,
     const char *output_path);
@@ -16,6 +21,16 @@ int rewrite_create_metadata_fixture(
 int rewrite_create_strict_fixture(
     const char *source_path,
     const char *output_path);
+int rewrite_create_root_parent_signature_fixture(
+    const char *source_path,
+    const char *output_path);
+int rewrite_create_mismatched_parent_signature_fixture(
+    const char *source_path,
+    const char *output_path);
+int rewrite_create_policy_fixture(
+    const char *source_path,
+    const char *output_path,
+    int kind);
 
 static void check_impl(int condition, const char *expression, int line)
 {
@@ -115,6 +130,308 @@ static rendered_page capture_page(quantapdf_document *document)
     return capture;
 }
 
+static void check_point_equal(quantapdf_point left, quantapdf_point right)
+{
+    CHECK(left.x == right.x);
+    CHECK(left.y == right.y);
+}
+
+static void check_rect_equal(quantapdf_rect left, quantapdf_rect right)
+{
+    CHECK(left.x0 == right.x0);
+    CHECK(left.y0 == right.y0);
+    CHECK(left.x1 == right.x1);
+    CHECK(left.y1 == right.y1);
+}
+
+static void check_borrowed_equal(
+    quantapdf_status left_status,
+    const char *left,
+    size_t left_size,
+    quantapdf_status right_status,
+    const char *right,
+    size_t right_size)
+{
+    CHECK(left_status == right_status);
+    CHECK((left == NULL) == (right == NULL));
+    CHECK(left_size == right_size);
+    if (left != NULL)
+        CHECK(memcmp(left, right, left_size) == 0);
+}
+
+static void check_outline_equal(
+    const quantapdf_outline *left,
+    const quantapdf_outline *right)
+{
+    size_t left_count = 0;
+    size_t right_count = 0;
+    size_t index;
+
+    CHECK(quantapdf_outline_count(left, &left_count) == QUANTAPDF_OK);
+    CHECK(quantapdf_outline_count(right, &right_count) == QUANTAPDF_OK);
+    CHECK(left_count == right_count);
+    for (index = 0; index < left_count; ++index) {
+        quantapdf_outline_info left_info = {0};
+        quantapdf_outline_info right_info = {0};
+        const char *left_text = NULL;
+        const char *right_text = NULL;
+        size_t left_size = 0;
+        size_t right_size = 0;
+        quantapdf_status left_status;
+        quantapdf_status right_status;
+
+        left_info.struct_size = sizeof(left_info);
+        right_info.struct_size = sizeof(right_info);
+        CHECK(quantapdf_outline_get_info(left, index, &left_info) ==
+              QUANTAPDF_OK);
+        CHECK(quantapdf_outline_get_info(right, index, &right_info) ==
+              QUANTAPDF_OK);
+        CHECK(left_info.parent_index == right_info.parent_index);
+        CHECK(left_info.first_child_index == right_info.first_child_index);
+        CHECK(left_info.next_sibling_index == right_info.next_sibling_index);
+        CHECK(left_info.destination_kind == right_info.destination_kind);
+        CHECK(left_info.target_page == right_info.target_page);
+        check_point_equal(left_info.target, right_info.target);
+        CHECK(left_info.is_open == right_info.is_open);
+
+        left_status = quantapdf_outline_title(
+            left, index, &left_text, &left_size);
+        right_status = quantapdf_outline_title(
+            right, index, &right_text, &right_size);
+        check_borrowed_equal(
+            left_status, left_text, left_size,
+            right_status, right_text, right_size);
+        left_text = NULL;
+        right_text = NULL;
+        left_size = 0;
+        right_size = 0;
+        left_status = quantapdf_outline_uri(
+            left, index, &left_text, &left_size);
+        right_status = quantapdf_outline_uri(
+            right, index, &right_text, &right_size);
+        check_borrowed_equal(
+            left_status, left_text, left_size,
+            right_status, right_text, right_size);
+    }
+}
+
+static void check_links_equal(
+    const quantapdf_link_page *left,
+    const quantapdf_link_page *right)
+{
+    size_t left_count = 0;
+    size_t right_count = 0;
+    size_t index;
+
+    CHECK(quantapdf_link_count(left, &left_count) == QUANTAPDF_OK);
+    CHECK(quantapdf_link_count(right, &right_count) == QUANTAPDF_OK);
+    CHECK(left_count == right_count);
+    for (index = 0; index < left_count; ++index) {
+        quantapdf_link_info left_info = {0};
+        quantapdf_link_info right_info = {0};
+        const char *left_uri = NULL;
+        const char *right_uri = NULL;
+        size_t left_size = 0;
+        size_t right_size = 0;
+        quantapdf_status left_status;
+        quantapdf_status right_status;
+
+        left_info.struct_size = sizeof(left_info);
+        right_info.struct_size = sizeof(right_info);
+        CHECK(quantapdf_link_get_info(left, index, &left_info) ==
+              QUANTAPDF_OK);
+        CHECK(quantapdf_link_get_info(right, index, &right_info) ==
+              QUANTAPDF_OK);
+        check_rect_equal(left_info.hotspot, right_info.hotspot);
+        CHECK(left_info.kind == right_info.kind);
+        CHECK(left_info.target_page == right_info.target_page);
+        check_point_equal(left_info.target, right_info.target);
+        left_status = quantapdf_link_uri(
+            left, index, &left_uri, &left_size);
+        right_status = quantapdf_link_uri(
+            right, index, &right_uri, &right_size);
+        check_borrowed_equal(
+            left_status, left_uri, left_size,
+            right_status, right_uri, right_size);
+    }
+}
+
+static void check_annotations_equal(
+    const quantapdf_annotation_page *left,
+    const quantapdf_annotation_page *right)
+{
+    size_t left_count = 0;
+    size_t right_count = 0;
+    size_t index;
+
+    CHECK(quantapdf_annotation_count(left, &left_count) == QUANTAPDF_OK);
+    CHECK(quantapdf_annotation_count(right, &right_count) == QUANTAPDF_OK);
+    CHECK(left_count == right_count);
+    for (index = 0; index < left_count; ++index) {
+        quantapdf_annotation_info left_info = {0};
+        quantapdf_annotation_info right_info = {0};
+        const char *left_contents = NULL;
+        const char *right_contents = NULL;
+        size_t left_size = 0;
+        size_t right_size = 0;
+        quantapdf_status left_status;
+        quantapdf_status right_status;
+
+        left_info.struct_size = sizeof(left_info);
+        right_info.struct_size = sizeof(right_info);
+        CHECK(quantapdf_annotation_get_info(left, index, &left_info) ==
+              QUANTAPDF_OK);
+        CHECK(quantapdf_annotation_get_info(right, index, &right_info) ==
+              QUANTAPDF_OK);
+        CHECK(left_info.type == right_info.type);
+        check_rect_equal(left_info.bounds, right_info.bounds);
+        CHECK(left_info.flags == right_info.flags);
+        left_status = quantapdf_annotation_contents(
+            left, index, &left_contents, &left_size);
+        right_status = quantapdf_annotation_contents(
+            right, index, &right_contents, &right_size);
+        check_borrowed_equal(
+            left_status, left_contents, left_size,
+            right_status, right_contents, right_size);
+    }
+}
+
+static void check_form_equal(
+    const quantapdf_form *left,
+    const quantapdf_form *right)
+{
+    size_t left_count = 0;
+    size_t right_count = 0;
+    size_t field_index;
+
+    CHECK(quantapdf_form_field_count(left, &left_count) == QUANTAPDF_OK);
+    CHECK(quantapdf_form_field_count(right, &right_count) == QUANTAPDF_OK);
+    CHECK(left_count == right_count);
+    for (field_index = 0; field_index < left_count; ++field_index) {
+        quantapdf_form_field_info left_info = {0};
+        quantapdf_form_field_info right_info = {0};
+        const char *left_text = NULL;
+        const char *right_text = NULL;
+        size_t left_size = 0;
+        size_t right_size = 0;
+        size_t index;
+        quantapdf_status left_status;
+        quantapdf_status right_status;
+
+        left_info.struct_size = sizeof(left_info);
+        right_info.struct_size = sizeof(right_info);
+        CHECK(quantapdf_form_field_get_info(
+                  left, field_index, &left_info) == QUANTAPDF_OK);
+        CHECK(quantapdf_form_field_get_info(
+                  right, field_index, &right_info) == QUANTAPDF_OK);
+        CHECK(left_info.type == right_info.type);
+        CHECK(left_info.flags == right_info.flags);
+        CHECK(left_info.value_presence == right_info.value_presence);
+        CHECK(left_info.value_count == right_info.value_count);
+        CHECK(left_info.option_count == right_info.option_count);
+        CHECK(left_info.widget_count == right_info.widget_count);
+        CHECK(left_info.is_multiselect == right_info.is_multiselect);
+        CHECK(left_info.is_signed == right_info.is_signed);
+
+        left_status = quantapdf_form_field_name(
+            left, field_index, &left_text, &left_size);
+        right_status = quantapdf_form_field_name(
+            right, field_index, &right_text, &right_size);
+        check_borrowed_equal(
+            left_status, left_text, left_size,
+            right_status, right_text, right_size);
+        left_text = NULL;
+        right_text = NULL;
+        left_size = 0;
+        right_size = 0;
+        left_status = quantapdf_form_field_label(
+            left, field_index, &left_text, &left_size);
+        right_status = quantapdf_form_field_label(
+            right, field_index, &right_text, &right_size);
+        check_borrowed_equal(
+            left_status, left_text, left_size,
+            right_status, right_text, right_size);
+
+        for (index = 0; index < left_info.value_count; ++index) {
+            quantapdf_form_value_info left_value = {0};
+            quantapdf_form_value_info right_value = {0};
+            left_value.struct_size = sizeof(left_value);
+            right_value.struct_size = sizeof(right_value);
+            CHECK(quantapdf_form_field_value_get_info(
+                      left, field_index, index, &left_value) == QUANTAPDF_OK);
+            CHECK(quantapdf_form_field_value_get_info(
+                      right, field_index, index, &right_value) == QUANTAPDF_OK);
+            CHECK(left_value.kind == right_value.kind);
+            CHECK(left_value.option_index == right_value.option_index);
+            if (left_value.kind == QUANTAPDF_FORM_VALUE_UTF8) {
+                left_text = NULL;
+                right_text = NULL;
+                left_size = 0;
+                right_size = 0;
+                left_status = quantapdf_form_field_value_utf8(
+                    left, field_index, index, &left_text, &left_size);
+                right_status = quantapdf_form_field_value_utf8(
+                    right, field_index, index, &right_text, &right_size);
+                check_borrowed_equal(
+                    left_status, left_text, left_size,
+                    right_status, right_text, right_size);
+            }
+        }
+        for (index = 0; index < left_info.option_count; ++index) {
+            quantapdf_form_option_info left_option = {0};
+            quantapdf_form_option_info right_option = {0};
+            left_option.struct_size = sizeof(left_option);
+            right_option.struct_size = sizeof(right_option);
+            CHECK(quantapdf_form_field_option_get_info(
+                      left, field_index, index, &left_option) == QUANTAPDF_OK);
+            CHECK(quantapdf_form_field_option_get_info(
+                      right, field_index, index, &right_option) == QUANTAPDF_OK);
+            CHECK(left_option.kind == right_option.kind);
+            left_text = NULL;
+            right_text = NULL;
+            left_size = 0;
+            right_size = 0;
+            left_status = quantapdf_form_field_option_export(
+                left, field_index, index, &left_text, &left_size);
+            right_status = quantapdf_form_field_option_export(
+                right, field_index, index, &right_text, &right_size);
+            check_borrowed_equal(
+                left_status, left_text, left_size,
+                right_status, right_text, right_size);
+            left_text = NULL;
+            right_text = NULL;
+            left_size = 0;
+            right_size = 0;
+            left_status = quantapdf_form_field_option_display(
+                left, field_index, index, &left_text, &left_size);
+            right_status = quantapdf_form_field_option_display(
+                right, field_index, index, &right_text, &right_size);
+            check_borrowed_equal(
+                left_status, left_text, left_size,
+                right_status, right_text, right_size);
+        }
+    }
+
+    CHECK(quantapdf_form_widget_count(left, &left_count) == QUANTAPDF_OK);
+    CHECK(quantapdf_form_widget_count(right, &right_count) == QUANTAPDF_OK);
+    CHECK(left_count == right_count);
+    for (field_index = 0; field_index < left_count; ++field_index) {
+        quantapdf_form_widget_info left_info = {0};
+        quantapdf_form_widget_info right_info = {0};
+        left_info.struct_size = sizeof(left_info);
+        right_info.struct_size = sizeof(right_info);
+        CHECK(quantapdf_form_widget_get_info(
+                  left, field_index, &left_info) == QUANTAPDF_OK);
+        CHECK(quantapdf_form_widget_get_info(
+                  right, field_index, &right_info) == QUANTAPDF_OK);
+        CHECK(left_info.field_index == right_info.field_index);
+        CHECK(left_info.page_index == right_info.page_index);
+        check_rect_equal(left_info.bounds, right_info.bounds);
+        CHECK(left_info.flags == right_info.flags);
+        CHECK(left_info.button_option_index == right_info.button_option_index);
+    }
+}
+
 static void test_render_text_and_page_semantics(void)
 {
     quantapdf_document *source = NULL;
@@ -186,8 +503,6 @@ static void test_snapshot_semantics(void)
     char *rewritten_title = NULL;
     size_t source_size = 0;
     size_t rewritten_size = 0;
-    size_t source_count = 0;
-    size_t rewritten_count = 0;
 
     CHECK(rewrite_create_metadata_fixture(
         ONE_PAGE_PDF, REWRITE_METADATA_PDF));
@@ -211,11 +526,7 @@ static void test_snapshot_semantics(void)
     CHECK(quantapdf_document_outline(source, &source_outline) == QUANTAPDF_OK);
     CHECK(quantapdf_document_outline(rewritten, &rewritten_outline) ==
           QUANTAPDF_OK);
-    CHECK(quantapdf_outline_count(source_outline, &source_count) ==
-          QUANTAPDF_OK);
-    CHECK(quantapdf_outline_count(rewritten_outline, &rewritten_count) ==
-          QUANTAPDF_OK);
-    CHECK(source_count == rewritten_count);
+    check_outline_equal(source_outline, rewritten_outline);
     quantapdf_drop_outline(rewritten_outline);
     quantapdf_drop_outline(source_outline);
     quantapdf_close(rewritten);
@@ -229,10 +540,7 @@ static void test_snapshot_semantics(void)
     CHECK(quantapdf_extract_links(source_page, &source_links) == QUANTAPDF_OK);
     CHECK(quantapdf_extract_links(rewritten_page, &rewritten_links) ==
           QUANTAPDF_OK);
-    CHECK(quantapdf_link_count(source_links, &source_count) == QUANTAPDF_OK);
-    CHECK(quantapdf_link_count(rewritten_links, &rewritten_count) ==
-          QUANTAPDF_OK);
-    CHECK(source_count == rewritten_count);
+    check_links_equal(source_links, rewritten_links);
     quantapdf_drop_link_page(rewritten_links);
     quantapdf_drop_link_page(source_links);
     quantapdf_drop_page(rewritten_page);
@@ -249,11 +557,7 @@ static void test_snapshot_semantics(void)
           QUANTAPDF_OK);
     CHECK(quantapdf_extract_annotations(
               rewritten_page, &rewritten_annotations) == QUANTAPDF_OK);
-    CHECK(quantapdf_annotation_count(source_annotations, &source_count) ==
-          QUANTAPDF_OK);
-    CHECK(quantapdf_annotation_count(
-              rewritten_annotations, &rewritten_count) == QUANTAPDF_OK);
-    CHECK(source_count == rewritten_count);
+    check_annotations_equal(source_annotations, rewritten_annotations);
     quantapdf_drop_annotation_page(rewritten_annotations);
     quantapdf_drop_annotation_page(source_annotations);
     quantapdf_drop_page(rewritten_page);
@@ -266,16 +570,7 @@ static void test_snapshot_semantics(void)
     open_rewritten_pair(REWRITE_VALIDATED_PDF, &source, &rewritten);
     CHECK(quantapdf_document_form(source, &source_form) == QUANTAPDF_OK);
     CHECK(quantapdf_document_form(rewritten, &rewritten_form) == QUANTAPDF_OK);
-    CHECK(quantapdf_form_field_count(source_form, &source_count) ==
-          QUANTAPDF_OK);
-    CHECK(quantapdf_form_field_count(rewritten_form, &rewritten_count) ==
-          QUANTAPDF_OK);
-    CHECK(source_count == rewritten_count);
-    CHECK(quantapdf_form_widget_count(source_form, &source_count) ==
-          QUANTAPDF_OK);
-    CHECK(quantapdf_form_widget_count(rewritten_form, &rewritten_count) ==
-          QUANTAPDF_OK);
-    CHECK(source_count == rewritten_count);
+    check_form_equal(source_form, rewritten_form);
     quantapdf_drop_form(rewritten_form);
     quantapdf_drop_form(source_form);
     quantapdf_close(rewritten);
@@ -318,6 +613,44 @@ static void test_fail_closed_policy(void)
     expect_rewrite_error(
         REPAIRABLE_BAD_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
 
+    CHECK(rewrite_create_root_parent_signature_fixture(
+        ONE_PAGE_PDF, REWRITE_ROOT_PARENT_SIGNED_PDF));
+    expect_rewrite_error(
+        REWRITE_ROOT_PARENT_SIGNED_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
+    CHECK(rewrite_create_mismatched_parent_signature_fixture(
+        ONE_PAGE_PDF, REWRITE_PARENT_MISMATCH_SIGNED_PDF));
+    expect_rewrite_error(
+        REWRITE_PARENT_MISMATCH_SIGNED_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
+
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 1));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_UNSUPPORTED);
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 2));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_UNSUPPORTED);
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 3));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 4));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 5));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_FORMAT);
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 6));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_UNSUPPORTED);
+    CHECK(rewrite_create_policy_fixture(
+        ONE_PAGE_PDF, REWRITE_POLICY_PDF, 7));
+    expect_rewrite_error(
+        REWRITE_POLICY_PDF, NULL, QUANTAPDF_ERROR_UNSUPPORTED);
+
     CHECK(quantapdf_open(
               UNSIGNED_SIGNATURE_PDF, NULL, &unsigned_document) ==
           QUANTAPDF_OK);
@@ -349,7 +682,6 @@ static void test_gc_and_repeated_determinism(void)
     source_data = read_file(REWRITE_GC_PDF, &source_size);
     CHECK(source_data != NULL);
     CHECK(rewrite_marker_mask(source_data, source_size) == 7);
-    free(source_data);
 
     CHECK(quantapdf_open(REWRITE_GC_PDF, NULL, &document) == QUANTAPDF_OK);
     CHECK(document != NULL);
@@ -365,6 +697,9 @@ static void test_gc_and_repeated_determinism(void)
     CHECK(first_size != 0 && first_size == second_size);
     CHECK(memcmp(first_data, second_data, first_size) == 0);
     CHECK(rewrite_marker_mask(first_data, first_size) == 4);
+    CHECK(rewrite_graph_invariants(
+        source_data, source_size, first_data, first_size));
+    free(source_data);
     CHECK(quantapdf_page_count(document, &page_count) == QUANTAPDF_OK);
     CHECK(page_count == 1);
     CHECK(quantapdf_output_save_file(first, REWRITE_OUTPUT_PDF) ==

--- a/tests/test_pdf_rewrite_lossless.c
+++ b/tests/test_pdf_rewrite_lossless.c
@@ -1,0 +1,28 @@
+#include <quantapdf/quantapdf.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n",
+                __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+int main(void)
+{
+    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+
+    CHECK(quantapdf_rewrite_lossless(NULL, &output) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(output == NULL);
+    CHECK(quantapdf_rewrite_lossless(NULL, NULL) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+    return EXIT_SUCCESS;
+}

--- a/tests/test_pdf_rewrite_lossless.c
+++ b/tests/test_pdf_rewrite_lossless.c
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+int rewrite_create_gc_fixture(const char *source_path, const char *output_path);
+int rewrite_marker_mask(const unsigned char *data, size_t size);
 
 static void check_impl(int condition, const char *expression, int line)
 {
@@ -15,6 +19,83 @@ static void check_impl(int condition, const char *expression, int line)
 
 #define CHECK(expression) check_impl((expression), #expression, __LINE__)
 
+static unsigned char *read_file(const char *path, size_t *out_size)
+{
+    FILE *file = NULL;
+    unsigned char *data;
+    long length;
+
+    *out_size = 0;
+#if defined(_WIN32)
+    if (fopen_s(&file, path, "rb") != 0)
+        return NULL;
+#else
+    file = fopen(path, "rb");
+    if (file == NULL)
+        return NULL;
+#endif
+    if (fseek(file, 0, SEEK_END) != 0 || (length = ftell(file)) <= 0 ||
+        fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    data = (unsigned char *)malloc((size_t)length);
+    if (data == NULL ||
+        fread(data, 1, (size_t)length, file) != (size_t)length) {
+        free(data);
+        fclose(file);
+        return NULL;
+    }
+    fclose(file);
+    *out_size = (size_t)length;
+    return data;
+}
+
+static void test_gc_and_repeated_determinism(void)
+{
+    quantapdf_document *document = NULL;
+    quantapdf_output *first = NULL;
+    quantapdf_output *second = NULL;
+    const unsigned char *first_data = NULL;
+    const unsigned char *second_data = NULL;
+    unsigned char *source_data;
+    size_t source_size = 0;
+    size_t first_size = 0;
+    size_t second_size = 0;
+    int page_count = 0;
+
+    CHECK(rewrite_create_gc_fixture(ONE_PAGE_PDF, REWRITE_GC_PDF));
+    source_data = read_file(REWRITE_GC_PDF, &source_size);
+    CHECK(source_data != NULL);
+    CHECK(rewrite_marker_mask(source_data, source_size) == 7);
+    free(source_data);
+
+    CHECK(quantapdf_open(REWRITE_GC_PDF, NULL, &document) == QUANTAPDF_OK);
+    CHECK(document != NULL);
+    CHECK(quantapdf_rewrite_lossless(document, &first) == QUANTAPDF_OK);
+    CHECK(first != NULL);
+    CHECK(quantapdf_rewrite_lossless(document, &second) == QUANTAPDF_OK);
+    CHECK(second != NULL);
+    CHECK(quantapdf_output_data(first, &first_data, &first_size) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_output_data(second, &second_data, &second_size) ==
+          QUANTAPDF_OK);
+    CHECK(first_data != NULL && second_data != NULL);
+    CHECK(first_size != 0 && first_size == second_size);
+    CHECK(memcmp(first_data, second_data, first_size) == 0);
+    CHECK(rewrite_marker_mask(first_data, first_size) == 4);
+    CHECK(quantapdf_page_count(document, &page_count) == QUANTAPDF_OK);
+    CHECK(page_count == 1);
+
+    quantapdf_close(document);
+    document = NULL;
+    CHECK(quantapdf_output_data(first, &first_data, &first_size) ==
+          QUANTAPDF_OK);
+    CHECK(first_data != NULL && first_size != 0);
+    quantapdf_drop_output(second);
+    quantapdf_drop_output(first);
+}
+
 int main(void)
 {
     quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
@@ -24,5 +105,6 @@ int main(void)
     CHECK(output == NULL);
     CHECK(quantapdf_rewrite_lossless(NULL, NULL) ==
           QUANTAPDF_ERROR_ARGUMENT);
+    test_gc_and_repeated_determinism();
     return EXIT_SUCCESS;
 }

--- a/tests/test_version.c
+++ b/tests/test_version.c
@@ -3,7 +3,7 @@
 #if QUANTAPDF_VERSION_MAJOR != 2
 #error unexpected major version
 #endif
-#if QUANTAPDF_VERSION_MINOR != 0
+#if QUANTAPDF_VERSION_MINOR != 1
 #error unexpected minor version
 #endif
 #if QUANTAPDF_VERSION_PATCH != 0


### PR DESCRIPTION
## Summary

- publish `quantapdf_rewrite_lossless()` in QuantaPDF 2.1 while preserving ABI version 2
- add a deterministic qpdf full-rewrite path that removes unreachable objects, preserves stream encodings and reachable object identity, and leaves the source immutable
- fail closed for encrypted, signed, structurally repaired, and malformed field-tree inputs
- document the fixed V1 policy and add semantic, idempotence, failure-atomicity, and raw object-graph coverage

## Verification

- fresh Windows MSVC Release configure and build
- 29/29 CTests pass
- installed DLL matches the 84-symbol ABI baseline
- installed header reports QuantaPDF 2.1.0 / ABI 2
- independent review: no Critical, Important, or Minor findings

Closes #56