### PR TITLE
feat: add structural PDF audit and sanitization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,8 @@ add_library(quantapdf
   src/pdf_edit.c
   src/pdf_edit_forms.c
   src/pdf_edit_annotations.c
-  src/pdf_flatten.c)
+  src/pdf_flatten.c
+  src/pdf_security.c)
 add_library(QuantaPDF::QuantaPDF ALIAS quantapdf)
 target_compile_features(quantapdf PUBLIC c_std_11)
 target_include_directories(quantapdf PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(QuantaPDF VERSION 2.2.0 LANGUAGES C CXX)
+project(QuantaPDF VERSION 2.3.0 LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The current supported surface includes:
 - URI/internal links, annotations, document metadata, and outlines
 - immutable AcroForm snapshots and isolated PDF edit sessions
 - page export/range export, output merging, and file saving
+- catalog-reachable document security audit and immutable policy sanitization
 - immutable CropBox crop, MediaBox trim, poster-split, interactive-content
   flattening, and lossless rewrite/GC transforms
 - stable status strings and one allocator-matched `quantapdf_free()` entry point
@@ -184,6 +185,66 @@ quantapdf_render_thumbnail(page, max_width, max_height, &bitmap);
 ```
 
 renders opaque RGB while preserving the page aspect ratio. The result fits inside the requested pixel box and never upscales beyond the page's 72-DPI size. Thumbnail rendering derives a DPI and reuses the same renderer rather than maintaining a separate raster path.
+
+## Document audit and sanitization
+
+Initialize the size-tagged audit result before calling the audit API, then test
+the independent finding bits that matter to your policy:
+
+```c
+quantapdf_audit_result audit = {
+    .struct_size = sizeof(quantapdf_audit_result),
+    .findings = 0
+};
+
+if (quantapdf_document_audit(doc, &audit) == QUANTAPDF_OK) {
+    if (audit.findings & QUANTAPDF_AUDIT_JAVASCRIPT_ACTION) {
+        /* JavaScript action or JavaScript name tree is reachable. */
+    }
+    if (audit.findings & QUANTAPDF_AUDIT_SIGNATURE) {
+        /* A signature structure is present; validity is not checked. */
+    }
+    if (audit.findings & QUANTAPDF_AUDIT_ENCRYPTION) {
+        /* The input is encrypted, even if it was opened with a password. */
+    }
+}
+```
+
+Sanitization returns a new immutable output and never mutates the opened
+document:
+
+```c
+quantapdf_output *output = NULL;
+
+if (quantapdf_sanitize(doc, QUANTAPDF_SANITIZE_ALL, &output) ==
+    QUANTAPDF_OK) {
+    const unsigned char *data = NULL;
+    size_t size = 0;
+
+    quantapdf_output_data(output, &data, &size);
+    /* data[0..size) is borrowed read-only storage owned by output. */
+
+    quantapdf_close(doc);
+    doc = NULL;
+    /* data remains valid because output owns its bytes independently. */
+
+    quantapdf_drop_output(output);
+}
+```
+
+`QUANTAPDF_SANITIZE_ALL` removes the seven sanitizable active-content classes.
+Safe internal `/GoTo` navigation is not reported as dangerous and is not
+removed. Signed or encrypted inputs are intentionally rejected by
+`quantapdf_sanitize()` with `QUANTAPDF_ERROR_UNSUPPORTED` because rewriting
+would invalidate a signature or silently decrypt the document.
+
+The audit is a strict, catalog-reachable structural inspection of conventional
+PDF security and active-content mechanisms. It is not antivirus or malware
+detection, content keyword scanning, cryptographic signature validation, or
+proof that arbitrary custom object edges are safe. Malformed conventional
+structures return `QUANTAPDF_ERROR_FORMAT`; a bounded traversal or a requested
+removal that cannot be proven complete returns `QUANTAPDF_ERROR_UNSUPPORTED`
+without publishing output.
 
 ## Lossless rewrite and garbage collection
 

--- a/abi/quantapdf-v2.exports
+++ b/abi/quantapdf-v2.exports
@@ -83,3 +83,5 @@ quantapdf_text_search
 quantapdf_text_span_count
 quantapdf_text_span_text
 quantapdf_trim_pages
+quantapdf_document_audit
+quantapdf_sanitize

--- a/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
@@ -1,0 +1,301 @@
+# QuantaPDF Document Audit and Sanitize V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a stable structure-level document audit and an immutable policy-driven sanitizer.
+
+**Architecture:** A size-tagged C audit result and flag-based sanitize facade delegate to one private QPDF security engine. The engine strictly reparses source bytes, walks only the reachable object graph with bounded storage, classifies executable and embedded structures, mutates a fresh graph for selected policies, verifies postconditions, and publishes deterministic owning bytes.
+
+**Tech Stack:** C11 public ABI, C++20 QPDF 12.4 bridge, PDFium observation backend, CMake Presets, CTest.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md`
+
+## Global Constraints
+
+- Public release version becomes 2.3.0; ABI version and shared-library major remain 2.
+- Existing declarations, enum values, ownership rules, and 85 exports do not change; exactly two exports are added.
+- Audit is structural, reachable-only, read-only, and fail-closed on malformed executable containers.
+- Sanitize is immutable, explicit-policy, failure-atomic, deterministic, and refuses signed or encrypted rewrites.
+- The graph work list is iterative, overflow-checked, bounded, and owns no PDF bytes.
+- Every production behavior is introduced by a witnessed RED test.
+
+---
+
+### Task 1: Publish the append-only API contract
+
+**Files:**
+- Create: `tests/test_pdf_security.c`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `include/quantapdf/quantapdf.h`
+- Create: `src/pdf_security.c`
+- Modify: `CMakeLists.txt`
+- Modify: `abi/quantapdf-v2.exports`
+- Modify: `tests/test_version.c`
+
+**Interfaces:**
+- Produces: `quantapdf_audit_result`, `quantapdf_audit_finding`, `quantapdf_sanitize_flag`, `quantapdf_document_audit`, and `quantapdf_sanitize`.
+- Consumes: existing opaque document/output handles and status values.
+
+Use these exact public names and values:
+
+```c
+typedef enum quantapdf_audit_finding {
+    QUANTAPDF_AUDIT_JAVASCRIPT_ACTION = 1u << 0,
+    QUANTAPDF_AUDIT_LAUNCH_ACTION = 1u << 1,
+    QUANTAPDF_AUDIT_EXTERNAL_ACTION = 1u << 2,
+    QUANTAPDF_AUDIT_OTHER_ACTION = 1u << 3,
+    QUANTAPDF_AUDIT_EMBEDDED_FILE = 1u << 4,
+    QUANTAPDF_AUDIT_XFA = 1u << 5,
+    QUANTAPDF_AUDIT_RICH_MEDIA = 1u << 6,
+    QUANTAPDF_AUDIT_SIGNATURE = 1u << 7,
+    QUANTAPDF_AUDIT_ENCRYPTION = 1u << 8
+} quantapdf_audit_finding;
+
+typedef enum quantapdf_sanitize_flag {
+    QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS = 1u << 0,
+    QUANTAPDF_SANITIZE_LAUNCH_ACTIONS = 1u << 1,
+    QUANTAPDF_SANITIZE_EXTERNAL_ACTIONS = 1u << 2,
+    QUANTAPDF_SANITIZE_OTHER_ACTIONS = 1u << 3,
+    QUANTAPDF_SANITIZE_EMBEDDED_FILES = 1u << 4,
+    QUANTAPDF_SANITIZE_XFA = 1u << 5,
+    QUANTAPDF_SANITIZE_RICH_MEDIA = 1u << 6,
+    QUANTAPDF_SANITIZE_ALL = (1u << 7) - 1u
+} quantapdf_sanitize_flag;
+```
+
+The exact result is `size_t struct_size` followed by `uint32_t findings`, with
+`QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE` ending at `findings` and
+`QUANTAPDF_AUDIT_RESULT_V1_SIZE` equal to `sizeof(quantapdf_audit_result)`.
+
+- [x] **Step 1: Write compile and argument RED tests**
+
+Add calls to the wished-for APIs. Assert NULL arguments, a short audit result,
+zero/unknown sanitize flags, and sentinel reset:
+
+```c
+quantapdf_audit_result audit = {0};
+quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+CHECK(quantapdf_document_audit(NULL, &audit) == QUANTAPDF_ERROR_ARGUMENT);
+CHECK(quantapdf_sanitize(NULL, QUANTAPDF_SANITIZE_ALL, &output) ==
+      QUANTAPDF_ERROR_ARGUMENT);
+CHECK(output == NULL);
+```
+
+- [x] **Step 2: Build the focused target and witness RED**
+
+Run the public test target. Expected: compilation fails because the new public
+types and functions do not exist.
+
+- [x] **Step 3: Add the minimal public shell**
+
+Publish the size-tagged result, finding/flag enums, constants, and function
+declarations. Add a C facade that clears addressable outputs, validates all
+arguments, and returns `QUANTAPDF_ERROR_UNSUPPORTED` for valid documents until
+the bridge exists. Add the source, exact exports, and bump 2.2.0 to 2.3.0.
+
+- [x] **Step 4: Reconfigure and run contract/version/ABI GREEN**
+
+Run the security, version, and ABI tests. The valid-document placeholder may
+still be unsupported; all argument contracts and exact 87-export checks pass.
+
+- [x] **Step 5: Commit**
+
+Commit as `feat: publish document security API`.
+
+### Task 2: Implement reachable document audit
+
+**Files:**
+- Modify: `tests/test_pdf_security.c`
+- Create: `tests/pdf_security_test_helpers.cpp`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `src/pdf_security.c`
+- Modify: `src/backend/qpdf_document.h`
+- Modify: `src/backend/qpdf_document.cpp`
+
+**Interfaces:**
+- Produces: `quantapdf_qpdf_document_audit(quantapdf_qpdf_document *, uint32_t *)`.
+- Test helper produces isolated valid and malformed PDF structures.
+
+The classifier uses these exact action classes:
+
+| `/S` name | Finding |
+|---|---|
+| `/GoTo` | none (safe internal navigation) |
+| `/JavaScript` | `QUANTAPDF_AUDIT_JAVASCRIPT_ACTION` |
+| `/Launch` | `QUANTAPDF_AUDIT_LAUNCH_ACTION` |
+| `/URI`, `/GoToR`, `/GoToE`, `/SubmitForm`, `/ImportData` | `QUANTAPDF_AUDIT_EXTERNAL_ACTION` |
+| every other name | `QUANTAPDF_AUDIT_OTHER_ACTION` |
+
+An object reached through `/OpenAction`, `/A`, an `/AA` entry, or action
+`/Next` must be a dictionary with a name `/S`; action `/Next` may instead be
+an array of such dictionaries. Catalog `/OpenAction` also permits a
+destination array, name, or string and those forms are not actions. Scan
+`/Next` even for safe `/GoTo` actions.
+
+The ordinary graph walk flags any `/AF` or `/EF` reference, embedded-file
+stream, or `/FileAttachment` annotation as embedded content. It flags
+`/RichMedia`, `/3D`, `/Movie`, `/Sound`, and `/Screen` annotation subtypes as
+rich media. Catalog `/Names` must be a dictionary when present; the presence
+of `/JavaScript` or `/EmbeddedFiles` beneath it sets the corresponding bit.
+Catalog `/AcroForm` must be a dictionary when present; `/XFA` sets its bit and
+the established strict effective-signature traversal supplies the signature
+bit. A present page/object `/Annots` entry must be an array of dictionaries.
+
+The shared traversal budget is `max(4096, source_size * 64)` processed or
+queued handles. Check the multiplication and every push; an exceeded budget
+returns `QUANTAPDF_ERROR_UNSUPPORTED`. De-duplicate indirect graph objects and
+indirect actions by `QPDFObjGen`. Direct input containers are acyclic by PDF
+syntax. Streams contribute their dictionaries only.
+
+- [x] **Step 1: Add clean, isolated-bit, reachability, and malformed RED tests**
+
+Generate one fixture per finding class. Verify clean and internal-GoTo inputs
+return zero, all nine public bits are isolated, dangerous unreferenced garbage
+is ignored, and malformed `/A`, `/AA`, name dictionaries, or annotation arrays
+return `QUANTAPDF_ERROR_FORMAT` with findings cleared.
+
+Also pass a result struct larger than V1 with a canary suffix: V1 fields change
+and the suffix remains byte-identical. Repeat audit on one document to prove
+that observation is non-mutating.
+
+- [x] **Step 2: Run the focused test and witness runtime RED**
+
+Expected: valid audits return the shell's unsupported status.
+
+- [x] **Step 3: Implement the bounded read-only engine**
+
+Strictly reparse source bytes, traverse the catalog-reachable graph
+iteratively, de-duplicate indirect objects by object-generation identity,
+classify conventional action positions and security structures, and map all
+exceptions. Enforce the work-item limit before each push.
+
+- [x] **Step 4: Run focused audit tests GREEN**
+
+Build and run only `quantapdf.pdf_security`; confirm every finding and
+fail-closed case passes.
+
+- [x] **Step 5: Commit**
+
+Commit as `feat: audit reachable PDF security structures`.
+
+### Task 3: Implement immutable policy sanitization
+
+**Files:**
+- Modify: `tests/test_pdf_security.c`
+- Modify: `tests/pdf_security_test_helpers.cpp`
+- Modify: `src/pdf_security.c`
+- Modify: `src/backend/qpdf_document.h`
+- Modify: `src/backend/qpdf_document.cpp`
+
+**Interfaces:**
+- Produces: `quantapdf_qpdf_sanitize(quantapdf_qpdf_document *, uint32_t, unsigned char **, size_t *)`.
+- Consumes: the Task 2 classifier and the established deterministic writer.
+
+Sanitize bits 0-6 map directly to audit bits 0-6. Complete the same strict
+audit before mutation. If `QUANTAPDF_AUDIT_SIGNATURE` or
+`QUANTAPDF_AUDIT_ENCRYPTION` is present, return
+`QUANTAPDF_ERROR_UNSUPPORTED` for every nonzero sanitize policy.
+
+Apply these exact mutations on the fresh private graph:
+
+- `/OpenAction` and `/A`: remove the owner key when the referenced action's
+  class is selected; preserve destinations and unselected action heads.
+- `/AA`: remove only selected event entries and remove the owner `/AA` key if
+  the event dictionary becomes empty.
+- action `/Next`: remove a selected single continuation; for arrays, retain
+  unselected actions in order and remove `/Next` if none survive. Recursively
+  sanitize continuation chains even when their head is safe or unselected.
+- catalog `/Names`: remove `/JavaScript` and/or `/EmbeddedFiles` only when its
+  matching policy is selected; remove catalog `/Names` if the dictionary then
+  has no keys.
+- embedded-file policy: remove every dictionary `/AF` and `/EF` key and filter
+  `/FileAttachment` annotations from every validated `/Annots` array.
+- XFA policy: remove only catalog `/AcroForm /XFA`.
+- rich-media policy: filter `/RichMedia`, `/3D`, `/Movie`, `/Sound`, and
+  `/Screen` annotations from every validated `/Annots` array.
+
+Preserve array order and all unselected keys/objects. If conventional removal
+leaves a selected finding reachable (for example a custom edge directly to an
+embedded-file stream), return `QUANTAPDF_ERROR_UNSUPPORTED` without output;
+do not relabel or retain payload bytes merely to make the bit disappear.
+
+- [x] **Step 1: Add policy isolation and `ALL` RED tests**
+
+For a combined fixture, sanitize one flag at a time, reopen output, audit it,
+and assert only the selected bit disappears. Assert `ALL` clears all seven
+sanitizable bits and preserves page/text/render observations.
+
+The combined fixture must place the four action classes in independent
+conventional owners so removing one does not make another unreachable. Include
+a safe internal `GoTo` action and assert it survives both partial and `ALL`
+sanitization. Add a custom direct reference to an embedded-file stream and
+assert embedded-file sanitization returns unsupported rather than publishing a
+false-clean output.
+
+- [x] **Step 2: Add ownership, security, and canonical RED tests**
+
+Assert source audit remains unchanged, output outlives the source, identical
+calls are byte-equal, reopen-then-sanitize is byte-equal, and signed/encrypted
+inputs return unsupported with NULL output.
+
+Use the C++ helper to inspect all written indirect objects and prove selected
+actions, name-tree entries, file specifications/embedded streams, XFA, and
+rich-media annotation objects made unreachable by conventional removal are
+absent from the serialized output, not merely hidden from the public scanner.
+
+- [x] **Step 3: Run and witness runtime RED**
+
+Expected: valid sanitize calls still return unsupported from the shell.
+
+- [x] **Step 4: Implement preflight, mutation, post-audit, and publication**
+
+Open a fresh strict graph, audit before mutation, reject signature/encryption,
+remove only selected conventional references, re-audit selected postconditions,
+and write with deterministic ID, disabled object streams, preserved stream
+data, and unreachable-object collection. Publish bytes only on success.
+
+- [x] **Step 5: Run focused sanitization tests GREEN**
+
+Run `quantapdf.pdf_security` plus rewrite/flatten regression tests.
+
+- [x] **Step 6: Commit**
+
+Commit as `feat: sanitize active PDF content`.
+
+### Task 4: Documentation and complete verification
+
+**Files:**
+- Modify: `README.md`
+- Add: `docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md`
+- Modify: `docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md`
+
+**Interfaces:**
+- Produces: supported-surface documentation and final release evidence.
+
+- [x] **Step 1: Document examples and exact boundaries**
+
+Show audit-result initialization, finding checks, `SANITIZE_ALL`, output
+ownership, signature/encryption rejection, and the structural-not-antivirus
+boundary.
+
+- [x] **Step 2: Run fresh Windows verification and install**
+
+Run configure, full build, all CTests, and the release install preset through
+`VsDevCmd.bat` with the pinned vcpkg root restored afterward.
+
+- [x] **Step 3: Verify installed ABI and header**
+
+Confirm exactly 87 named exports, version 2.3.0/ABI 2, and compile a consumer
+against the installed package.
+
+- [x] **Step 4: Run static review checks**
+
+Inspect the diff, search for implementation placeholders and forbidden legacy
+backend/license references, and confirm no generated build/vcpkg files are
+tracked.
+
+- [ ] **Step 5: Complete branch workflow**
+
+Use the finishing-development-branch process, push the reviewed branch, open a
+PR, and require Linux release/sanitizer, macOS, and Windows success on the exact
+head before merge.

--- a/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
@@ -265,6 +265,7 @@ Commit as `feat: sanitize active PDF content`.
 ### Task 4: Documentation and complete verification
 
 **Files:**
+- Modify: `CMakeLists.txt`
 - Modify: `README.md`
 - Add: `docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md`
 - Modify: `docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md`

--- a/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
@@ -245,6 +245,10 @@ NULL. This covers direct and indirect catalog Names descendants, JavaScript
 name-tree arrays/actions, AcroForm/XFA, `/AA`, `/Next`, `/Annots`, `/AF`, `/EF`,
 and action-owner keys. Multiple aliases with the same role remain supported; an
 unrelated policy that would not mutate the ambiguous container is not rejected.
+Treat structurally matching annotation `/P`, `/IRT`, `/Popup`, and popup
+`/Parent` backlinks as page/annotation roles rather than custom aliases. Do not
+grant that role solely by key spelling: require the referenced page type or
+annotation subtype so a custom edge to an arbitrary object remains ambiguous.
 
 - [x] **Step 1: Add policy isolation and `ALL` RED tests**
 

--- a/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
@@ -132,6 +132,17 @@ an array of such dictionaries. Catalog `/OpenAction` also permits a
 destination array, name, or string and those forms are not actions. Scan
 `/Next` even for safe `/GoTo` actions.
 
+The catalog `/Names /JavaScript` entry is walked as a strict iterative PDF name
+tree. Nodes are dictionaries; `/Kids` is an array of dictionary nodes;
+`/Names` is an even array of alternating string keys and action dictionaries;
+`/Kids` and `/Names` are mutually exclusive; and optional `/Limits` is exactly
+two strings. Empty roots are accepted. Feed every action value and recursive
+`/Next` continuation through the shared classifier, charge every enqueue and
+inspected pair before indirect de-duplication, and terminate safely on indirect
+cycles. Malformed trees return FORMAT and exhausted traversal returns
+UNSUPPORTED. Tree presence still contributes the JavaScript finding in
+addition to every action class found in its values.
+
 The ordinary graph walk flags any `/AF` or `/EF` reference, embedded-file
 stream, or `/FileAttachment` annotation as embedded content. It flags
 `/RichMedia`, `/3D`, `/Movie`, `/Sound`, and `/Screen` annotation subtypes as
@@ -207,7 +218,9 @@ Apply these exact mutations on the fresh private graph:
   sanitize continuation chains even when their head is safe or unselected.
 - catalog `/Names`: remove `/JavaScript` and/or `/EmbeddedFiles` only when its
   matching policy is selected; remove catalog `/Names` if the dictionary then
-  has no keys.
+  has no keys. When JavaScript itself is unselected, walk retained name-tree
+  actions: remove a selected head as its complete key/value pair and sanitize
+  selected continuation classes from safe or unselected heads.
 - embedded-file policy: remove every dictionary `/AF` and `/EF` key and filter
   `/FileAttachment` annotations from every validated `/Annots` array.
 - XFA policy: remove only catalog `/AcroForm /XFA`.
@@ -218,6 +231,16 @@ Preserve array order and all unselected keys/objects. If conventional removal
 leaves a selected finding reachable (for example a custom edge directly to an
 embedded-file stream), return `QUANTAPDF_ERROR_UNSUPPORTED` without output;
 do not relabel or retain payload bytes merely to make the bit disappear.
+
+Before mutation, run an independent iterative, overflow-checked, source-bounded
+ownership/role preflight. Record every incoming semantic role for reachable
+indirect containers, charging before role-aware de-duplication. If a container
+that the selected policy would mutate is also referenced through a custom edge
+or a different conventional role, return `QUANTAPDF_ERROR_UNSUPPORTED` before
+mutation and leave output NULL. This covers catalog Names, JavaScript name-tree
+arrays/actions, AcroForm/XFA, `/AA`, `/Next`, `/Annots`, `/AF`, and `/EF` owner
+containers. Multiple aliases with the same role remain supported; an unrelated
+policy that would not mutate the ambiguous container is not rejected.
 
 - [x] **Step 1: Add policy isolation and `ALL` RED tests**
 
@@ -242,6 +265,13 @@ Use the C++ helper to inspect all written indirect objects and prove selected
 actions, name-tree entries, file specifications/embedded streams, XFA, and
 rich-media annotation objects made unreachable by conventional removal are
 absent from the serialized output, not merely hidden from the public scanner.
+
+Add genuine JavaScript name-tree fixtures for safe GoTo, a representative
+active head, every continuation class, malformed nodes and containers, cycles,
+and a compressed charge-before-de-duplication budget case. Add mixed-role
+`/Annots`-`/Next` and conventional/custom aliases for every mutable container
+family; partial selected policies must return unsupported with NULL output,
+while existing same-role sharing and an unrelated policy remain successful.
 
 - [x] **Step 3: Run and witness runtime RED**
 

--- a/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
@@ -135,13 +135,15 @@ destination array, name, or string and those forms are not actions. Scan
 The catalog `/Names /JavaScript` entry is walked as a strict iterative PDF name
 tree. Nodes are dictionaries; `/Kids` is an array of dictionary nodes;
 `/Names` is an even array of alternating string keys and action dictionaries;
-`/Kids` and `/Names` are mutually exclusive; and optional `/Limits` is exactly
-two strings. Empty roots are accepted. Feed every action value and recursive
-`/Next` continuation through the shared classifier, charge every enqueue and
-inspected pair before indirect de-duplication, and terminate safely on indirect
-cycles. Malformed trees return FORMAT and exhausted traversal returns
-UNSUPPORTED. Tree presence still contributes the JavaScript finding in
-addition to every action class found in its values.
+and `/Kids` and `/Names` are mutually exclusive. Raw string keys and child
+subtree ranges are strictly increasing and nonoverlapping. `/Limits` is
+optional, but every present pair must exactly equal the node's actual first and
+last descendant keys. Empty nodes are accepted only without `/Limits`. Every
+indirect node occurs once: cycles and multi-parent duplicates return FORMAT.
+Feed every action value and recursive `/Next` continuation through the shared
+classifier and charge every enqueue or inspected pair before the repeat check.
+Exhausted traversal returns UNSUPPORTED. Tree presence still contributes the
+JavaScript finding in addition to every action class found in its values.
 
 The ordinary graph walk flags any `/AF` or `/EF` reference, embedded-file
 stream, or `/FileAttachment` annotation as embedded content. It flags
@@ -234,13 +236,15 @@ do not relabel or retain payload bytes merely to make the bit disappear.
 
 Before mutation, run an independent iterative, overflow-checked, source-bounded
 ownership/role preflight. Record every incoming semantic role for reachable
-indirect containers, charging before role-aware de-duplication. If a container
-that the selected policy would mutate is also referenced through a custom edge
-or a different conventional role, return `QUANTAPDF_ERROR_UNSUPPORTED` before
-mutation and leave output NULL. This covers catalog Names, JavaScript name-tree
-arrays/actions, AcroForm/XFA, `/AA`, `/Next`, `/Annots`, `/AF`, and `/EF` owner
-containers. Multiple aliases with the same role remain supported; an unrelated
-policy that would not mutate the ambiguous container is not rejected.
+indirect containers, charging before role-aware de-duplication, and carry the
+nearest indirect mutation anchor through direct descendants. An indirect child
+becomes its own anchor. If a selected edit's container or nearest indirect
+anchor is also referenced through a custom edge or a different conventional
+role, return `QUANTAPDF_ERROR_UNSUPPORTED` before mutation and leave output
+NULL. This covers direct and indirect catalog Names descendants, JavaScript
+name-tree arrays/actions, AcroForm/XFA, `/AA`, `/Next`, `/Annots`, `/AF`, `/EF`,
+and action-owner keys. Multiple aliases with the same role remain supported; an
+unrelated policy that would not mutate the ambiguous container is not rejected.
 
 - [x] **Step 1: Add policy isolation and `ALL` RED tests**
 
@@ -267,8 +271,10 @@ rich-media annotation objects made unreachable by conventional removal are
 absent from the serialized output, not merely hidden from the public scanner.
 
 Add genuine JavaScript name-tree fixtures for safe GoTo, a representative
-active head, every continuation class, malformed nodes and containers, cycles,
-and a compressed charge-before-de-duplication budget case. Add mixed-role
+active head, every continuation class, malformed nodes and containers,
+repeated nodes, unordered or duplicate keys, inconsistent limits and child
+ranges, a valid limited multilevel tree, and a compressed
+charge-before-repeat-check budget case. Add mixed-role
 `/Annots`-`/Next` and conventional/custom aliases for every mutable container
 family; partial selected policies must return unsupported with NULL output,
 while existing same-role sharing and an unrelated policy remain successful.

--- a/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
@@ -84,14 +84,20 @@ findings. Malformed action containers return `QUANTAPDF_ERROR_FORMAT` instead
 of being silently skipped.
 
 The catalog `/Names /JavaScript` value is a strict PDF name tree, not merely a
-presence marker. Its iterative walker accepts an empty root, otherwise validates
-dictionary nodes, mutually exclusive `/Kids` and `/Names`, two-string
-`/Limits`, dictionary children, even alternating string/action pairs, and every
-action dictionary through the shared classifier. It follows every action
+presence marker. Its iterative postorder walker accepts an empty root and empty
+nodes without `/Limits`; otherwise it validates dictionary nodes, mutually
+exclusive `/Kids` and `/Names`, dictionary children, even alternating
+string/action pairs, and every action dictionary through the shared classifier.
+Leaf keys are raw string bytes in strictly increasing order. Child subtree
+ranges are strictly increasing and nonoverlapping. `/Limits` is optional for
+compatibility, but whenever present it is exactly two strings equal to the
+actual first and last key of that node's nonempty subtree; an empty node cannot
+have `/Limits`. It follows every action
 `/Next` chain, so a JavaScript tree can report launch, external, or other action
-bits in addition to the JavaScript-tree presence bit. Indirect nodes and actions
-are cycle-safe, and every enqueue or inspected name-tree item is charged before
-de-duplication against the shared audit budget. Malformed trees return
+bits in addition to the JavaScript-tree presence bit. Every indirect name-tree
+node may occur exactly once: a cycle or multi-parent duplicate is malformed.
+Actions remain cycle-safe. Every enqueue or inspected name-tree item is charged
+before the repeat check against the shared audit budget. Malformed trees return
 `QUANTAPDF_ERROR_FORMAT`; exhausted traversal returns
 `QUANTAPDF_ERROR_UNSUPPORTED`.
 
@@ -145,15 +151,18 @@ Repeated identical calls and reopen-then-sanitize are byte-idempotent.
 
 Before mutation, a second bounded role/ownership preflight records every
 reachable indirect container reference by semantic role, charging before
-role-aware de-duplication. A container that the selected policy would mutate is
-rejected with `QUANTAPDF_ERROR_UNSUPPORTED` if it also has an incoming custom
-alias or a different conventional role. This prevents one in-place edit from
-silently changing an unselected interpretation, such as one array serving both
-`/Annots` and action `/Next`. Multiple aliases in the same semantic role remain
-supported, including shared `/AA` dictionaries and shared `/Next` arrays. Direct
-containers cannot be shared by a serialized PDF and retain normal mutation
-behavior. Alias rejection happens after strict audit but before any mutation or
-output publication.
+role-aware de-duplication. Traversal carries the stable nearest indirect owner
+as a mutation anchor. An indirect child becomes its own anchor; editing any
+direct descendant targets that nearest indirect anchor. A selected target is
+rejected with `QUANTAPDF_ERROR_UNSUPPORTED` if its anchor also has an incoming
+custom alias or a different conventional role. This covers direct `/Next`,
+`/AA`, `/Annots`, JavaScript name-pair arrays and catalog name descendants,
+AcroForm/XFA, `/AF`, `/EF`, and action-owner keys as well as indirect mutable
+containers. It prevents one in-place edit from silently changing an unselected
+interpretation, such as one array serving both `/Annots` and action `/Next`.
+Multiple aliases in the same semantic role remain supported, including shared
+`/AA` dictionaries and shared `/Next` arrays. Alias rejection happens after
+strict audit but before any mutation or output publication.
 
 ## Ownership and failure atomicity
 
@@ -179,11 +188,13 @@ Tests prove:
 - safe internal navigation is not reported or removed;
 - unreferenced dangerous-looking garbage is ignored;
 - malformed action/name/annotation structures fail closed;
-- JavaScript name-tree heads and all continuation classes, malformed nodes,
-  cycles, and charge-before-de-duplication budget exhaustion;
+- JavaScript name-tree heads and all continuation classes, strictly ordered
+  byte keys and child ranges, exact optional limits, repeated-node rejection,
+  and charge-before-repeat-check budget exhaustion;
 - every sanitize flag is isolated and `ALL` clears every sanitizable finding;
 - partial sanitize preserves unselected findings;
-- selected mutation of cross-role or conventional/custom indirect aliases is
+- selected mutation of cross-role or conventional/custom indirect aliases,
+  including mutations through direct descendants anchored at those objects, is
   unsupported with NULL output, while same-role sharing and unrelated policies
   remain supported;
 - source immutability, output lifetime, determinism, and idempotence;

--- a/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
@@ -83,6 +83,18 @@ tree. Internal `/GoTo` actions and destination arrays are navigation, not
 findings. Malformed action containers return `QUANTAPDF_ERROR_FORMAT` instead
 of being silently skipped.
 
+The catalog `/Names /JavaScript` value is a strict PDF name tree, not merely a
+presence marker. Its iterative walker accepts an empty root, otherwise validates
+dictionary nodes, mutually exclusive `/Kids` and `/Names`, two-string
+`/Limits`, dictionary children, even alternating string/action pairs, and every
+action dictionary through the shared classifier. It follows every action
+`/Next` chain, so a JavaScript tree can report launch, external, or other action
+bits in addition to the JavaScript-tree presence bit. Indirect nodes and actions
+are cycle-safe, and every enqueue or inspected name-tree item is charged before
+de-duplication against the shared audit budget. Malformed trees return
+`QUANTAPDF_ERROR_FORMAT`; exhausted traversal returns
+`QUANTAPDF_ERROR_UNSUPPORTED`.
+
 Embedded-file detection covers the catalog `/Names /EmbeddedFiles` tree,
 associated-file `/AF` references, file specifications with `/EF`, embedded-file
 streams, and file-attachment annotations. XFA is detected at
@@ -116,7 +128,10 @@ The sanitizer opens a fresh private graph, completes audit/preflight before
 mutation, and then removes selected references:
 
 - selected actions from `/OpenAction`, `/A`, `/AA`, and `/Next`;
-- `/Names /JavaScript` or `/Names /EmbeddedFiles` as selected;
+- `/Names /JavaScript` or `/Names /EmbeddedFiles` as selected; when the
+  JavaScript policy is unselected, selected non-JavaScript action heads are
+  removed as complete name/value pairs and selected `/Next` continuations are
+  still pruned from retained safe or unselected name-tree actions;
 - `/AF` and `/EF` references plus file-attachment annotations for embedded-file
   removal;
 - `/AcroForm /XFA` for XFA removal;
@@ -127,6 +142,18 @@ bit is absent before bytes are published. Unselected categories remain
 unchanged. The writer uses deterministic IDs, disables object streams,
 preserves stream data, and discards objects made unreachable by sanitization.
 Repeated identical calls and reopen-then-sanitize are byte-idempotent.
+
+Before mutation, a second bounded role/ownership preflight records every
+reachable indirect container reference by semantic role, charging before
+role-aware de-duplication. A container that the selected policy would mutate is
+rejected with `QUANTAPDF_ERROR_UNSUPPORTED` if it also has an incoming custom
+alias or a different conventional role. This prevents one in-place edit from
+silently changing an unselected interpretation, such as one array serving both
+`/Annots` and action `/Next`. Multiple aliases in the same semantic role remain
+supported, including shared `/AA` dictionaries and shared `/Next` arrays. Direct
+containers cannot be shared by a serialized PDF and retain normal mutation
+behavior. Alias rejection happens after strict audit but before any mutation or
+output publication.
 
 ## Ownership and failure atomicity
 
@@ -152,8 +179,13 @@ Tests prove:
 - safe internal navigation is not reported or removed;
 - unreferenced dangerous-looking garbage is ignored;
 - malformed action/name/annotation structures fail closed;
+- JavaScript name-tree heads and all continuation classes, malformed nodes,
+  cycles, and charge-before-de-duplication budget exhaustion;
 - every sanitize flag is isolated and `ALL` clears every sanitizable finding;
 - partial sanitize preserves unselected findings;
+- selected mutation of cross-role or conventional/custom indirect aliases is
+  unsupported with NULL output, while same-role sharing and unrelated policies
+  remain supported;
 - source immutability, output lifetime, determinism, and idempotence;
 - encrypted and signature-bearing inputs audit correctly and sanitize as
   unsupported;

--- a/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
@@ -158,8 +158,11 @@ Tests prove:
 - encrypted and signature-bearing inputs audit correctly and sanitize as
   unsupported;
 - NULL, short-structure, zero-flag, unknown-flag, and sentinel-output behavior;
-- exact v2 exports, installed header version, full Windows tests, and CI on
-  Linux release/sanitizer, macOS, and Windows.
+- exact v2 exports, installed header version, and full local Windows tests.
+
+Before merge, the exact reviewed head must also pass Linux release/sanitizer,
+macOS, and Windows CI. That cross-platform evidence is a pending branch
+integration gate, not evidence supplied by the local Task 4 verification.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
@@ -160,6 +160,11 @@ custom alias or a different conventional role. This covers direct `/Next`,
 AcroForm/XFA, `/AF`, `/EF`, and action-owner keys as well as indirect mutable
 containers. It prevents one in-place edit from silently changing an unselected
 interpretation, such as one array serving both `/Annots` and action `/Next`.
+Standard annotation backlinks retain conventional roles: a structurally valid
+annotation `/P` points to a page, `/IRT` and `/Popup` point to annotations, and
+a popup annotation `/Parent` points to its parent annotation. The preflight
+requires the expected page type or annotation subtype before assigning those
+roles; arbitrary objects reached through the same key names remain custom.
 Multiple aliases in the same semantic role remain supported, including shared
 `/AA` dictionaries and shared `/Next` arrays. Alias rejection happens after
 strict audit but before any mutation or output publication.

--- a/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
@@ -1,0 +1,186 @@
+# QuantaPDF Document Audit and Sanitize V1 Design
+
+**Status:** Approved for implementation by the continuing development request
+
+## Goal
+
+Add a structure-level security audit and an immutable sanitizer without exposing
+QPDF objects or changing the v2 ABI contract.
+
+```c
+QUANTAPDF_API quantapdf_status quantapdf_document_audit(
+    quantapdf_document *document,
+    quantapdf_audit_result *out_result);
+
+QUANTAPDF_API quantapdf_status quantapdf_sanitize(
+    quantapdf_document *document,
+    uint32_t flags,
+    quantapdf_output **out_output);
+```
+
+The audit reports the presence of reachable PDF structures that can execute
+actions, leave the document, carry embedded payloads, or invalidate a rewrite.
+The sanitizer removes explicitly selected classes and returns a new owning PDF.
+Neither operation mutates the source document.
+
+## Public contract
+
+`quantapdf_audit_result` is a size-tagged, single-result output structure:
+
+```c
+typedef struct quantapdf_audit_result {
+    size_t struct_size;
+    uint32_t findings;
+} quantapdf_audit_result;
+```
+
+V1 findings are independent bits:
+
+- JavaScript action;
+- launch action;
+- external action (`URI`, `GoToR`, `GoToE`, `SubmitForm`, or `ImportData`);
+- other active or unknown action (every action other than internal `GoTo` and
+  the preceding named classes);
+- embedded file;
+- XFA;
+- rich-media annotation (`RichMedia`, `3D`, `Movie`, `Sound`, or `Screen`);
+- signature structure;
+- encryption.
+
+A signature finding means that a populated effective `/FT /Sig` field or a
+catalog `/Perms` signature is present. It is not a cryptographic-validity
+claim. An encryption finding is returned even when the caller supplied the
+correct password to `quantapdf_open()`.
+
+`quantapdf_document_audit` requires a non-NULL document and result. The caller
+sets `struct_size`; V1 requires at least `QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE`.
+The function clears `findings` before backend work whenever that field is
+addressable. A larger structure is accepted and only the known V1 prefix is
+written, allowing a future library to extend the structure without overwriting
+an older caller.
+
+`quantapdf_sanitize` requires a non-NULL document and output pointer, a nonzero
+combination of known flags, and resets `*out_output` to NULL before validation.
+Success returns independent owning bytes that remain valid after the source is
+closed. Unknown or zero flags return `QUANTAPDF_ERROR_ARGUMENT`.
+
+Adding the two functions is an append-only ABI v2 change. The release becomes
+2.3.0, `QUANTAPDF_ABI_VERSION` and shared-library major remain 2, and the exact
+Windows export baseline grows from 85 to 87 names.
+
+## Audit model
+
+The backend reparses source bytes into a fresh private QPDF graph with recovery
+disabled and warnings captured. It audits only objects reachable from the
+catalog root. Unreferenced garbage cannot execute and does not create a
+finding. Content stream bytes and ordinary strings are not searched for words
+such as `JavaScript`; this prevents false positives and keeps the API a PDF
+structure audit rather than a malware-content scanner.
+
+Executable action positions are catalog `/OpenAction`, dictionary `/A`,
+dictionary `/AA` entries, action `/Next` chains, and the catalog JavaScript name
+tree. Internal `/GoTo` actions and destination arrays are navigation, not
+findings. Malformed action containers return `QUANTAPDF_ERROR_FORMAT` instead
+of being silently skipped.
+
+Embedded-file detection covers the catalog `/Names /EmbeddedFiles` tree,
+associated-file `/AF` references, file specifications with `/EF`, embedded-file
+streams, and file-attachment annotations. XFA is detected at
+`/Root /AcroForm /XFA`. Rich media is detected by annotation subtype.
+
+The graph walk is iterative. Indirect objects are de-duplicated by
+`QPDFObjGen`; streams contribute their dictionaries but their bytes are never
+decoded. Work-list growth is checked and bounded by a conservative limit
+derived from source size. Exceeding the completeness limit returns
+`QUANTAPDF_ERROR_UNSUPPORTED`; allocation failure returns
+`QUANTAPDF_ERROR_NOMEM`.
+
+## Sanitize policy
+
+Sanitize flags correspond exactly to the first seven finding classes:
+
+- JavaScript actions and the JavaScript name tree;
+- launch actions;
+- external actions;
+- other active or unknown actions;
+- embedded files;
+- XFA;
+- rich-media annotations.
+
+`QUANTAPDF_SANITIZE_ALL` combines those seven bits. Signature and encryption
+are observations, not removal flags. Every sanitize call rejects a document
+with either condition because a full rewrite would invalidate a signature or
+silently decrypt the file.
+
+The sanitizer opens a fresh private graph, completes audit/preflight before
+mutation, and then removes selected references:
+
+- selected actions from `/OpenAction`, `/A`, `/AA`, and `/Next`;
+- `/Names /JavaScript` or `/Names /EmbeddedFiles` as selected;
+- `/AF` and `/EF` references plus file-attachment annotations for embedded-file
+  removal;
+- `/AcroForm /XFA` for XFA removal;
+- selected rich-media annotations from page `/Annots` arrays.
+
+After mutation, the same audit engine must prove that every selected finding
+bit is absent before bytes are published. Unselected categories remain
+unchanged. The writer uses deterministic IDs, disables object streams,
+preserves stream data, and discards objects made unreachable by sanitization.
+Repeated identical calls and reopen-then-sanitize are byte-idempotent.
+
+## Ownership and failure atomicity
+
+The public document owns source bytes and both backend handles. Audit borrows
+them only for the duration of the call and publishes no pointers. Sanitize
+creates one private QPDF owner, then copies the final writer buffer into the
+heap allocation owned by `quantapdf_output`. No borrowed QPDF memory crosses
+the C++ bridge.
+
+The C facade allocates an output shell but publishes it only after backend
+success. Every failure frees the shell and any returned buffer, leaving
+`*out_output == NULL`. All C++ exceptions stay inside the bridge and map to the
+existing status enum.
+
+The implementation is single-call/single-threaded. It adds no global mutable
+state, background work, queues, callbacks, or shutdown protocol.
+
+## Verification
+
+Tests prove:
+
+- every finding bit in isolation plus a clean zero-result document;
+- safe internal navigation is not reported or removed;
+- unreferenced dangerous-looking garbage is ignored;
+- malformed action/name/annotation structures fail closed;
+- every sanitize flag is isolated and `ALL` clears every sanitizable finding;
+- partial sanitize preserves unselected findings;
+- source immutability, output lifetime, determinism, and idempotence;
+- encrypted and signature-bearing inputs audit correctly and sanitize as
+  unsupported;
+- NULL, short-structure, zero-flag, unknown-flag, and sentinel-output behavior;
+- exact v2 exports, installed header version, full Windows tests, and CI on
+  Linux release/sanitizer, macOS, and Windows.
+
+## Non-goals
+
+- antivirus heuristics, JavaScript parsing, URL reputation, or content-stream
+  keyword scanning;
+- cryptographic signature validation or preservation;
+- password removal, re-encryption, or encrypted output;
+- generic metadata removal, form flattening, annotation flattening, redaction,
+  image optimization, or repair;
+- a public PDF object model, callback visitor, or policy plugin ABI;
+- mutation of the opened source document.
+
+## Files
+
+- `include/quantapdf/quantapdf.h`: findings, flags, result, APIs, and 2.3.0.
+- `src/pdf_security.c`: argument checks and output ownership facade.
+- `src/backend/qpdf_document.h`: private audit/sanitize bridge declarations.
+- `src/backend/qpdf_document.cpp`: bounded graph audit and sanitizer.
+- `tests/test_pdf_security.c`: public behavior and ownership tests.
+- `tests/pdf_security_test_helpers.cpp`: precise structure fixtures and raw
+  postcondition checks.
+- `tests/CMakeLists.txt`: `quantapdf.pdf_security` target.
+- `abi/quantapdf-v2.exports`: two appended public names.
+- `README.md`: documented safety boundary and examples.

--- a/include/quantapdf/quantapdf.h
+++ b/include/quantapdf/quantapdf.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 #define QUANTAPDF_VERSION_MAJOR 2
-#define QUANTAPDF_VERSION_MINOR 2
+#define QUANTAPDF_VERSION_MINOR 3
 #define QUANTAPDF_VERSION_PATCH 0
 #define QUANTAPDF_ABI_VERSION 2
 
@@ -70,6 +70,38 @@ typedef enum quantapdf_flatten_flag {
     QUANTAPDF_FLATTEN_ANNOTATIONS = 1u << 0,
     QUANTAPDF_FLATTEN_WIDGETS = 1u << 1
 } quantapdf_flatten_flag;
+
+typedef enum quantapdf_audit_finding {
+    QUANTAPDF_AUDIT_JAVASCRIPT_ACTION = 1u << 0,
+    QUANTAPDF_AUDIT_LAUNCH_ACTION = 1u << 1,
+    QUANTAPDF_AUDIT_EXTERNAL_ACTION = 1u << 2,
+    QUANTAPDF_AUDIT_OTHER_ACTION = 1u << 3,
+    QUANTAPDF_AUDIT_EMBEDDED_FILE = 1u << 4,
+    QUANTAPDF_AUDIT_XFA = 1u << 5,
+    QUANTAPDF_AUDIT_RICH_MEDIA = 1u << 6,
+    QUANTAPDF_AUDIT_SIGNATURE = 1u << 7,
+    QUANTAPDF_AUDIT_ENCRYPTION = 1u << 8
+} quantapdf_audit_finding;
+
+typedef enum quantapdf_sanitize_flag {
+    QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS = 1u << 0,
+    QUANTAPDF_SANITIZE_LAUNCH_ACTIONS = 1u << 1,
+    QUANTAPDF_SANITIZE_EXTERNAL_ACTIONS = 1u << 2,
+    QUANTAPDF_SANITIZE_OTHER_ACTIONS = 1u << 3,
+    QUANTAPDF_SANITIZE_EMBEDDED_FILES = 1u << 4,
+    QUANTAPDF_SANITIZE_XFA = 1u << 5,
+    QUANTAPDF_SANITIZE_RICH_MEDIA = 1u << 6,
+    QUANTAPDF_SANITIZE_ALL = (1u << 7) - 1u
+} quantapdf_sanitize_flag;
+
+typedef struct quantapdf_audit_result {
+    size_t struct_size;
+    uint32_t findings;
+} quantapdf_audit_result;
+
+#define QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE \
+    (offsetof(quantapdf_audit_result, findings) + sizeof(uint32_t))
+#define QUANTAPDF_AUDIT_RESULT_V1_SIZE (sizeof(quantapdf_audit_result))
 
 /*
  * These types are traversed as C arrays and therefore have fixed V1 layouts.
@@ -429,6 +461,10 @@ QUANTAPDF_API quantapdf_status quantapdf_document_metadata(
     char **out_utf8,
     size_t *out_size);
 
+QUANTAPDF_API quantapdf_status quantapdf_document_audit(
+    quantapdf_document *document,
+    quantapdf_audit_result *out_result);
+
 QUANTAPDF_API quantapdf_status quantapdf_document_outline(
     quantapdf_document *document,
     quantapdf_outline **out_outline);
@@ -494,6 +530,11 @@ QUANTAPDF_API quantapdf_status quantapdf_rewrite_lossless(
     quantapdf_output **out_output);
 
 QUANTAPDF_API quantapdf_status quantapdf_flatten_interactive(
+    quantapdf_document *document,
+    uint32_t flags,
+    quantapdf_output **out_output);
+
+QUANTAPDF_API quantapdf_status quantapdf_sanitize(
     quantapdf_document *document,
     uint32_t flags,
     quantapdf_output **out_output);

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -1856,6 +1856,26 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                         item.role == quantapdf_qpdf_alias_role::page_tree) &&
                        key == "/Parent") {
                 child_role = quantapdf_qpdf_alias_role::page_tree;
+            } else if (item.role == quantapdf_qpdf_alias_role::annotation &&
+                       key == "/P" && child.isDictionary() &&
+                       child.getKey("/Type").isName() &&
+                       child.getKey("/Type").getName() == "/Page") {
+                child_role = quantapdf_qpdf_alias_role::page;
+            } else if (item.role == quantapdf_qpdf_alias_role::annotation &&
+                       key == "/IRT" && child.isDictionary() &&
+                       child.getKey("/Subtype").isName()) {
+                child_role = quantapdf_qpdf_alias_role::annotation;
+            } else if (item.role == quantapdf_qpdf_alias_role::annotation &&
+                       key == "/Popup" && child.isDictionary() &&
+                       child.getKey("/Subtype").isName() &&
+                       child.getKey("/Subtype").getName() == "/Popup") {
+                child_role = quantapdf_qpdf_alias_role::annotation;
+            } else if (item.role == quantapdf_qpdf_alias_role::annotation &&
+                       key == "/Parent" && object.getKey("/Subtype").isName() &&
+                       object.getKey("/Subtype").getName() == "/Popup" &&
+                       child.isDictionary() &&
+                       child.getKey("/Subtype").isName()) {
+                child_role = quantapdf_qpdf_alias_role::annotation;
             } else if (item.role ==
                            quantapdf_qpdf_alias_role::additional_actions) {
                 child_role = quantapdf_qpdf_alias_role::action;

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -766,7 +766,7 @@ static quantapdf_status quantapdf_qpdf_lossless_preflight(QPDF& pdf)
     return QUANTAPDF_OK;
 }
 
-struct quantapdf_qpdf_audit_budget {
+struct quantapdf_qpdf_work_budget {
     size_t limit = 0;
     size_t used = 0;
 
@@ -786,11 +786,47 @@ struct quantapdf_qpdf_audit_field_item {
     QPDFObjectHandle inherited_value = QPDFObjectHandle::newNull();
 };
 
-static quantapdf_status quantapdf_qpdf_audit_push(
+static quantapdf_status quantapdf_qpdf_init_work_budget(
+    size_t source_size,
+    quantapdf_qpdf_work_budget *budget)
+{
+    if (source_size > std::numeric_limits<size_t>::max() / 64u)
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    budget->limit = std::max<size_t>(4096u, source_size * 64u);
+    budget->used = 0;
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_classify_action(
+    QPDFObjectHandle action,
+    uint32_t *finding)
+{
+    *finding = 0;
+    if (!action.isDictionary())
+        return QUANTAPDF_ERROR_FORMAT;
+    QPDFObjectHandle type = action.getKey("/S");
+    if (!type.isName())
+        return QUANTAPDF_ERROR_FORMAT;
+    std::string const name = type.getName();
+    if (name == "/JavaScript") {
+        *finding = QUANTAPDF_AUDIT_JAVASCRIPT_ACTION;
+    } else if (name == "/Launch") {
+        *finding = QUANTAPDF_AUDIT_LAUNCH_ACTION;
+    } else if (name == "/URI" || name == "/GoToR" ||
+               name == "/GoToE" || name == "/SubmitForm" ||
+               name == "/ImportData") {
+        *finding = QUANTAPDF_AUDIT_EXTERNAL_ACTION;
+    } else if (name != "/GoTo") {
+        *finding = QUANTAPDF_AUDIT_OTHER_ACTION;
+    }
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_work_push(
     QPDFObjectHandle object,
     std::vector<QPDFObjectHandle> *work,
     std::set<QPDFObjGen> *seen,
-    quantapdf_qpdf_audit_budget *budget)
+    quantapdf_qpdf_work_budget *budget)
 {
     if (!budget->take())
         return QUANTAPDF_ERROR_UNSUPPORTED;
@@ -804,15 +840,15 @@ static quantapdf_status quantapdf_qpdf_audit_push_action(
     QPDFObjectHandle action,
     std::vector<QPDFObjectHandle> *work,
     std::set<QPDFObjGen> *seen,
-    quantapdf_qpdf_audit_budget *budget)
+    quantapdf_qpdf_work_budget *budget)
 {
-    return quantapdf_qpdf_audit_push(action, work, seen, budget);
+    return quantapdf_qpdf_work_push(action, work, seen, budget);
 }
 
 static quantapdf_status quantapdf_qpdf_audit_actions(
     std::vector<QPDFObjectHandle> *work,
     std::set<QPDFObjGen> *seen,
-    quantapdf_qpdf_audit_budget *budget,
+    quantapdf_qpdf_work_budget *budget,
     uint32_t *findings)
 {
     while (!work->empty()) {
@@ -820,21 +856,12 @@ static quantapdf_status quantapdf_qpdf_audit_actions(
         work->pop_back();
         if (!action.isDictionary())
             return QUANTAPDF_ERROR_FORMAT;
-        QPDFObjectHandle type = action.getKey("/S");
-        if (!type.isName())
-            return QUANTAPDF_ERROR_FORMAT;
-        std::string const name = type.getName();
-        if (name == "/JavaScript") {
-            *findings |= QUANTAPDF_AUDIT_JAVASCRIPT_ACTION;
-        } else if (name == "/Launch") {
-            *findings |= QUANTAPDF_AUDIT_LAUNCH_ACTION;
-        } else if (name == "/URI" || name == "/GoToR" ||
-                   name == "/GoToE" || name == "/SubmitForm" ||
-                   name == "/ImportData") {
-            *findings |= QUANTAPDF_AUDIT_EXTERNAL_ACTION;
-        } else if (name != "/GoTo") {
-            *findings |= QUANTAPDF_AUDIT_OTHER_ACTION;
-        }
+        uint32_t finding = 0;
+        quantapdf_status const classification =
+            quantapdf_qpdf_classify_action(action, &finding);
+        if (classification != QUANTAPDF_OK)
+            return classification;
+        *findings |= finding;
 
         if (!action.hasKey("/Next"))
             continue;
@@ -865,7 +892,7 @@ static quantapdf_status quantapdf_qpdf_audit_actions(
 
 static quantapdf_status quantapdf_qpdf_audit_signature_fields(
     QPDFObjectHandle acroform,
-    quantapdf_qpdf_audit_budget *budget,
+    quantapdf_qpdf_work_budget *budget,
     uint32_t *findings)
 {
     if (!acroform.hasKey("/Fields"))
@@ -944,7 +971,7 @@ static quantapdf_status quantapdf_qpdf_audit_signature_fields(
 
 static quantapdf_status quantapdf_qpdf_audit_catalog_signatures(
     QPDFObjectHandle root,
-    quantapdf_qpdf_audit_budget *budget,
+    quantapdf_qpdf_work_budget *budget,
     uint32_t *findings)
 {
     if (!root.hasKey("/Perms"))
@@ -978,14 +1005,14 @@ static bool quantapdf_qpdf_audit_rich_media(std::string const& subtype)
 
 static quantapdf_status quantapdf_qpdf_audit_graph(
     QPDFObjectHandle root,
-    quantapdf_qpdf_audit_budget *budget,
+    quantapdf_qpdf_work_budget *budget,
     uint32_t *findings)
 {
     std::vector<QPDFObjectHandle> graph_work;
     std::vector<QPDFObjectHandle> action_work;
     std::set<QPDFObjGen> graph_seen;
     std::set<QPDFObjGen> action_seen;
-    quantapdf_status status = quantapdf_qpdf_audit_push(
+    quantapdf_status status = quantapdf_qpdf_work_push(
         root, &graph_work, &graph_seen, budget);
     if (status != QUANTAPDF_OK)
         return status;
@@ -1014,7 +1041,7 @@ static quantapdf_status quantapdf_qpdf_audit_graph(
         if (object.isArray()) {
             int const count = object.getArrayNItems();
             for (int index = 0; index < count; ++index) {
-                status = quantapdf_qpdf_audit_push(
+                status = quantapdf_qpdf_work_push(
                     object.getArrayItem(index), &graph_work,
                     &graph_seen, budget);
                 if (status != QUANTAPDF_OK)
@@ -1067,7 +1094,7 @@ static quantapdf_status quantapdf_qpdf_audit_graph(
             }
         }
         for (std::string const& key : object.getKeys()) {
-            status = quantapdf_qpdf_audit_push(
+            status = quantapdf_qpdf_work_push(
                 object.getKey(key), &graph_work, &graph_seen, budget);
             if (status != QUANTAPDF_OK)
                 return status;
@@ -1082,10 +1109,11 @@ static quantapdf_status quantapdf_qpdf_audit_document(
     size_t source_size,
     uint32_t *findings)
 {
-    if (source_size > std::numeric_limits<size_t>::max() / 64u)
-        return QUANTAPDF_ERROR_UNSUPPORTED;
-    quantapdf_qpdf_audit_budget budget;
-    budget.limit = std::max<size_t>(4096u, source_size * 64u);
+    quantapdf_qpdf_work_budget budget;
+    quantapdf_status status =
+        quantapdf_qpdf_init_work_budget(source_size, &budget);
+    if (status != QUANTAPDF_OK)
+        return status;
 
     QPDFObjectHandle root = pdf.getRoot();
     if (!root.isDictionary())
@@ -1093,7 +1121,7 @@ static quantapdf_status quantapdf_qpdf_audit_document(
     if (pdf.isEncrypted())
         *findings |= QUANTAPDF_AUDIT_ENCRYPTION;
 
-    quantapdf_status status = quantapdf_qpdf_audit_catalog_signatures(
+    status = quantapdf_qpdf_audit_catalog_signatures(
         root, &budget, findings);
     if (status != QUANTAPDF_OK)
         return status;
@@ -1120,6 +1148,228 @@ static quantapdf_status quantapdf_qpdf_audit_document(
             return status;
     }
     return quantapdf_qpdf_audit_graph(root, &budget, findings);
+}
+
+static quantapdf_status quantapdf_qpdf_sanitize_queue_action(
+    QPDFObjectHandle action,
+    uint32_t flags,
+    std::vector<QPDFObjectHandle> *work,
+    std::set<QPDFObjGen> *seen,
+    quantapdf_qpdf_work_budget *budget,
+    bool *selected)
+{
+    if (!budget->take())
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    uint32_t finding = 0;
+    quantapdf_status const status =
+        quantapdf_qpdf_classify_action(action, &finding);
+    if (status != QUANTAPDF_OK)
+        return status;
+    *selected = (finding & flags) != 0;
+    if (*selected)
+        return QUANTAPDF_OK;
+    if (action.isIndirect() && !seen->insert(action.getObjGen()).second)
+        return QUANTAPDF_OK;
+    work->push_back(action);
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_sanitize_actions(
+    uint32_t flags,
+    std::vector<QPDFObjectHandle> *work,
+    std::set<QPDFObjGen> *seen,
+    quantapdf_qpdf_work_budget *budget)
+{
+    while (!work->empty()) {
+        QPDFObjectHandle action = work->back();
+        work->pop_back();
+        if (!action.hasKey("/Next"))
+            continue;
+
+        QPDFObjectHandle next = action.getKey("/Next");
+        if (next.isDictionary()) {
+            bool selected = false;
+            quantapdf_status const status =
+                quantapdf_qpdf_sanitize_queue_action(
+                    next, flags, work, seen, budget, &selected);
+            if (status != QUANTAPDF_OK)
+                return status;
+            if (selected)
+                action.removeKey("/Next");
+            continue;
+        }
+        if (!next.isArray())
+            return QUANTAPDF_ERROR_FORMAT;
+
+        std::vector<int> selected_indices;
+        int const count = next.getArrayNItems();
+        selected_indices.reserve(static_cast<size_t>(count));
+        for (int index = 0; index < count; ++index) {
+            bool selected = false;
+            quantapdf_status const status =
+                quantapdf_qpdf_sanitize_queue_action(
+                    next.getArrayItem(index), flags, work, seen,
+                    budget, &selected);
+            if (status != QUANTAPDF_OK)
+                return status;
+            if (selected)
+                selected_indices.push_back(index);
+        }
+        for (auto index = selected_indices.rbegin();
+             index != selected_indices.rend(); ++index) {
+            next.eraseItem(*index);
+        }
+        if (next.getArrayNItems() == 0)
+            action.removeKey("/Next");
+    }
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_sanitize_graph(
+    QPDF& pdf,
+    size_t source_size,
+    uint32_t flags)
+{
+    quantapdf_qpdf_work_budget budget;
+    quantapdf_status status =
+        quantapdf_qpdf_init_work_budget(source_size, &budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+
+    QPDFObjectHandle root = pdf.getRoot();
+    std::vector<QPDFObjectHandle> graph_work;
+    std::vector<QPDFObjectHandle> action_work;
+    std::set<QPDFObjGen> graph_seen;
+    std::set<QPDFObjGen> action_seen;
+
+    if (root.hasKey("/Names")) {
+        if (!budget.take())
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+        QPDFObjectHandle names = root.getKey("/Names");
+        if ((flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) != 0)
+            names.removeKey("/JavaScript");
+        if ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0)
+            names.removeKey("/EmbeddedFiles");
+        if (names.getKeys().empty())
+            root.removeKey("/Names");
+    }
+
+    if (root.hasKey("/AcroForm") &&
+        (flags & QUANTAPDF_SANITIZE_XFA) != 0) {
+        if (!budget.take())
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+        root.getKey("/AcroForm").removeKey("/XFA");
+    }
+
+    if (root.hasKey("/OpenAction")) {
+        QPDFObjectHandle open_action = root.getKey("/OpenAction");
+        if (!open_action.isArray() && !open_action.isName() &&
+            !open_action.isString()) {
+            bool selected = false;
+            status = quantapdf_qpdf_sanitize_queue_action(
+                open_action, flags, &action_work, &action_seen,
+                &budget, &selected);
+            if (status != QUANTAPDF_OK)
+                return status;
+            if (selected)
+                root.removeKey("/OpenAction");
+        }
+    }
+
+    status = quantapdf_qpdf_work_push(
+        root, &graph_work, &graph_seen, &budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+    while (!graph_work.empty()) {
+        QPDFObjectHandle object = graph_work.back();
+        graph_work.pop_back();
+        if (object.isStream())
+            object = object.getDict();
+        if (object.isArray()) {
+            int const count = object.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                status = quantapdf_qpdf_work_push(
+                    object.getArrayItem(index), &graph_work,
+                    &graph_seen, &budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+            continue;
+        }
+        if (!object.isDictionary())
+            continue;
+
+        if ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0) {
+            object.removeKey("/AF");
+            object.removeKey("/EF");
+        }
+
+        if (object.hasKey("/A")) {
+            bool selected = false;
+            status = quantapdf_qpdf_sanitize_queue_action(
+                object.getKey("/A"), flags, &action_work,
+                &action_seen, &budget, &selected);
+            if (status != QUANTAPDF_OK)
+                return status;
+            if (selected)
+                object.removeKey("/A");
+        }
+
+        if (object.hasKey("/AA")) {
+            QPDFObjectHandle additional = object.getKey("/AA");
+            std::vector<std::string> selected_keys;
+            for (std::string const& key : additional.getKeys()) {
+                bool selected = false;
+                status = quantapdf_qpdf_sanitize_queue_action(
+                    additional.getKey(key), flags, &action_work,
+                    &action_seen, &budget, &selected);
+                if (status != QUANTAPDF_OK)
+                    return status;
+                if (selected)
+                    selected_keys.push_back(key);
+            }
+            for (std::string const& key : selected_keys)
+                additional.removeKey(key);
+            if (additional.getKeys().empty())
+                object.removeKey("/AA");
+        }
+
+        if (object.hasKey("/Annots")) {
+            QPDFObjectHandle annots = object.getKey("/Annots");
+            std::vector<int> selected_indices;
+            int const count = annots.getArrayNItems();
+            selected_indices.reserve(static_cast<size_t>(count));
+            for (int index = 0; index < count; ++index) {
+                if (!budget.take())
+                    return QUANTAPDF_ERROR_UNSUPPORTED;
+                QPDFObjectHandle annotation = annots.getArrayItem(index);
+                QPDFObjectHandle subtype = annotation.getKey("/Subtype");
+                if (!subtype.isName())
+                    continue;
+                std::string const name = subtype.getName();
+                if (((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
+                     name == "/FileAttachment") ||
+                    ((flags & QUANTAPDF_SANITIZE_RICH_MEDIA) != 0 &&
+                     quantapdf_qpdf_audit_rich_media(name))) {
+                    selected_indices.push_back(index);
+                }
+            }
+            for (auto index = selected_indices.rbegin();
+                 index != selected_indices.rend(); ++index) {
+                annots.eraseItem(*index);
+            }
+        }
+
+        for (std::string const& key : object.getKeys()) {
+            status = quantapdf_qpdf_work_push(
+                object.getKey(key), &graph_work, &graph_seen, &budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
+    }
+
+    return quantapdf_qpdf_sanitize_actions(
+        flags, &action_work, &action_seen, &budget);
 }
 
 static quantapdf_status quantapdf_qpdf_public_crop_to_pdf(
@@ -3331,6 +3581,82 @@ extern "C" quantapdf_status quantapdf_qpdf_document_audit(
         if (pdf->anyWarnings())
             return QUANTAPDF_ERROR_FORMAT;
         *out_findings = findings;
+        return QUANTAPDF_OK;
+    } catch (QPDFExc const& error) {
+        return quantapdf_status_from_qpdf(error);
+    } catch (std::bad_alloc const&) {
+        return QUANTAPDF_ERROR_NOMEM;
+    } catch (std::exception const&) {
+        return QUANTAPDF_ERROR_BACKEND;
+    } catch (...) {
+        return QUANTAPDF_ERROR_BACKEND;
+    }
+}
+
+extern "C" quantapdf_status quantapdf_qpdf_sanitize(
+    quantapdf_qpdf_document *document,
+    uint32_t flags,
+    unsigned char **out_data,
+    size_t *out_size)
+{
+    if (out_data == nullptr || out_size == nullptr)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    *out_data = nullptr;
+    *out_size = 0;
+    if (document == nullptr || document->pdf == nullptr ||
+        document->source_data == nullptr || document->source_size == 0 ||
+        flags == 0 || (flags & ~QUANTAPDF_SANITIZE_ALL) != 0)
+        return QUANTAPDF_ERROR_ARGUMENT;
+
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->setAttemptRecovery(false);
+        pdf->processMemoryFile(
+            "quantapdf-sanitize",
+            reinterpret_cast<char const *>(document->source_data),
+            document->source_size,
+            document->password.c_str());
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+
+        uint32_t findings = 0;
+        quantapdf_status status = quantapdf_qpdf_audit_document(
+            *pdf, document->source_size, &findings);
+        if (status != QUANTAPDF_OK)
+            return status;
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+        if ((findings & (QUANTAPDF_AUDIT_SIGNATURE |
+                         QUANTAPDF_AUDIT_ENCRYPTION)) != 0)
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+
+        status = quantapdf_qpdf_sanitize_graph(
+            *pdf, document->source_size, flags);
+        if (status != QUANTAPDF_OK)
+            return status;
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+
+        findings = 0;
+        status = quantapdf_qpdf_audit_document(
+            *pdf, document->source_size, &findings);
+        if (status != QUANTAPDF_OK)
+            return status;
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+        if ((findings & flags) != 0)
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+
+        status = quantapdf_qpdf_write_memory(*pdf, out_data, out_size);
+        if (status != QUANTAPDF_OK)
+            return status;
+        if (pdf->anyWarnings()) {
+            std::free(*out_data);
+            *out_data = nullptr;
+            *out_size = 0;
+            return QUANTAPDF_ERROR_FORMAT;
+        }
         return QUANTAPDF_OK;
     } catch (QPDFExc const& error) {
         return quantapdf_status_from_qpdf(error);

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -766,6 +766,329 @@ static quantapdf_status quantapdf_qpdf_lossless_preflight(QPDF& pdf)
     return QUANTAPDF_OK;
 }
 
+struct quantapdf_qpdf_audit_budget {
+    size_t limit = 0;
+    size_t used = 0;
+
+    bool take() noexcept
+    {
+        if (used >= limit)
+            return false;
+        ++used;
+        return true;
+    }
+};
+
+struct quantapdf_qpdf_audit_field_item {
+    QPDFObjectHandle field = QPDFObjectHandle::newNull();
+    QPDFObjectHandle expected_parent = QPDFObjectHandle::newNull();
+    std::string inherited_type;
+    QPDFObjectHandle inherited_value = QPDFObjectHandle::newNull();
+};
+
+static quantapdf_status quantapdf_qpdf_audit_push(
+    QPDFObjectHandle object,
+    std::vector<QPDFObjectHandle> *work,
+    std::set<QPDFObjGen> *seen,
+    quantapdf_qpdf_audit_budget *budget)
+{
+    if (object.isIndirect() && !seen->insert(object.getObjGen()).second)
+        return QUANTAPDF_OK;
+    if (!budget->take())
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    work->push_back(object);
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_audit_push_action(
+    QPDFObjectHandle action,
+    std::vector<QPDFObjectHandle> *work,
+    std::set<QPDFObjGen> *seen,
+    quantapdf_qpdf_audit_budget *budget)
+{
+    return quantapdf_qpdf_audit_push(action, work, seen, budget);
+}
+
+static quantapdf_status quantapdf_qpdf_audit_actions(
+    std::vector<QPDFObjectHandle> *work,
+    std::set<QPDFObjGen> *seen,
+    quantapdf_qpdf_audit_budget *budget,
+    uint32_t *findings)
+{
+    while (!work->empty()) {
+        QPDFObjectHandle action = work->back();
+        work->pop_back();
+        if (!action.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        QPDFObjectHandle type = action.getKey("/S");
+        if (!type.isName())
+            return QUANTAPDF_ERROR_FORMAT;
+        std::string const name = type.getName();
+        if (name == "/JavaScript") {
+            *findings |= QUANTAPDF_AUDIT_JAVASCRIPT_ACTION;
+        } else if (name == "/Launch") {
+            *findings |= QUANTAPDF_AUDIT_LAUNCH_ACTION;
+        } else if (name == "/URI" || name == "/GoToR" ||
+                   name == "/GoToE" || name == "/SubmitForm" ||
+                   name == "/ImportData") {
+            *findings |= QUANTAPDF_AUDIT_EXTERNAL_ACTION;
+        } else if (name != "/GoTo") {
+            *findings |= QUANTAPDF_AUDIT_OTHER_ACTION;
+        }
+
+        if (!action.hasKey("/Next"))
+            continue;
+        QPDFObjectHandle next = action.getKey("/Next");
+        if (next.isDictionary()) {
+            quantapdf_status const status = quantapdf_qpdf_audit_push_action(
+                next, work, seen, budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        } else if (next.isArray()) {
+            int const count = next.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                QPDFObjectHandle item = next.getArrayItem(index);
+                if (!item.isDictionary())
+                    return QUANTAPDF_ERROR_FORMAT;
+                quantapdf_status const status =
+                    quantapdf_qpdf_audit_push_action(
+                        item, work, seen, budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+        } else {
+            return QUANTAPDF_ERROR_FORMAT;
+        }
+    }
+    return QUANTAPDF_OK;
+}
+
+static quantapdf_status quantapdf_qpdf_audit_signature_fields(
+    QPDFObjectHandle acroform,
+    quantapdf_qpdf_audit_budget *budget,
+    uint32_t *findings)
+{
+    if (!acroform.hasKey("/Fields"))
+        return QUANTAPDF_OK;
+    QPDFObjectHandle fields = acroform.getKey("/Fields");
+    if (!fields.isArray())
+        return QUANTAPDF_ERROR_FORMAT;
+
+    std::vector<quantapdf_qpdf_audit_field_item> work;
+    std::set<QPDFObjGen> seen;
+    int const field_count = fields.getArrayNItems();
+    for (int index = 0; index < field_count; ++index) {
+        if (!budget->take())
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+        quantapdf_qpdf_audit_field_item item;
+        item.field = fields.getArrayItem(index);
+        work.push_back(std::move(item));
+    }
+
+    while (!work.empty()) {
+        quantapdf_qpdf_audit_field_item item = std::move(work.back());
+        work.pop_back();
+        QPDFObjectHandle field = item.field;
+        if (!field.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        if (field.isIndirect() && !seen.insert(field.getObjGen()).second)
+            return QUANTAPDF_ERROR_FORMAT;
+
+        QPDFObjectHandle actual_parent = field.getKey("/Parent");
+        if ((item.expected_parent.isNull() && !actual_parent.isNull()) ||
+            (!item.expected_parent.isNull() &&
+             !quantapdf_qpdf_same_object(
+                 item.expected_parent, actual_parent)))
+            return QUANTAPDF_ERROR_FORMAT;
+
+        std::string field_type = item.inherited_type;
+        QPDFObjectHandle type = field.getKey("/FT");
+        if (!type.isNull()) {
+            if (!type.isName())
+                return QUANTAPDF_ERROR_FORMAT;
+            field_type = type.getName();
+        }
+        QPDFObjectHandle value = field.getKey("/V");
+        if (value.isNull())
+            value = item.inherited_value;
+        if (field_type == "/Sig" && !value.isNull()) {
+            if (!value.isDictionary())
+                return QUANTAPDF_ERROR_FORMAT;
+            QPDFObjectHandle signature_type = value.getKey("/Type");
+            if (!signature_type.isNull() &&
+                (!signature_type.isName() ||
+                 signature_type.getName() != "/Sig"))
+                return QUANTAPDF_ERROR_FORMAT;
+            *findings |= QUANTAPDF_AUDIT_SIGNATURE;
+        }
+
+        QPDFObjectHandle kids = field.getKey("/Kids");
+        if (kids.isNull())
+            continue;
+        if (!kids.isArray())
+            return QUANTAPDF_ERROR_FORMAT;
+        int const kid_count = kids.getArrayNItems();
+        for (int index = 0; index < kid_count; ++index) {
+            if (!budget->take())
+                return QUANTAPDF_ERROR_UNSUPPORTED;
+            quantapdf_qpdf_audit_field_item child;
+            child.field = kids.getArrayItem(index);
+            child.expected_parent = field;
+            child.inherited_type = field_type;
+            child.inherited_value = value;
+            work.push_back(std::move(child));
+        }
+    }
+    return QUANTAPDF_OK;
+}
+
+static bool quantapdf_qpdf_audit_rich_media(std::string const& subtype)
+{
+    return subtype == "/RichMedia" || subtype == "/3D" ||
+        subtype == "/Movie" || subtype == "/Sound" ||
+        subtype == "/Screen";
+}
+
+static quantapdf_status quantapdf_qpdf_audit_graph(
+    QPDFObjectHandle root,
+    quantapdf_qpdf_audit_budget *budget,
+    uint32_t *findings)
+{
+    std::vector<QPDFObjectHandle> graph_work;
+    std::vector<QPDFObjectHandle> action_work;
+    std::set<QPDFObjGen> graph_seen;
+    std::set<QPDFObjGen> action_seen;
+    quantapdf_status status = quantapdf_qpdf_audit_push(
+        root, &graph_work, &graph_seen, budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+
+    if (root.hasKey("/OpenAction")) {
+        QPDFObjectHandle open_action = root.getKey("/OpenAction");
+        if (!open_action.isArray() && !open_action.isName() &&
+            !open_action.isString()) {
+            status = quantapdf_qpdf_audit_push_action(
+                open_action, &action_work, &action_seen, budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
+    }
+
+    while (!graph_work.empty()) {
+        QPDFObjectHandle object = graph_work.back();
+        graph_work.pop_back();
+        if (object.isStream()) {
+            QPDFObjectHandle dictionary = object.getDict();
+            QPDFObjectHandle type = dictionary.getKey("/Type");
+            if (type.isName() && type.getName() == "/EmbeddedFile")
+                *findings |= QUANTAPDF_AUDIT_EMBEDDED_FILE;
+            object = dictionary;
+        }
+        if (object.isArray()) {
+            int const count = object.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                status = quantapdf_qpdf_audit_push(
+                    object.getArrayItem(index), &graph_work,
+                    &graph_seen, budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+            continue;
+        }
+        if (!object.isDictionary())
+            continue;
+
+        if (object.hasKey("/AF") || object.hasKey("/EF"))
+            *findings |= QUANTAPDF_AUDIT_EMBEDDED_FILE;
+        if (object.hasKey("/A")) {
+            status = quantapdf_qpdf_audit_push_action(
+                object.getKey("/A"), &action_work, &action_seen, budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
+        if (object.hasKey("/AA")) {
+            QPDFObjectHandle additional = object.getKey("/AA");
+            if (!additional.isDictionary())
+                return QUANTAPDF_ERROR_FORMAT;
+            for (std::string const& key : additional.getKeys()) {
+                status = quantapdf_qpdf_audit_push_action(
+                    additional.getKey(key), &action_work,
+                    &action_seen, budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+        }
+        if (object.hasKey("/Annots")) {
+            QPDFObjectHandle annots = object.getKey("/Annots");
+            if (!annots.isArray())
+                return QUANTAPDF_ERROR_FORMAT;
+            int const count = annots.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                QPDFObjectHandle annotation = annots.getArrayItem(index);
+                if (!annotation.isDictionary())
+                    return QUANTAPDF_ERROR_FORMAT;
+                QPDFObjectHandle subtype = annotation.getKey("/Subtype");
+                if (!subtype.isName())
+                    continue;
+                std::string const name = subtype.getName();
+                if (name == "/FileAttachment")
+                    *findings |= QUANTAPDF_AUDIT_EMBEDDED_FILE;
+                if (quantapdf_qpdf_audit_rich_media(name))
+                    *findings |= QUANTAPDF_AUDIT_RICH_MEDIA;
+            }
+        }
+        for (std::string const& key : object.getKeys()) {
+            status = quantapdf_qpdf_audit_push(
+                object.getKey(key), &graph_work, &graph_seen, budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
+    }
+    return quantapdf_qpdf_audit_actions(
+        &action_work, &action_seen, budget, findings);
+}
+
+static quantapdf_status quantapdf_qpdf_audit_document(
+    QPDF& pdf,
+    size_t source_size,
+    uint32_t *findings)
+{
+    if (source_size > std::numeric_limits<size_t>::max() / 64u)
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    quantapdf_qpdf_audit_budget budget;
+    budget.limit = std::max<size_t>(4096u, source_size * 64u);
+
+    QPDFObjectHandle root = pdf.getRoot();
+    if (!root.isDictionary())
+        return QUANTAPDF_ERROR_FORMAT;
+    if (pdf.isEncrypted())
+        *findings |= QUANTAPDF_AUDIT_ENCRYPTION;
+
+    if (root.hasKey("/Names")) {
+        QPDFObjectHandle names = root.getKey("/Names");
+        if (!names.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        if (names.hasKey("/JavaScript"))
+            *findings |= QUANTAPDF_AUDIT_JAVASCRIPT_ACTION;
+        if (names.hasKey("/EmbeddedFiles"))
+            *findings |= QUANTAPDF_AUDIT_EMBEDDED_FILE;
+    }
+
+    if (root.hasKey("/AcroForm")) {
+        QPDFObjectHandle acroform = root.getKey("/AcroForm");
+        if (!acroform.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        if (acroform.hasKey("/XFA"))
+            *findings |= QUANTAPDF_AUDIT_XFA;
+        quantapdf_status const status =
+            quantapdf_qpdf_audit_signature_fields(
+                acroform, &budget, findings);
+        if (status != QUANTAPDF_OK)
+            return status;
+    }
+    return quantapdf_qpdf_audit_graph(root, &budget, findings);
+}
+
 static quantapdf_status quantapdf_qpdf_public_crop_to_pdf(
     quantapdf_qpdf_page_geometry const& geometry,
     quantapdf_rect const& requested,
@@ -2933,6 +3256,48 @@ extern "C" quantapdf_status quantapdf_qpdf_rewrite_lossless(
             *out_size = 0;
             return QUANTAPDF_ERROR_FORMAT;
         }
+        return QUANTAPDF_OK;
+    } catch (QPDFExc const& error) {
+        return quantapdf_status_from_qpdf(error);
+    } catch (std::bad_alloc const&) {
+        return QUANTAPDF_ERROR_NOMEM;
+    } catch (std::exception const&) {
+        return QUANTAPDF_ERROR_BACKEND;
+    } catch (...) {
+        return QUANTAPDF_ERROR_BACKEND;
+    }
+}
+
+extern "C" quantapdf_status quantapdf_qpdf_document_audit(
+    quantapdf_qpdf_document *document,
+    uint32_t *out_findings)
+{
+    if (out_findings == nullptr)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    *out_findings = 0;
+    if (document == nullptr || document->pdf == nullptr ||
+        document->source_data == nullptr || document->source_size == 0)
+        return QUANTAPDF_ERROR_ARGUMENT;
+
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->setAttemptRecovery(false);
+        pdf->processMemoryFile(
+            "quantapdf-document-audit",
+            reinterpret_cast<char const *>(document->source_data),
+            document->source_size,
+            document->password.c_str());
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+        uint32_t findings = 0;
+        quantapdf_status const status = quantapdf_qpdf_audit_document(
+            *pdf, document->source_size, &findings);
+        if (status != QUANTAPDF_OK)
+            return status;
+        if (pdf->anyWarnings())
+            return QUANTAPDF_ERROR_FORMAT;
+        *out_findings = findings;
         return QUANTAPDF_OK;
     } catch (QPDFExc const& error) {
         return quantapdf_status_from_qpdf(error);

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -792,10 +792,10 @@ static quantapdf_status quantapdf_qpdf_audit_push(
     std::set<QPDFObjGen> *seen,
     quantapdf_qpdf_audit_budget *budget)
 {
-    if (object.isIndirect() && !seen->insert(object.getObjGen()).second)
-        return QUANTAPDF_OK;
     if (!budget->take())
         return QUANTAPDF_ERROR_UNSUPPORTED;
+    if (object.isIndirect() && !seen->insert(object.getObjGen()).second)
+        return QUANTAPDF_OK;
     work->push_back(object);
     return QUANTAPDF_OK;
 }
@@ -942,6 +942,33 @@ static quantapdf_status quantapdf_qpdf_audit_signature_fields(
     return QUANTAPDF_OK;
 }
 
+static quantapdf_status quantapdf_qpdf_audit_catalog_signatures(
+    QPDFObjectHandle root,
+    quantapdf_qpdf_audit_budget *budget,
+    uint32_t *findings)
+{
+    if (!root.hasKey("/Perms"))
+        return QUANTAPDF_OK;
+    QPDFObjectHandle permissions = root.getKey("/Perms");
+    if (!permissions.isDictionary())
+        return QUANTAPDF_ERROR_FORMAT;
+    for (char const *key : {"/DocMDP", "/UR", "/UR3"}) {
+        if (!permissions.hasKey(key))
+            continue;
+        if (!budget->take())
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+        QPDFObjectHandle signature = permissions.getKey(key);
+        if (!signature.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+        QPDFObjectHandle type = signature.getKey("/Type");
+        if (!type.isNull() &&
+            (!type.isName() || type.getName() != "/Sig"))
+            return QUANTAPDF_ERROR_FORMAT;
+        *findings |= QUANTAPDF_AUDIT_SIGNATURE;
+    }
+    return QUANTAPDF_OK;
+}
+
 static bool quantapdf_qpdf_audit_rich_media(std::string const& subtype)
 {
     return subtype == "/RichMedia" || subtype == "/3D" ||
@@ -1024,6 +1051,8 @@ static quantapdf_status quantapdf_qpdf_audit_graph(
                 return QUANTAPDF_ERROR_FORMAT;
             int const count = annots.getArrayNItems();
             for (int index = 0; index < count; ++index) {
+                if (!budget->take())
+                    return QUANTAPDF_ERROR_UNSUPPORTED;
                 QPDFObjectHandle annotation = annots.getArrayItem(index);
                 if (!annotation.isDictionary())
                     return QUANTAPDF_ERROR_FORMAT;
@@ -1064,6 +1093,11 @@ static quantapdf_status quantapdf_qpdf_audit_document(
     if (pdf.isEncrypted())
         *findings |= QUANTAPDF_AUDIT_ENCRYPTION;
 
+    quantapdf_status status = quantapdf_qpdf_audit_catalog_signatures(
+        root, &budget, findings);
+    if (status != QUANTAPDF_OK)
+        return status;
+
     if (root.hasKey("/Names")) {
         QPDFObjectHandle names = root.getKey("/Names");
         if (!names.isDictionary())
@@ -1080,9 +1114,8 @@ static quantapdf_status quantapdf_qpdf_audit_document(
             return QUANTAPDF_ERROR_FORMAT;
         if (acroform.hasKey("/XFA"))
             *findings |= QUANTAPDF_AUDIT_XFA;
-        quantapdf_status const status =
-            quantapdf_qpdf_audit_signature_fields(
-                acroform, &budget, findings);
+        status = quantapdf_qpdf_audit_signature_fields(
+            acroform, &budget, findings);
         if (status != QUANTAPDF_OK)
             return status;
     }

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -1178,6 +1178,7 @@ static quantapdf_status quantapdf_qpdf_sanitize_actions(
     uint32_t flags,
     std::vector<QPDFObjectHandle> *work,
     std::set<QPDFObjGen> *seen,
+    std::set<QPDFObjGen> *emptied_by_selected_removal,
     quantapdf_qpdf_work_budget *budget)
 {
     while (!work->empty()) {
@@ -1219,7 +1220,15 @@ static quantapdf_status quantapdf_qpdf_sanitize_actions(
              index != selected_indices.rend(); ++index) {
             next.eraseItem(*index);
         }
-        if (!selected_indices.empty() && next.getArrayNItems() == 0)
+        bool const emptied =
+            !selected_indices.empty() && next.getArrayNItems() == 0;
+        if (emptied && next.isIndirect())
+            emptied_by_selected_removal->insert(next.getObjGen());
+        bool const shared_emptied =
+            next.isIndirect() && next.getArrayNItems() == 0 &&
+            emptied_by_selected_removal->find(next.getObjGen()) !=
+                emptied_by_selected_removal->end();
+        if (emptied || shared_emptied)
             action.removeKey("/Next");
     }
     return QUANTAPDF_OK;
@@ -1241,6 +1250,7 @@ static quantapdf_status quantapdf_qpdf_sanitize_graph(
     std::vector<QPDFObjectHandle> action_work;
     std::set<QPDFObjGen> graph_seen;
     std::set<QPDFObjGen> action_seen;
+    std::set<QPDFObjGen> emptied_by_selected_removal;
 
     if (root.hasKey("/Names")) {
         if (!budget.take())
@@ -1337,7 +1347,16 @@ static quantapdf_status quantapdf_qpdf_sanitize_graph(
             }
             for (std::string const& key : selected_keys)
                 additional.removeKey(key);
-            if (!selected_keys.empty() && additional.getKeys().empty())
+            bool const emptied =
+                !selected_keys.empty() && additional.getKeys().empty();
+            if (emptied && additional.isIndirect()) {
+                emptied_by_selected_removal.insert(additional.getObjGen());
+            }
+            bool const shared_emptied =
+                additional.isIndirect() && additional.getKeys().empty() &&
+                emptied_by_selected_removal.find(additional.getObjGen()) !=
+                    emptied_by_selected_removal.end();
+            if (emptied || shared_emptied)
                 object.removeKey("/AA");
         }
 
@@ -1376,7 +1395,8 @@ static quantapdf_status quantapdf_qpdf_sanitize_graph(
     }
 
     return quantapdf_qpdf_sanitize_actions(
-        flags, &action_work, &action_seen, &budget);
+        flags, &action_work, &action_seen,
+        &emptied_by_selected_removal, &budget);
 }
 
 static quantapdf_status quantapdf_qpdf_public_crop_to_pdf(

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -1219,7 +1219,7 @@ static quantapdf_status quantapdf_qpdf_sanitize_actions(
              index != selected_indices.rend(); ++index) {
             next.eraseItem(*index);
         }
-        if (next.getArrayNItems() == 0)
+        if (!selected_indices.empty() && next.getArrayNItems() == 0)
             action.removeKey("/Next");
     }
     return QUANTAPDF_OK;
@@ -1246,11 +1246,18 @@ static quantapdf_status quantapdf_qpdf_sanitize_graph(
         if (!budget.take())
             return QUANTAPDF_ERROR_UNSUPPORTED;
         QPDFObjectHandle names = root.getKey("/Names");
-        if ((flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) != 0)
+        bool selected_removed = false;
+        if ((flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) != 0 &&
+            names.hasKey("/JavaScript")) {
             names.removeKey("/JavaScript");
-        if ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0)
+            selected_removed = true;
+        }
+        if ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
+            names.hasKey("/EmbeddedFiles")) {
             names.removeKey("/EmbeddedFiles");
-        if (names.getKeys().empty())
+            selected_removed = true;
+        }
+        if (selected_removed && names.getKeys().empty())
             root.removeKey("/Names");
     }
 
@@ -1330,7 +1337,7 @@ static quantapdf_status quantapdf_qpdf_sanitize_graph(
             }
             for (std::string const& key : selected_keys)
                 additional.removeKey(key);
-            if (additional.getKeys().empty())
+            if (!selected_keys.empty() && additional.getKeys().empty())
                 object.removeKey("/AA");
         }
 

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -890,75 +890,144 @@ static quantapdf_status quantapdf_qpdf_audit_actions(
     return QUANTAPDF_OK;
 }
 
+static bool quantapdf_qpdf_name_key_less(
+    std::string const& left,
+    std::string const& right)
+{
+    return std::lexicographical_compare(
+        left.begin(), left.end(), right.begin(), right.end(),
+        [](char a, char b) {
+            return static_cast<unsigned char>(a) <
+                static_cast<unsigned char>(b);
+        });
+}
+
 static quantapdf_status quantapdf_qpdf_audit_javascript_name_tree(
     QPDFObjectHandle tree,
     std::vector<QPDFObjectHandle> *action_work,
     std::set<QPDFObjGen> *action_seen,
     quantapdf_qpdf_work_budget *budget)
 {
-    std::vector<QPDFObjectHandle> node_work;
+    struct frame {
+        QPDFObjectHandle node = QPDFObjectHandle::newNull();
+        bool initialized = false;
+        int next_child = 0;
+        int child_count = 0;
+        bool has_range = false;
+        std::string first;
+        std::string last;
+        bool has_limits = false;
+        std::string limit_first;
+        std::string limit_last;
+    };
+    std::vector<frame> node_work;
     std::set<QPDFObjGen> node_seen;
-    quantapdf_status status = quantapdf_qpdf_work_push(
-        tree, &node_work, &node_seen, budget);
-    if (status != QUANTAPDF_OK)
-        return status;
+    if (!budget->take())
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    if (tree.isIndirect())
+        node_seen.insert(tree.getObjGen());
+    node_work.push_back({tree});
 
     while (!node_work.empty()) {
-        QPDFObjectHandle node = node_work.back();
-        node_work.pop_back();
-        if (!node.isDictionary())
+        frame& current = node_work.back();
+        if (!current.initialized) {
+            QPDFObjectHandle node = current.node;
+            if (!node.isDictionary())
+                return QUANTAPDF_ERROR_FORMAT;
+            bool const has_kids = node.hasKey("/Kids");
+            bool const has_names = node.hasKey("/Names");
+            if (has_kids && has_names)
+                return QUANTAPDF_ERROR_FORMAT;
+            if (node.hasKey("/Limits")) {
+                QPDFObjectHandle limits = node.getKey("/Limits");
+                if (!limits.isArray() || limits.getArrayNItems() != 2)
+                    return QUANTAPDF_ERROR_FORMAT;
+                for (int index = 0; index < 2; ++index) {
+                    if (!budget->take())
+                        return QUANTAPDF_ERROR_UNSUPPORTED;
+                    if (!limits.getArrayItem(index).isString())
+                        return QUANTAPDF_ERROR_FORMAT;
+                }
+                current.has_limits = true;
+                current.limit_first =
+                    limits.getArrayItem(0).getStringValue();
+                current.limit_last =
+                    limits.getArrayItem(1).getStringValue();
+            }
+            if (has_kids) {
+                QPDFObjectHandle kids = node.getKey("/Kids");
+                if (!kids.isArray())
+                    return QUANTAPDF_ERROR_FORMAT;
+                current.child_count = kids.getArrayNItems();
+            } else if (has_names) {
+                QPDFObjectHandle names = node.getKey("/Names");
+                if (!names.isArray())
+                    return QUANTAPDF_ERROR_FORMAT;
+                int const count = names.getArrayNItems();
+                if ((count & 1) != 0)
+                    return QUANTAPDF_ERROR_FORMAT;
+                for (int index = 0; index < count; index += 2) {
+                    if (!budget->take())
+                        return QUANTAPDF_ERROR_UNSUPPORTED;
+                    QPDFObjectHandle key = names.getArrayItem(index);
+                    if (!key.isString())
+                        return QUANTAPDF_ERROR_FORMAT;
+                    std::string const value = key.getStringValue();
+                    if (current.has_range &&
+                        !quantapdf_qpdf_name_key_less(current.last, value))
+                        return QUANTAPDF_ERROR_FORMAT;
+                    if (!current.has_range) {
+                        current.first = value;
+                        current.has_range = true;
+                    }
+                    current.last = value;
+                    QPDFObjectHandle action = names.getArrayItem(index + 1);
+                    if (!action.isDictionary())
+                        return QUANTAPDF_ERROR_FORMAT;
+                    quantapdf_status const status =
+                        quantapdf_qpdf_audit_push_action(
+                            action, action_work, action_seen, budget);
+                    if (status != QUANTAPDF_OK)
+                        return status;
+                }
+            }
+            current.initialized = true;
+        }
+
+        if (current.next_child < current.child_count) {
+            QPDFObjectHandle kids = current.node.getKey("/Kids");
+            QPDFObjectHandle child =
+                kids.getArrayItem(current.next_child++);
+            if (!budget->take())
+                return QUANTAPDF_ERROR_UNSUPPORTED;
+            if (!child.isDictionary())
+                return QUANTAPDF_ERROR_FORMAT;
+            if (child.isIndirect() &&
+                !node_seen.insert(child.getObjGen()).second)
+                return QUANTAPDF_ERROR_FORMAT;
+            node_work.push_back({child});
+            continue;
+        }
+
+        if (current.has_limits &&
+            (!current.has_range || current.limit_first != current.first ||
+             current.limit_last != current.last))
             return QUANTAPDF_ERROR_FORMAT;
 
-        bool const has_kids = node.hasKey("/Kids");
-        bool const has_names = node.hasKey("/Names");
-        if (has_kids && has_names)
-            return QUANTAPDF_ERROR_FORMAT;
-        if (node.hasKey("/Limits")) {
-            QPDFObjectHandle limits = node.getKey("/Limits");
-            if (!limits.isArray() || limits.getArrayNItems() != 2)
+        bool const has_range = current.has_range;
+        std::string const first = current.first;
+        std::string const last = current.last;
+        node_work.pop_back();
+        if (!node_work.empty() && has_range) {
+            frame& parent = node_work.back();
+            if (parent.has_range &&
+                !quantapdf_qpdf_name_key_less(parent.last, first))
                 return QUANTAPDF_ERROR_FORMAT;
-            for (int index = 0; index < 2; ++index) {
-                if (!budget->take())
-                    return QUANTAPDF_ERROR_UNSUPPORTED;
-                if (!limits.getArrayItem(index).isString())
-                    return QUANTAPDF_ERROR_FORMAT;
+            if (!parent.has_range) {
+                parent.first = first;
+                parent.has_range = true;
             }
-        }
-        if (has_kids) {
-            QPDFObjectHandle kids = node.getKey("/Kids");
-            if (!kids.isArray())
-                return QUANTAPDF_ERROR_FORMAT;
-            int const count = kids.getArrayNItems();
-            for (int index = 0; index < count; ++index) {
-                QPDFObjectHandle child = kids.getArrayItem(index);
-                if (!child.isDictionary())
-                    return QUANTAPDF_ERROR_FORMAT;
-                status = quantapdf_qpdf_work_push(
-                    child, &node_work, &node_seen, budget);
-                if (status != QUANTAPDF_OK)
-                    return status;
-            }
-        }
-        if (has_names) {
-            QPDFObjectHandle names = node.getKey("/Names");
-            if (!names.isArray())
-                return QUANTAPDF_ERROR_FORMAT;
-            int const count = names.getArrayNItems();
-            if ((count & 1) != 0)
-                return QUANTAPDF_ERROR_FORMAT;
-            for (int index = 0; index < count; index += 2) {
-                if (!budget->take())
-                    return QUANTAPDF_ERROR_UNSUPPORTED;
-                if (!names.getArrayItem(index).isString())
-                    return QUANTAPDF_ERROR_FORMAT;
-                QPDFObjectHandle action = names.getArrayItem(index + 1);
-                if (!action.isDictionary())
-                    return QUANTAPDF_ERROR_FORMAT;
-                status = quantapdf_qpdf_audit_push_action(
-                    action, action_work, action_seen, budget);
-                if (status != QUANTAPDF_OK)
-                    return status;
-            }
+            parent.last = last;
         }
     }
     return QUANTAPDF_OK;
@@ -1326,50 +1395,116 @@ static quantapdf_status quantapdf_qpdf_sanitize_javascript_name_tree(
     std::set<QPDFObjGen> *action_seen,
     quantapdf_qpdf_work_budget *budget)
 {
-    std::vector<QPDFObjectHandle> node_work;
+    struct frame {
+        QPDFObjectHandle node = QPDFObjectHandle::newNull();
+        bool initialized = false;
+        int next_child = 0;
+        int child_count = 0;
+        bool has_range = false;
+        std::string first;
+        std::string last;
+        bool changed = false;
+    };
+    std::vector<frame> node_work;
     std::set<QPDFObjGen> node_seen;
-    quantapdf_status status = quantapdf_qpdf_work_push(
-        tree, &node_work, &node_seen, budget);
-    if (status != QUANTAPDF_OK)
-        return status;
+    if (!budget->take())
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    if (tree.isIndirect())
+        node_seen.insert(tree.getObjGen());
+    node_work.push_back({tree});
 
     while (!node_work.empty()) {
-        QPDFObjectHandle node = node_work.back();
-        node_work.pop_back();
-        if (node.hasKey("/Kids")) {
-            QPDFObjectHandle kids = node.getKey("/Kids");
-            int const count = kids.getArrayNItems();
-            for (int index = 0; index < count; ++index) {
-                status = quantapdf_qpdf_work_push(
-                    kids.getArrayItem(index), &node_work,
-                    &node_seen, budget);
-                if (status != QUANTAPDF_OK)
-                    return status;
+        frame& current = node_work.back();
+        if (!current.initialized) {
+            if (current.node.hasKey("/Limits")) {
+                for (int index = 0; index < 2; ++index) {
+                    if (!budget->take())
+                        return QUANTAPDF_ERROR_UNSUPPORTED;
+                }
             }
+            if (current.node.hasKey("/Kids")) {
+                current.child_count =
+                    current.node.getKey("/Kids").getArrayNItems();
+            } else if (current.node.hasKey("/Names")) {
+                QPDFObjectHandle names = current.node.getKey("/Names");
+                std::vector<int> selected_pairs;
+                int const count = names.getArrayNItems();
+                selected_pairs.reserve(static_cast<size_t>(count / 2));
+                for (int index = 0; index < count; index += 2) {
+                    if (!budget->take())
+                        return QUANTAPDF_ERROR_UNSUPPORTED;
+                    bool selected = false;
+                    quantapdf_status const status =
+                        quantapdf_qpdf_sanitize_queue_action(
+                            names.getArrayItem(index + 1), flags,
+                            action_work, action_seen, budget, &selected);
+                    if (status != QUANTAPDF_OK)
+                        return status;
+                    if (selected)
+                        selected_pairs.push_back(index);
+                }
+                for (auto index = selected_pairs.rbegin();
+                     index != selected_pairs.rend(); ++index) {
+                    names.eraseItem(*index + 1);
+                    names.eraseItem(*index);
+                }
+                current.changed = !selected_pairs.empty();
+                int const retained_count = names.getArrayNItems();
+                if (retained_count != 0) {
+                    current.has_range = true;
+                    current.first =
+                        names.getArrayItem(0).getStringValue();
+                    current.last = names.getArrayItem(
+                        retained_count - 2).getStringValue();
+                }
+            }
+            current.initialized = true;
         }
-        if (!node.hasKey("/Names"))
-            continue;
 
-        QPDFObjectHandle names = node.getKey("/Names");
-        std::vector<int> selected_pairs;
-        int const count = names.getArrayNItems();
-        selected_pairs.reserve(static_cast<size_t>(count / 2));
-        for (int index = 0; index < count; index += 2) {
+        if (current.next_child < current.child_count) {
+            QPDFObjectHandle child = current.node.getKey("/Kids").getArrayItem(
+                current.next_child++);
             if (!budget->take())
                 return QUANTAPDF_ERROR_UNSUPPORTED;
-            bool selected = false;
-            status = quantapdf_qpdf_sanitize_queue_action(
-                names.getArrayItem(index + 1), flags, action_work,
-                action_seen, budget, &selected);
-            if (status != QUANTAPDF_OK)
-                return status;
-            if (selected)
-                selected_pairs.push_back(index);
+            if (child.isIndirect() &&
+                !node_seen.insert(child.getObjGen()).second)
+                continue;
+            node_work.push_back({child});
+            continue;
         }
-        for (auto index = selected_pairs.rbegin();
-             index != selected_pairs.rend(); ++index) {
-            names.eraseItem(*index + 1);
-            names.eraseItem(*index);
+
+        if (current.changed && current.node.hasKey("/Limits")) {
+            if (!current.has_range) {
+                current.node.removeKey("/Limits");
+            } else {
+                QPDFObjectHandle limits = current.node.getKey("/Limits");
+                if (limits.getArrayItem(0).getStringValue() != current.first ||
+                    limits.getArrayItem(1).getStringValue() != current.last) {
+                    QPDFObjectHandle replacement = QPDFObjectHandle::newArray();
+                    replacement.appendItem(
+                        QPDFObjectHandle::newString(current.first));
+                    replacement.appendItem(
+                        QPDFObjectHandle::newString(current.last));
+                    current.node.replaceKey("/Limits", replacement);
+                }
+            }
+        }
+
+        bool const has_range = current.has_range;
+        std::string const first = current.first;
+        std::string const last = current.last;
+        bool const changed = current.changed;
+        node_work.pop_back();
+        if (!node_work.empty()) {
+            frame& parent = node_work.back();
+            parent.changed = parent.changed || changed;
+            if (has_range) {
+                if (!parent.has_range) {
+                    parent.first = first;
+                    parent.has_range = true;
+                }
+                parent.last = last;
+            }
         }
     }
     return QUANTAPDF_OK;
@@ -1391,17 +1526,22 @@ enum class quantapdf_qpdf_alias_role : unsigned {
     embedded_files,
     javascript_node,
     javascript_kids,
-    javascript_names
+    javascript_names,
+    page_tree,
+    page_kids,
+    page
 };
 
 struct quantapdf_qpdf_alias_item {
     QPDFObjectHandle object = QPDFObjectHandle::newNull();
     quantapdf_qpdf_alias_role role = quantapdf_qpdf_alias_role::custom;
+    QPDFObjectHandle anchor = QPDFObjectHandle::newNull();
 };
 
 static quantapdf_status quantapdf_qpdf_alias_push(
     QPDFObjectHandle object,
     quantapdf_qpdf_alias_role role,
+    QPDFObjectHandle anchor,
     std::vector<quantapdf_qpdf_alias_item> *work,
     std::set<std::pair<QPDFObjGen, unsigned>> *seen,
     std::map<QPDFObjGen, uint32_t> *roles,
@@ -1411,20 +1551,24 @@ static quantapdf_status quantapdf_qpdf_alias_push(
         return QUANTAPDF_ERROR_UNSUPPORTED;
     if (object.isIndirect()) {
         QPDFObjGen const id = object.getObjGen();
+        anchor = object;
         (*roles)[id] |= UINT32_C(1) << static_cast<unsigned>(role);
         if (!seen->insert({id, static_cast<unsigned>(role)}).second)
             return QUANTAPDF_OK;
     }
-    work->push_back({object, role});
+    work->push_back({object, role, anchor});
     return QUANTAPDF_OK;
 }
 
 static void quantapdf_qpdf_alias_mark_target(
     QPDFObjectHandle object,
+    QPDFObjectHandle anchor,
     std::set<QPDFObjGen> *targets)
 {
     if (object.isIndirect())
         targets->insert(object.getObjGen());
+    else if (anchor.isIndirect())
+        targets->insert(anchor.getObjGen());
 }
 
 static quantapdf_status quantapdf_qpdf_alias_action_selected(
@@ -1472,7 +1616,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
     std::set<QPDFObjGen> targets;
     QPDFObjectHandle root = pdf.getRoot();
     status = quantapdf_qpdf_alias_push(
-        root, quantapdf_qpdf_alias_role::root, &work, &seen,
+        root, quantapdf_qpdf_alias_role::root,
+        QPDFObjectHandle::newNull(), &work, &seen,
         &roles, &budget);
     if (status != QUANTAPDF_OK)
         return status;
@@ -1488,6 +1633,7 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
         if (object.isArray()) {
             int const count = object.getArrayNItems();
             for (int index = 0; index < count; ++index) {
+                QPDFObjectHandle child = object.getArrayItem(index);
                 quantapdf_qpdf_alias_role child_role =
                     quantapdf_qpdf_alias_role::custom;
                 switch (item.role) {
@@ -1508,11 +1654,18 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                         ? quantapdf_qpdf_alias_role::custom
                         : quantapdf_qpdf_alias_role::javascript_action;
                     break;
+                case quantapdf_qpdf_alias_role::page_kids: {
+                    QPDFObjectHandle type = child.getKey("/Type");
+                    child_role = type.isName() && type.getName() == "/Pages"
+                        ? quantapdf_qpdf_alias_role::page_tree
+                        : quantapdf_qpdf_alias_role::page;
+                    break;
+                }
                 default:
                     break;
                 }
                 status = quantapdf_qpdf_alias_push(
-                    object.getArrayItem(index), child_role, &work,
+                    child, child_role, item.anchor, &work,
                     &seen, &roles, &budget);
                 if (status != QUANTAPDF_OK)
                     return status;
@@ -1525,7 +1678,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                     if (status != QUANTAPDF_OK)
                         return status;
                     if (selected) {
-                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        quantapdf_qpdf_alias_mark_target(
+                            identity, item.anchor, &targets);
                         break;
                     }
                 }
@@ -1534,7 +1688,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                 for (int index = 0; index < count; ++index) {
                     if (quantapdf_qpdf_alias_rich_annotation_selected(
                             object.getArrayItem(index), flags)) {
-                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        quantapdf_qpdf_alias_mark_target(
+                            identity, item.anchor, &targets);
                         break;
                     }
                 }
@@ -1548,7 +1703,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                     if (status != QUANTAPDF_OK)
                         return status;
                     if (selected) {
-                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        quantapdf_qpdf_alias_mark_target(
+                            identity, item.anchor, &targets);
                         break;
                     }
                 }
@@ -1565,7 +1721,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
         if (!removed_javascript_subtree &&
             (flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
             (object.hasKey("/AF") || object.hasKey("/EF"))) {
-            quantapdf_qpdf_alias_mark_target(identity, &targets);
+            quantapdf_qpdf_alias_mark_target(
+                identity, item.anchor, &targets);
         }
 
         if (item.role == quantapdf_qpdf_alias_role::root) {
@@ -1575,14 +1732,16 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                      names.hasKey("/JavaScript")) ||
                     ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
                      names.hasKey("/EmbeddedFiles"))) {
-                    quantapdf_qpdf_alias_mark_target(names, &targets);
+                    quantapdf_qpdf_alias_mark_target(
+                        names, item.anchor, &targets);
                 }
             }
             if (object.hasKey("/AcroForm") &&
                 (flags & QUANTAPDF_SANITIZE_XFA) != 0) {
                 QPDFObjectHandle acroform = object.getKey("/AcroForm");
                 if (acroform.hasKey("/XFA"))
-                    quantapdf_qpdf_alias_mark_target(acroform, &targets);
+                    quantapdf_qpdf_alias_mark_target(
+                        acroform, item.anchor, &targets);
             }
             if (object.hasKey("/OpenAction")) {
                 QPDFObjectHandle action = object.getKey("/OpenAction");
@@ -1594,7 +1753,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                     if (status != QUANTAPDF_OK)
                         return status;
                     if (selected)
-                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        quantapdf_qpdf_alias_mark_target(
+                            identity, item.anchor, &targets);
                 }
             }
         }
@@ -1606,7 +1766,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
             if (status != QUANTAPDF_OK)
                 return status;
             if (selected)
-                quantapdf_qpdf_alias_mark_target(identity, &targets);
+                quantapdf_qpdf_alias_mark_target(
+                    identity, item.anchor, &targets);
         }
         if (!removed_javascript_subtree && object.hasKey("/AA")) {
             QPDFObjectHandle additional = object.getKey("/AA");
@@ -1622,9 +1783,11 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                     ++selected_count;
             }
             if (selected_count != 0)
-                quantapdf_qpdf_alias_mark_target(additional, &targets);
+                quantapdf_qpdf_alias_mark_target(
+                    additional, item.anchor, &targets);
             if (selected_count != 0 && selected_count == keys.size())
-                quantapdf_qpdf_alias_mark_target(identity, &targets);
+                quantapdf_qpdf_alias_mark_target(
+                    identity, item.anchor, &targets);
         }
 
         bool const action_context =
@@ -1640,7 +1803,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                 if (status != QUANTAPDF_OK)
                     return status;
                 if (selected)
-                    quantapdf_qpdf_alias_mark_target(identity, &targets);
+                    quantapdf_qpdf_alias_mark_target(
+                        identity, item.anchor, &targets);
             } else {
                 int const count = next.getArrayNItems();
                 int selected_count = 0;
@@ -1654,7 +1818,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                         ++selected_count;
                 }
                 if (selected_count == count && count != 0)
-                    quantapdf_qpdf_alias_mark_target(identity, &targets);
+                    quantapdf_qpdf_alias_mark_target(
+                        identity, item.anchor, &targets);
             }
         }
 
@@ -1665,6 +1830,9 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
             if (item.role == quantapdf_qpdf_alias_role::root &&
                 key == "/Names") {
                 child_role = quantapdf_qpdf_alias_role::catalog_names;
+            } else if (item.role == quantapdf_qpdf_alias_role::root &&
+                       key == "/Pages") {
+                child_role = quantapdf_qpdf_alias_role::page_tree;
             } else if (item.role == quantapdf_qpdf_alias_role::root &&
                        key == "/AcroForm") {
                 child_role = quantapdf_qpdf_alias_role::acroform;
@@ -1681,6 +1849,13 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
             } else if (item.role == quantapdf_qpdf_alias_role::javascript_node &&
                        key == "/Names") {
                 child_role = quantapdf_qpdf_alias_role::javascript_names;
+            } else if (item.role == quantapdf_qpdf_alias_role::page_tree &&
+                       key == "/Kids") {
+                child_role = quantapdf_qpdf_alias_role::page_kids;
+            } else if ((item.role == quantapdf_qpdf_alias_role::page ||
+                        item.role == quantapdf_qpdf_alias_role::page_tree) &&
+                       key == "/Parent") {
+                child_role = quantapdf_qpdf_alias_role::page_tree;
             } else if (item.role ==
                            quantapdf_qpdf_alias_role::additional_actions) {
                 child_role = quantapdf_qpdf_alias_role::action;
@@ -1705,7 +1880,8 @@ static quantapdf_status quantapdf_qpdf_preflight_aliases(
                 child_role = quantapdf_qpdf_alias_role::embedded_files;
             }
             status = quantapdf_qpdf_alias_push(
-                child, child_role, &work, &seen, &roles, &budget);
+                child, child_role, item.anchor, &work, &seen,
+                &roles, &budget);
             if (status != QUANTAPDF_OK)
                 return status;
         }

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -926,7 +926,8 @@ static quantapdf_status quantapdf_qpdf_audit_javascript_name_tree(
         return QUANTAPDF_ERROR_UNSUPPORTED;
     if (tree.isIndirect())
         node_seen.insert(tree.getObjGen());
-    node_work.push_back({tree});
+    node_work.emplace_back();
+    node_work.back().node = tree;
 
     while (!node_work.empty()) {
         frame& current = node_work.back();
@@ -1005,7 +1006,8 @@ static quantapdf_status quantapdf_qpdf_audit_javascript_name_tree(
             if (child.isIndirect() &&
                 !node_seen.insert(child.getObjGen()).second)
                 return QUANTAPDF_ERROR_FORMAT;
-            node_work.push_back({child});
+            node_work.emplace_back();
+            node_work.back().node = child;
             continue;
         }
 
@@ -1411,7 +1413,8 @@ static quantapdf_status quantapdf_qpdf_sanitize_javascript_name_tree(
         return QUANTAPDF_ERROR_UNSUPPORTED;
     if (tree.isIndirect())
         node_seen.insert(tree.getObjGen());
-    node_work.push_back({tree});
+    node_work.emplace_back();
+    node_work.back().node = tree;
 
     while (!node_work.empty()) {
         frame& current = node_work.back();
@@ -1469,7 +1472,8 @@ static quantapdf_status quantapdf_qpdf_sanitize_javascript_name_tree(
             if (child.isIndirect() &&
                 !node_seen.insert(child.getObjGen()).second)
                 continue;
-            node_work.push_back({child});
+            node_work.emplace_back();
+            node_work.back().node = child;
             continue;
         }
 

--- a/src/backend/qpdf_document.cpp
+++ b/src/backend/qpdf_document.cpp
@@ -890,6 +890,80 @@ static quantapdf_status quantapdf_qpdf_audit_actions(
     return QUANTAPDF_OK;
 }
 
+static quantapdf_status quantapdf_qpdf_audit_javascript_name_tree(
+    QPDFObjectHandle tree,
+    std::vector<QPDFObjectHandle> *action_work,
+    std::set<QPDFObjGen> *action_seen,
+    quantapdf_qpdf_work_budget *budget)
+{
+    std::vector<QPDFObjectHandle> node_work;
+    std::set<QPDFObjGen> node_seen;
+    quantapdf_status status = quantapdf_qpdf_work_push(
+        tree, &node_work, &node_seen, budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+
+    while (!node_work.empty()) {
+        QPDFObjectHandle node = node_work.back();
+        node_work.pop_back();
+        if (!node.isDictionary())
+            return QUANTAPDF_ERROR_FORMAT;
+
+        bool const has_kids = node.hasKey("/Kids");
+        bool const has_names = node.hasKey("/Names");
+        if (has_kids && has_names)
+            return QUANTAPDF_ERROR_FORMAT;
+        if (node.hasKey("/Limits")) {
+            QPDFObjectHandle limits = node.getKey("/Limits");
+            if (!limits.isArray() || limits.getArrayNItems() != 2)
+                return QUANTAPDF_ERROR_FORMAT;
+            for (int index = 0; index < 2; ++index) {
+                if (!budget->take())
+                    return QUANTAPDF_ERROR_UNSUPPORTED;
+                if (!limits.getArrayItem(index).isString())
+                    return QUANTAPDF_ERROR_FORMAT;
+            }
+        }
+        if (has_kids) {
+            QPDFObjectHandle kids = node.getKey("/Kids");
+            if (!kids.isArray())
+                return QUANTAPDF_ERROR_FORMAT;
+            int const count = kids.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                QPDFObjectHandle child = kids.getArrayItem(index);
+                if (!child.isDictionary())
+                    return QUANTAPDF_ERROR_FORMAT;
+                status = quantapdf_qpdf_work_push(
+                    child, &node_work, &node_seen, budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+        }
+        if (has_names) {
+            QPDFObjectHandle names = node.getKey("/Names");
+            if (!names.isArray())
+                return QUANTAPDF_ERROR_FORMAT;
+            int const count = names.getArrayNItems();
+            if ((count & 1) != 0)
+                return QUANTAPDF_ERROR_FORMAT;
+            for (int index = 0; index < count; index += 2) {
+                if (!budget->take())
+                    return QUANTAPDF_ERROR_UNSUPPORTED;
+                if (!names.getArrayItem(index).isString())
+                    return QUANTAPDF_ERROR_FORMAT;
+                QPDFObjectHandle action = names.getArrayItem(index + 1);
+                if (!action.isDictionary())
+                    return QUANTAPDF_ERROR_FORMAT;
+                status = quantapdf_qpdf_audit_push_action(
+                    action, action_work, action_seen, budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+        }
+    }
+    return QUANTAPDF_OK;
+}
+
 static quantapdf_status quantapdf_qpdf_audit_signature_fields(
     QPDFObjectHandle acroform,
     quantapdf_qpdf_work_budget *budget,
@@ -1023,6 +1097,17 @@ static quantapdf_status quantapdf_qpdf_audit_graph(
             !open_action.isString()) {
             status = quantapdf_qpdf_audit_push_action(
                 open_action, &action_work, &action_seen, budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
+    }
+
+    if (root.hasKey("/Names")) {
+        QPDFObjectHandle names = root.getKey("/Names");
+        if (names.hasKey("/JavaScript")) {
+            status = quantapdf_qpdf_audit_javascript_name_tree(
+                names.getKey("/JavaScript"), &action_work,
+                &action_seen, budget);
             if (status != QUANTAPDF_OK)
                 return status;
         }
@@ -1234,6 +1319,406 @@ static quantapdf_status quantapdf_qpdf_sanitize_actions(
     return QUANTAPDF_OK;
 }
 
+static quantapdf_status quantapdf_qpdf_sanitize_javascript_name_tree(
+    QPDFObjectHandle tree,
+    uint32_t flags,
+    std::vector<QPDFObjectHandle> *action_work,
+    std::set<QPDFObjGen> *action_seen,
+    quantapdf_qpdf_work_budget *budget)
+{
+    std::vector<QPDFObjectHandle> node_work;
+    std::set<QPDFObjGen> node_seen;
+    quantapdf_status status = quantapdf_qpdf_work_push(
+        tree, &node_work, &node_seen, budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+
+    while (!node_work.empty()) {
+        QPDFObjectHandle node = node_work.back();
+        node_work.pop_back();
+        if (node.hasKey("/Kids")) {
+            QPDFObjectHandle kids = node.getKey("/Kids");
+            int const count = kids.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                status = quantapdf_qpdf_work_push(
+                    kids.getArrayItem(index), &node_work,
+                    &node_seen, budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+        }
+        if (!node.hasKey("/Names"))
+            continue;
+
+        QPDFObjectHandle names = node.getKey("/Names");
+        std::vector<int> selected_pairs;
+        int const count = names.getArrayNItems();
+        selected_pairs.reserve(static_cast<size_t>(count / 2));
+        for (int index = 0; index < count; index += 2) {
+            if (!budget->take())
+                return QUANTAPDF_ERROR_UNSUPPORTED;
+            bool selected = false;
+            status = quantapdf_qpdf_sanitize_queue_action(
+                names.getArrayItem(index + 1), flags, action_work,
+                action_seen, budget, &selected);
+            if (status != QUANTAPDF_OK)
+                return status;
+            if (selected)
+                selected_pairs.push_back(index);
+        }
+        for (auto index = selected_pairs.rbegin();
+             index != selected_pairs.rend(); ++index) {
+            names.eraseItem(*index + 1);
+            names.eraseItem(*index);
+        }
+    }
+    return QUANTAPDF_OK;
+}
+
+enum class quantapdf_qpdf_alias_role : unsigned {
+    root,
+    custom,
+    catalog_names,
+    acroform,
+    additional_actions,
+    action,
+    javascript_action,
+    next_array,
+    annots_array,
+    annotation,
+    associated_files,
+    associated_file,
+    embedded_files,
+    javascript_node,
+    javascript_kids,
+    javascript_names
+};
+
+struct quantapdf_qpdf_alias_item {
+    QPDFObjectHandle object = QPDFObjectHandle::newNull();
+    quantapdf_qpdf_alias_role role = quantapdf_qpdf_alias_role::custom;
+};
+
+static quantapdf_status quantapdf_qpdf_alias_push(
+    QPDFObjectHandle object,
+    quantapdf_qpdf_alias_role role,
+    std::vector<quantapdf_qpdf_alias_item> *work,
+    std::set<std::pair<QPDFObjGen, unsigned>> *seen,
+    std::map<QPDFObjGen, uint32_t> *roles,
+    quantapdf_qpdf_work_budget *budget)
+{
+    if (!budget->take())
+        return QUANTAPDF_ERROR_UNSUPPORTED;
+    if (object.isIndirect()) {
+        QPDFObjGen const id = object.getObjGen();
+        (*roles)[id] |= UINT32_C(1) << static_cast<unsigned>(role);
+        if (!seen->insert({id, static_cast<unsigned>(role)}).second)
+            return QUANTAPDF_OK;
+    }
+    work->push_back({object, role});
+    return QUANTAPDF_OK;
+}
+
+static void quantapdf_qpdf_alias_mark_target(
+    QPDFObjectHandle object,
+    std::set<QPDFObjGen> *targets)
+{
+    if (object.isIndirect())
+        targets->insert(object.getObjGen());
+}
+
+static quantapdf_status quantapdf_qpdf_alias_action_selected(
+    QPDFObjectHandle action,
+    uint32_t flags,
+    bool *selected)
+{
+    uint32_t finding = 0;
+    quantapdf_status const status =
+        quantapdf_qpdf_classify_action(action, &finding);
+    if (status != QUANTAPDF_OK)
+        return status;
+    *selected = (finding & flags) != 0;
+    return QUANTAPDF_OK;
+}
+
+static bool quantapdf_qpdf_alias_rich_annotation_selected(
+    QPDFObjectHandle annotation,
+    uint32_t flags)
+{
+    QPDFObjectHandle subtype = annotation.getKey("/Subtype");
+    if (!subtype.isName())
+        return false;
+    std::string const name = subtype.getName();
+    return ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
+            name == "/FileAttachment") ||
+        ((flags & QUANTAPDF_SANITIZE_RICH_MEDIA) != 0 &&
+         quantapdf_qpdf_audit_rich_media(name));
+}
+
+static quantapdf_status quantapdf_qpdf_preflight_aliases(
+    QPDF& pdf,
+    size_t source_size,
+    uint32_t flags)
+{
+    quantapdf_qpdf_work_budget budget;
+    quantapdf_status status =
+        quantapdf_qpdf_init_work_budget(source_size, &budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+
+    std::vector<quantapdf_qpdf_alias_item> work;
+    std::set<std::pair<QPDFObjGen, unsigned>> seen;
+    std::map<QPDFObjGen, uint32_t> roles;
+    std::set<QPDFObjGen> targets;
+    QPDFObjectHandle root = pdf.getRoot();
+    status = quantapdf_qpdf_alias_push(
+        root, quantapdf_qpdf_alias_role::root, &work, &seen,
+        &roles, &budget);
+    if (status != QUANTAPDF_OK)
+        return status;
+
+    while (!work.empty()) {
+        quantapdf_qpdf_alias_item item = std::move(work.back());
+        work.pop_back();
+        QPDFObjectHandle identity = item.object;
+        QPDFObjectHandle object = item.object;
+        if (object.isStream())
+            object = object.getDict();
+
+        if (object.isArray()) {
+            int const count = object.getArrayNItems();
+            for (int index = 0; index < count; ++index) {
+                quantapdf_qpdf_alias_role child_role =
+                    quantapdf_qpdf_alias_role::custom;
+                switch (item.role) {
+                case quantapdf_qpdf_alias_role::next_array:
+                    child_role = quantapdf_qpdf_alias_role::action;
+                    break;
+                case quantapdf_qpdf_alias_role::annots_array:
+                    child_role = quantapdf_qpdf_alias_role::annotation;
+                    break;
+                case quantapdf_qpdf_alias_role::associated_files:
+                    child_role = quantapdf_qpdf_alias_role::associated_file;
+                    break;
+                case quantapdf_qpdf_alias_role::javascript_kids:
+                    child_role = quantapdf_qpdf_alias_role::javascript_node;
+                    break;
+                case quantapdf_qpdf_alias_role::javascript_names:
+                    child_role = (index & 1) == 0
+                        ? quantapdf_qpdf_alias_role::custom
+                        : quantapdf_qpdf_alias_role::javascript_action;
+                    break;
+                default:
+                    break;
+                }
+                status = quantapdf_qpdf_alias_push(
+                    object.getArrayItem(index), child_role, &work,
+                    &seen, &roles, &budget);
+                if (status != QUANTAPDF_OK)
+                    return status;
+            }
+            if (item.role == quantapdf_qpdf_alias_role::next_array) {
+                for (int index = 0; index < count; ++index) {
+                    bool selected = false;
+                    status = quantapdf_qpdf_alias_action_selected(
+                        object.getArrayItem(index), flags, &selected);
+                    if (status != QUANTAPDF_OK)
+                        return status;
+                    if (selected) {
+                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        break;
+                    }
+                }
+            } else if (item.role ==
+                       quantapdf_qpdf_alias_role::annots_array) {
+                for (int index = 0; index < count; ++index) {
+                    if (quantapdf_qpdf_alias_rich_annotation_selected(
+                            object.getArrayItem(index), flags)) {
+                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        break;
+                    }
+                }
+            } else if (item.role ==
+                           quantapdf_qpdf_alias_role::javascript_names &&
+                       (flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) == 0) {
+                for (int index = 1; index < count; index += 2) {
+                    bool selected = false;
+                    status = quantapdf_qpdf_alias_action_selected(
+                        object.getArrayItem(index), flags, &selected);
+                    if (status != QUANTAPDF_OK)
+                        return status;
+                    if (selected) {
+                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        if (!object.isDictionary())
+            continue;
+
+        bool const removed_javascript_subtree =
+            (flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) != 0 &&
+            (item.role == quantapdf_qpdf_alias_role::javascript_node ||
+             item.role == quantapdf_qpdf_alias_role::javascript_action);
+        if (!removed_javascript_subtree &&
+            (flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
+            (object.hasKey("/AF") || object.hasKey("/EF"))) {
+            quantapdf_qpdf_alias_mark_target(identity, &targets);
+        }
+
+        if (item.role == quantapdf_qpdf_alias_role::root) {
+            if (object.hasKey("/Names")) {
+                QPDFObjectHandle names = object.getKey("/Names");
+                if (((flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) != 0 &&
+                     names.hasKey("/JavaScript")) ||
+                    ((flags & QUANTAPDF_SANITIZE_EMBEDDED_FILES) != 0 &&
+                     names.hasKey("/EmbeddedFiles"))) {
+                    quantapdf_qpdf_alias_mark_target(names, &targets);
+                }
+            }
+            if (object.hasKey("/AcroForm") &&
+                (flags & QUANTAPDF_SANITIZE_XFA) != 0) {
+                QPDFObjectHandle acroform = object.getKey("/AcroForm");
+                if (acroform.hasKey("/XFA"))
+                    quantapdf_qpdf_alias_mark_target(acroform, &targets);
+            }
+            if (object.hasKey("/OpenAction")) {
+                QPDFObjectHandle action = object.getKey("/OpenAction");
+                if (!action.isArray() && !action.isName() &&
+                    !action.isString()) {
+                    bool selected = false;
+                    status = quantapdf_qpdf_alias_action_selected(
+                        action, flags, &selected);
+                    if (status != QUANTAPDF_OK)
+                        return status;
+                    if (selected)
+                        quantapdf_qpdf_alias_mark_target(identity, &targets);
+                }
+            }
+        }
+
+        if (!removed_javascript_subtree && object.hasKey("/A")) {
+            bool selected = false;
+            status = quantapdf_qpdf_alias_action_selected(
+                object.getKey("/A"), flags, &selected);
+            if (status != QUANTAPDF_OK)
+                return status;
+            if (selected)
+                quantapdf_qpdf_alias_mark_target(identity, &targets);
+        }
+        if (!removed_javascript_subtree && object.hasKey("/AA")) {
+            QPDFObjectHandle additional = object.getKey("/AA");
+            size_t selected_count = 0;
+            std::set<std::string> const keys = additional.getKeys();
+            for (std::string const& key : keys) {
+                bool selected = false;
+                status = quantapdf_qpdf_alias_action_selected(
+                    additional.getKey(key), flags, &selected);
+                if (status != QUANTAPDF_OK)
+                    return status;
+                if (selected)
+                    ++selected_count;
+            }
+            if (selected_count != 0)
+                quantapdf_qpdf_alias_mark_target(additional, &targets);
+            if (selected_count != 0 && selected_count == keys.size())
+                quantapdf_qpdf_alias_mark_target(identity, &targets);
+        }
+
+        bool const action_context =
+            item.role == quantapdf_qpdf_alias_role::action ||
+            item.role == quantapdf_qpdf_alias_role::javascript_action;
+        if (action_context && !removed_javascript_subtree &&
+            object.hasKey("/Next")) {
+            QPDFObjectHandle next = object.getKey("/Next");
+            if (next.isDictionary()) {
+                bool selected = false;
+                status = quantapdf_qpdf_alias_action_selected(
+                    next, flags, &selected);
+                if (status != QUANTAPDF_OK)
+                    return status;
+                if (selected)
+                    quantapdf_qpdf_alias_mark_target(identity, &targets);
+            } else {
+                int const count = next.getArrayNItems();
+                int selected_count = 0;
+                for (int index = 0; index < count; ++index) {
+                    bool selected = false;
+                    status = quantapdf_qpdf_alias_action_selected(
+                        next.getArrayItem(index), flags, &selected);
+                    if (status != QUANTAPDF_OK)
+                        return status;
+                    if (selected)
+                        ++selected_count;
+                }
+                if (selected_count == count && count != 0)
+                    quantapdf_qpdf_alias_mark_target(identity, &targets);
+            }
+        }
+
+        for (std::string const& key : object.getKeys()) {
+            QPDFObjectHandle child = object.getKey(key);
+            quantapdf_qpdf_alias_role child_role =
+                quantapdf_qpdf_alias_role::custom;
+            if (item.role == quantapdf_qpdf_alias_role::root &&
+                key == "/Names") {
+                child_role = quantapdf_qpdf_alias_role::catalog_names;
+            } else if (item.role == quantapdf_qpdf_alias_role::root &&
+                       key == "/AcroForm") {
+                child_role = quantapdf_qpdf_alias_role::acroform;
+            } else if (item.role == quantapdf_qpdf_alias_role::root &&
+                       key == "/OpenAction" && !child.isArray() &&
+                       !child.isName() && !child.isString()) {
+                child_role = quantapdf_qpdf_alias_role::action;
+            } else if (item.role == quantapdf_qpdf_alias_role::catalog_names &&
+                       key == "/JavaScript") {
+                child_role = quantapdf_qpdf_alias_role::javascript_node;
+            } else if (item.role == quantapdf_qpdf_alias_role::javascript_node &&
+                       key == "/Kids") {
+                child_role = quantapdf_qpdf_alias_role::javascript_kids;
+            } else if (item.role == quantapdf_qpdf_alias_role::javascript_node &&
+                       key == "/Names") {
+                child_role = quantapdf_qpdf_alias_role::javascript_names;
+            } else if (item.role ==
+                           quantapdf_qpdf_alias_role::additional_actions) {
+                child_role = quantapdf_qpdf_alias_role::action;
+            } else if (action_context && key == "/Next") {
+                if (child.isArray()) {
+                    child_role = quantapdf_qpdf_alias_role::next_array;
+                } else {
+                    child_role = item.role ==
+                            quantapdf_qpdf_alias_role::javascript_action
+                        ? quantapdf_qpdf_alias_role::javascript_action
+                        : quantapdf_qpdf_alias_role::action;
+                }
+            } else if (key == "/A") {
+                child_role = quantapdf_qpdf_alias_role::action;
+            } else if (key == "/AA") {
+                child_role = quantapdf_qpdf_alias_role::additional_actions;
+            } else if (key == "/Annots") {
+                child_role = quantapdf_qpdf_alias_role::annots_array;
+            } else if (key == "/AF") {
+                child_role = quantapdf_qpdf_alias_role::associated_files;
+            } else if (key == "/EF") {
+                child_role = quantapdf_qpdf_alias_role::embedded_files;
+            }
+            status = quantapdf_qpdf_alias_push(
+                child, child_role, &work, &seen, &roles, &budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
+    }
+
+    for (QPDFObjGen const& target : targets) {
+        uint32_t const role_mask = roles[target];
+        if ((role_mask & (role_mask - 1u)) != 0)
+            return QUANTAPDF_ERROR_UNSUPPORTED;
+    }
+    return QUANTAPDF_OK;
+}
+
 static quantapdf_status quantapdf_qpdf_sanitize_graph(
     QPDF& pdf,
     size_t source_size,
@@ -1269,6 +1754,14 @@ static quantapdf_status quantapdf_qpdf_sanitize_graph(
         }
         if (selected_removed && names.getKeys().empty())
             root.removeKey("/Names");
+        else if ((flags & QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS) == 0 &&
+                 names.hasKey("/JavaScript")) {
+            status = quantapdf_qpdf_sanitize_javascript_name_tree(
+                names.getKey("/JavaScript"), flags, &action_work,
+                &action_seen, &budget);
+            if (status != QUANTAPDF_OK)
+                return status;
+        }
     }
 
     if (root.hasKey("/AcroForm") &&
@@ -3657,6 +4150,11 @@ extern "C" quantapdf_status quantapdf_qpdf_sanitize(
         if ((findings & (QUANTAPDF_AUDIT_SIGNATURE |
                          QUANTAPDF_AUDIT_ENCRYPTION)) != 0)
             return QUANTAPDF_ERROR_UNSUPPORTED;
+
+        status = quantapdf_qpdf_preflight_aliases(
+            *pdf, document->source_size, flags);
+        if (status != QUANTAPDF_OK)
+            return status;
 
         status = quantapdf_qpdf_sanitize_graph(
             *pdf, document->source_size, flags);

--- a/src/backend/qpdf_document.h
+++ b/src/backend/qpdf_document.h
@@ -100,6 +100,10 @@ quantapdf_status quantapdf_qpdf_rewrite_lossless(
     unsigned char **out_data,
     size_t *out_size);
 
+quantapdf_status quantapdf_qpdf_document_audit(
+    quantapdf_qpdf_document *document,
+    uint32_t *out_findings);
+
 quantapdf_status quantapdf_qpdf_flatten_interactive(
     quantapdf_qpdf_document *document,
     uint32_t flags,

--- a/src/backend/qpdf_document.h
+++ b/src/backend/qpdf_document.h
@@ -104,6 +104,12 @@ quantapdf_status quantapdf_qpdf_document_audit(
     quantapdf_qpdf_document *document,
     uint32_t *out_findings);
 
+quantapdf_status quantapdf_qpdf_sanitize(
+    quantapdf_qpdf_document *document,
+    uint32_t flags,
+    unsigned char **out_data,
+    size_t *out_size);
+
 quantapdf_status quantapdf_qpdf_flatten_interactive(
     quantapdf_qpdf_document *document,
     uint32_t flags,

--- a/src/pdf_security.c
+++ b/src/pdf_security.c
@@ -1,0 +1,29 @@
+#include "internal.h"
+
+quantapdf_status quantapdf_document_audit(
+    quantapdf_document *document,
+    quantapdf_audit_result *out_result)
+{
+    if (out_result == NULL)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    if (out_result->struct_size >= QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE)
+        out_result->findings = 0;
+    if (document == NULL ||
+        out_result->struct_size < QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    return QUANTAPDF_ERROR_UNSUPPORTED;
+}
+
+quantapdf_status quantapdf_sanitize(
+    quantapdf_document *document,
+    uint32_t flags,
+    quantapdf_output **out_output)
+{
+    if (out_output == NULL)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    *out_output = NULL;
+    if (document == NULL || flags == 0 ||
+        (flags & ~QUANTAPDF_SANITIZE_ALL) != 0)
+        return QUANTAPDF_ERROR_ARGUMENT;
+    return QUANTAPDF_ERROR_UNSUPPORTED;
+}

--- a/src/pdf_security.c
+++ b/src/pdf_security.c
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "backend/qpdf_document.h"
 
 quantapdf_status quantapdf_document_audit(
     quantapdf_document *document,
@@ -11,7 +12,8 @@ quantapdf_status quantapdf_document_audit(
     if (document == NULL ||
         out_result->struct_size < QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE)
         return QUANTAPDF_ERROR_ARGUMENT;
-    return QUANTAPDF_ERROR_UNSUPPORTED;
+    return quantapdf_qpdf_document_audit(
+        document->qpdf_document, &out_result->findings);
 }
 
 quantapdf_status quantapdf_sanitize(

--- a/src/pdf_security.c
+++ b/src/pdf_security.c
@@ -1,6 +1,8 @@
 #include "internal.h"
 #include "backend/qpdf_document.h"
 
+#include <stdlib.h>
+
 quantapdf_status quantapdf_document_audit(
     quantapdf_document *document,
     quantapdf_audit_result *out_result)
@@ -21,11 +23,29 @@ quantapdf_status quantapdf_sanitize(
     uint32_t flags,
     quantapdf_output **out_output)
 {
+    quantapdf_output *output;
+    quantapdf_status status;
+
     if (out_output == NULL)
         return QUANTAPDF_ERROR_ARGUMENT;
     *out_output = NULL;
-    if (document == NULL || flags == 0 ||
+    if (document == NULL || document->qpdf_document == NULL || flags == 0 ||
         (flags & ~QUANTAPDF_SANITIZE_ALL) != 0)
         return QUANTAPDF_ERROR_ARGUMENT;
-    return QUANTAPDF_ERROR_UNSUPPORTED;
+
+    output = (quantapdf_output *)calloc(1, sizeof(*output));
+    if (output == NULL)
+        return QUANTAPDF_ERROR_NOMEM;
+    status = quantapdf_qpdf_sanitize(
+        document->qpdf_document,
+        flags,
+        &output->data,
+        &output->size);
+    if (status != QUANTAPDF_OK) {
+        free(output->data);
+        free(output);
+        return status;
+    }
+    *out_output = output;
+    return QUANTAPDF_OK;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,13 @@ add_executable(quantapdf_test_version test_version.c)
 target_link_libraries(quantapdf_test_version PRIVATE QuantaPDF::QuantaPDF)
 add_test(NAME quantapdf.version COMMAND quantapdf_test_version)
 
+add_executable(quantapdf_test_pdf_security test_pdf_security.c)
+target_link_libraries(quantapdf_test_pdf_security PRIVATE QuantaPDF::QuantaPDF)
+target_compile_definitions(quantapdf_test_pdf_security PRIVATE
+  SECURITY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf")
+add_test(NAME quantapdf.pdf_security COMMAND quantapdf_test_pdf_security)
+set_tests_properties(quantapdf.pdf_security PROPERTIES TIMEOUT 30)
+
 add_executable(quantapdf_test_pdf_rewrite_lossless
   test_pdf_rewrite_lossless.c
   rewrite_test_helpers.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,10 +20,18 @@ add_executable(quantapdf_test_version test_version.c)
 target_link_libraries(quantapdf_test_version PRIVATE QuantaPDF::QuantaPDF)
 add_test(NAME quantapdf.version COMMAND quantapdf_test_version)
 
-add_executable(quantapdf_test_pdf_security test_pdf_security.c)
-target_link_libraries(quantapdf_test_pdf_security PRIVATE QuantaPDF::QuantaPDF)
+add_executable(quantapdf_test_pdf_security
+  test_pdf_security.c
+  pdf_security_test_helpers.cpp)
+target_link_libraries(quantapdf_test_pdf_security PRIVATE
+  QuantaPDF::QuantaPDF
+  qpdf::libqpdf)
+target_compile_features(quantapdf_test_pdf_security PRIVATE cxx_std_20)
 target_compile_definitions(quantapdf_test_pdf_security PRIVATE
-  SECURITY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf")
+  SECURITY_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/one-page.pdf"
+  SECURITY_SIGNED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/annotation-mutation-signed.pdf"
+  SECURITY_ENCRYPTED_PDF="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/encrypted-one-page.pdf"
+  SECURITY_FIXTURE_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 add_test(NAME quantapdf.pdf_security COMMAND quantapdf_test_pdf_security)
 set_tests_properties(quantapdf.pdf_security PROPERTIES TIMEOUT 30)
 

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -2,8 +2,38 @@
 #include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFWriter.hh>
 
+#include <cstdint>
 #include <string>
 #include <vector>
+
+enum pdf_security_marker : uint32_t {
+    pdf_security_marker_javascript = UINT32_C(1) << 0,
+    pdf_security_marker_launch = UINT32_C(1) << 1,
+    pdf_security_marker_external = UINT32_C(1) << 2,
+    pdf_security_marker_other = UINT32_C(1) << 3,
+    pdf_security_marker_embedded = UINT32_C(1) << 4,
+    pdf_security_marker_xfa = UINT32_C(1) << 5,
+    pdf_security_marker_rich_media = UINT32_C(1) << 6,
+    pdf_security_marker_safe_goto = UINT32_C(1) << 7,
+};
+
+static QPDFObjectHandle pdf_security_marked_dictionary(
+    QPDF& pdf,
+    char const *marker)
+{
+    return pdf.makeIndirectObject(QPDFObjectHandle::newDictionary({
+        {"/QuantaPDFMarker", QPDFObjectHandle::newString(marker)}}));
+}
+
+static QPDFObjectHandle pdf_security_marked_action(
+    QPDF& pdf,
+    char const *name,
+    char const *marker)
+{
+    QPDFObjectHandle action = pdf_security_marked_dictionary(pdf, marker);
+    action.replaceKey("/S", QPDFObjectHandle::newName(name));
+    return action;
+}
 
 static QPDFObjectHandle pdf_security_action(QPDF& pdf, const char *name)
 {
@@ -16,6 +46,114 @@ static QPDFObjectHandle pdf_security_signature(QPDF& pdf)
     return pdf.makeIndirectObject(QPDFObjectHandle::newDictionary({
         {"/Type", QPDFObjectHandle::newName("/Sig")},
         {"/Contents", QPDFObjectHandle::newString("signed")}}));
+}
+
+static void pdf_security_make_combined_fixture(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    QPDFObjectHandle page)
+{
+    QPDFObjectHandle javascript = pdf_security_marked_action(
+        pdf, "/JavaScript", "javascript-action");
+    QPDFObjectHandle launch = pdf_security_marked_action(
+        pdf, "/Launch", "launch-action");
+    QPDFObjectHandle external = pdf_security_marked_action(
+        pdf, "/URI", "external-action");
+    QPDFObjectHandle other = pdf_security_marked_action(
+        pdf, "/Named", "other-action");
+    QPDFObjectHandle safe = pdf_security_marked_action(
+        pdf, "/GoTo", "safe-goto");
+    QPDFObjectHandle nested = QPDFObjectHandle::newArray();
+    nested.appendItem(pdf_security_marked_action(
+        pdf, "/JavaScript", "javascript-next"));
+    nested.appendItem(pdf_security_marked_action(
+        pdf, "/Launch", "launch-next"));
+    nested.appendItem(pdf_security_marked_action(
+        pdf, "/GoTo", "safe-goto-next"));
+    safe.replaceKey("/D", QPDFObjectHandle::newName("/SafeDestination"));
+    safe.replaceKey("/Next", nested);
+
+    root.replaceKey("/OpenAction", javascript);
+    root.replaceKey(
+        "/QuantaPDFLaunchOwner",
+        QPDFObjectHandle::newDictionary({{"/A", launch}}));
+    root.replaceKey(
+        "/QuantaPDFExternalOwner",
+        QPDFObjectHandle::newDictionary({
+            {"/AA", QPDFObjectHandle::newDictionary({{"/E", external}})}}));
+    root.replaceKey(
+        "/QuantaPDFOtherOwner",
+        QPDFObjectHandle::newDictionary({{"/A", other}}));
+    root.replaceKey(
+        "/QuantaPDFSafeOwner",
+        QPDFObjectHandle::newDictionary({{"/A", safe}}));
+
+    QPDFObjectHandle javascript_names = pdf_security_marked_dictionary(
+        pdf, "javascript-names");
+    QPDFObjectHandle embedded_stream = pdf.newStream("embedded-name-payload");
+    embedded_stream.getDict().replaceKey(
+        "/Type", QPDFObjectHandle::newName("/EmbeddedFile"));
+    embedded_stream.getDict().replaceKey(
+        "/QuantaPDFMarker",
+        QPDFObjectHandle::newString("embedded-name-stream"));
+    QPDFObjectHandle file_spec = pdf_security_marked_dictionary(
+        pdf, "embedded-file-spec");
+    file_spec.replaceKey("/Type", QPDFObjectHandle::newName("/Filespec"));
+    file_spec.replaceKey(
+        "/EF", QPDFObjectHandle::newDictionary({{"/F", embedded_stream}}));
+    QPDFObjectHandle embedded_names = pdf_security_marked_dictionary(
+        pdf, "embedded-names");
+    QPDFObjectHandle name_pairs = QPDFObjectHandle::newArray();
+    name_pairs.appendItem(QPDFObjectHandle::newString("payload.bin"));
+    name_pairs.appendItem(file_spec);
+    embedded_names.replaceKey("/Names", name_pairs);
+    root.replaceKey(
+        "/Names", QPDFObjectHandle::newDictionary({
+            {"/JavaScript", javascript_names},
+            {"/EmbeddedFiles", embedded_names},
+            {"/Dests", QPDFObjectHandle::newDictionary()}}));
+
+    QPDFObjectHandle af_spec = pdf_security_marked_dictionary(
+        pdf, "embedded-af-file-spec");
+    af_spec.replaceKey("/Type", QPDFObjectHandle::newName("/Filespec"));
+    QPDFObjectHandle associated_files = QPDFObjectHandle::newArray();
+    associated_files.appendItem(af_spec);
+    root.replaceKey("/AF", associated_files);
+
+    QPDFObjectHandle ef_stream = pdf.newStream("embedded-ef-payload");
+    ef_stream.getDict().replaceKey(
+        "/Type", QPDFObjectHandle::newName("/EmbeddedFile"));
+    ef_stream.getDict().replaceKey(
+        "/QuantaPDFMarker", QPDFObjectHandle::newString("embedded-ef-stream"));
+    root.replaceKey(
+        "/QuantaPDFEFOwner",
+        QPDFObjectHandle::newDictionary({
+            {"/EF", QPDFObjectHandle::newDictionary({{"/F", ef_stream}})}}));
+
+    QPDFObjectHandle xfa = pdf.newStream("xfa-payload");
+    xfa.getDict().replaceKey(
+        "/QuantaPDFMarker", QPDFObjectHandle::newString("xfa"));
+    root.replaceKey(
+        "/AcroForm", QPDFObjectHandle::newDictionary({
+            {"/Fields", QPDFObjectHandle::newArray()}, {"/XFA", xfa}}));
+
+    QPDFObjectHandle file_attachment = pdf_security_marked_dictionary(
+        pdf, "embedded-file-attachment");
+    file_attachment.replaceKey(
+        "/Subtype", QPDFObjectHandle::newName("/FileAttachment"));
+    QPDFObjectHandle rich_media = pdf_security_marked_dictionary(
+        pdf, "rich-media");
+    rich_media.replaceKey(
+        "/Subtype", QPDFObjectHandle::newName("/RichMedia"));
+    QPDFObjectHandle harmless = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({
+            {"/Subtype", QPDFObjectHandle::newName("/Text")},
+            {"/Type", QPDFObjectHandle::newName("/Filespec")}}));
+    QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+    annots.appendItem(file_attachment);
+    annots.appendItem(harmless);
+    annots.appendItem(rich_media);
+    page.replaceKey("/Annots", annots);
 }
 
 static void pdf_security_write(
@@ -170,7 +308,9 @@ extern "C" int pdf_security_create_fixture(
         if (pages.empty())
             return 0;
 
-        if (scenario == "internal_goto") {
+        if (scenario == "sanitize_combined") {
+            pdf_security_make_combined_fixture(*pdf, root, pages[0]);
+        } else if (scenario == "internal_goto") {
             pdf_security_set_open_action(*pdf, root, "/GoTo");
         } else if (scenario == "open_destination_array") {
             root.replaceKey("/OpenAction", QPDFObjectHandle::newArray());
@@ -375,6 +515,64 @@ extern "C" int pdf_security_create_fixture(
 
         pdf_security_write(
             *pdf, output_path, preserve_unreferenced, compressed_objects);
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}
+
+extern "C" int pdf_security_inspect_output(
+    unsigned char const *data,
+    size_t size,
+    uint32_t *out_markers,
+    int *out_has_object_stream)
+{
+    if (data == nullptr || size == 0 || out_markers == nullptr ||
+        out_has_object_stream == nullptr)
+        return 0;
+    *out_markers = 0;
+    *out_has_object_stream = 0;
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->setAttemptRecovery(false);
+        pdf->processMemoryFile(
+            "pdf-security-sanitize-output",
+            reinterpret_cast<char const *>(data),
+            size);
+        for (QPDFObjectHandle object : pdf->getAllObjects()) {
+            QPDFObjectHandle dictionary = object.isStream()
+                ? object.getDict()
+                : object;
+            if (!dictionary.isDictionary())
+                continue;
+            QPDFObjectHandle type = dictionary.getKey("/Type");
+            if (type.isName() && type.getName() == "/ObjStm")
+                *out_has_object_stream = 1;
+            QPDFObjectHandle marker = dictionary.getKey("/QuantaPDFMarker");
+            if (!marker.isString())
+                continue;
+            std::string const value = marker.getUTF8Value();
+            if (value.rfind("javascript-", 0) == 0) {
+                *out_markers |= pdf_security_marker_javascript;
+            } else if (value.rfind("launch-", 0) == 0) {
+                *out_markers |= pdf_security_marker_launch;
+            } else if (value == "external-action") {
+                *out_markers |= pdf_security_marker_external;
+            } else if (value == "other-action") {
+                *out_markers |= pdf_security_marker_other;
+            } else if (value.rfind("embedded-", 0) == 0) {
+                *out_markers |= pdf_security_marker_embedded;
+            } else if (value == "xfa") {
+                *out_markers |= pdf_security_marker_xfa;
+            } else if (value == "rich-media") {
+                *out_markers |= pdf_security_marker_rich_media;
+            } else if (value.rfind("safe-goto", 0) == 0) {
+                *out_markers |= pdf_security_marker_safe_goto;
+            }
+        }
+        if (pdf->anyWarnings())
+            return 0;
         return 1;
     } catch (...) {
         return 0;

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -3,6 +3,7 @@
 #include <qpdf/QPDFWriter.hh>
 
 #include <cstdint>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -292,6 +293,47 @@ static void pdf_security_stress_shared_annots(
         "/QuantaPDFStressOwners", pdf.makeIndirectObject(owners));
 }
 
+static void pdf_security_empty_container_fixture(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    bool selected_children)
+{
+    QPDFObjectHandle names = QPDFObjectHandle::newDictionary();
+    QPDFObjectHandle additional = QPDFObjectHandle::newDictionary();
+    QPDFObjectHandle safe = pdf_security_action(pdf, "/GoTo");
+    QPDFObjectHandle next = QPDFObjectHandle::newArray();
+    if (selected_children) {
+        names.replaceKey(
+            "/JavaScript", pdf.makeIndirectObject(
+                QPDFObjectHandle::newDictionary()));
+        additional.replaceKey(
+            "/E", pdf_security_action(pdf, "/JavaScript"));
+        next.appendItem(pdf_security_action(pdf, "/JavaScript"));
+    }
+    safe.replaceKey("/Next", next);
+    root.replaceKey("/Names", names);
+    root.replaceKey(
+        "/QuantaPDFEmptyAAOwner",
+        QPDFObjectHandle::newDictionary({{"/AA", additional}}));
+    root.replaceKey(
+        "/QuantaPDFEmptyNextOwner",
+        QPDFObjectHandle::newDictionary({{"/A", safe}}));
+}
+
+static void pdf_security_budget_tuner(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    int count)
+{
+    QPDFObjectHandle shared = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary());
+    QPDFObjectHandle references = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index)
+        references.appendItem(shared);
+    root.replaceKey(
+        "/QuantaPDFBudgetTuner", pdf.makeIndirectObject(references));
+}
+
 extern "C" int pdf_security_create_fixture(
     const char *source_path,
     const char *output_path,
@@ -310,6 +352,10 @@ extern "C" int pdf_security_create_fixture(
 
         if (scenario == "sanitize_combined") {
             pdf_security_make_combined_fixture(*pdf, root, pages[0]);
+        } else if (scenario == "sanitize_empty_unselected") {
+            pdf_security_empty_container_fixture(*pdf, root, false);
+        } else if (scenario == "sanitize_selected_to_empty") {
+            pdf_security_empty_container_fixture(*pdf, root, true);
         } else if (scenario == "internal_goto") {
             pdf_security_set_open_action(*pdf, root, "/GoTo");
         } else if (scenario == "open_destination_array") {
@@ -509,15 +555,71 @@ extern "C" int pdf_security_create_fixture(
         } else if (scenario == "budget_shared_annots") {
             pdf_security_stress_shared_annots(*pdf, root, 2048);
             compressed_objects = true;
+        } else if (scenario == "mutation_budget_shared_next") {
+            pdf_security_stress_shared_next(*pdf, root, 590);
+            pdf_security_budget_tuner(*pdf, root, 212);
+            root.replaceKey("/Names", QPDFObjectHandle::newDictionary());
+            root.replaceKey("/AcroForm", QPDFObjectHandle::newDictionary());
+            compressed_objects = true;
         } else {
             return 0;
         }
 
         pdf_security_write(
             *pdf, output_path, preserve_unreferenced, compressed_objects);
+        if (scenario == "mutation_budget_shared_next") {
+            std::ifstream written(
+                output_path, std::ios::binary | std::ios::ate);
+            std::streamoff const written_size = written.tellg();
+            written.close();
+            constexpr std::streamoff target_size = 5498;
+            if (written_size < 0 || written_size > target_size)
+                return 0;
+            std::ofstream padding(
+                output_path, std::ios::binary | std::ios::app);
+            padding << std::string(
+                static_cast<size_t>(target_size - written_size), ' ');
+            if (!padding)
+                return 0;
+        }
         return 1;
     } catch (...) {
         return 0;
+    }
+}
+
+extern "C" int pdf_security_inspect_empty_containers(
+    unsigned char const *data,
+    size_t size)
+{
+    if (data == nullptr || size == 0)
+        return -1;
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->setAttemptRecovery(false);
+        pdf->processMemoryFile(
+            "pdf-security-empty-container-output",
+            reinterpret_cast<char const *>(data),
+            size);
+        QPDFObjectHandle root = pdf->getRoot();
+        int mask = 0;
+        QPDFObjectHandle names = root.getKey("/Names");
+        if (names.isDictionary() && names.getKeys().empty())
+            mask |= 1;
+        QPDFObjectHandle aa_owner = root.getKey("/QuantaPDFEmptyAAOwner");
+        QPDFObjectHandle additional = aa_owner.getKey("/AA");
+        if (additional.isDictionary() && additional.getKeys().empty())
+            mask |= 2;
+        QPDFObjectHandle next_owner =
+            root.getKey("/QuantaPDFEmptyNextOwner");
+        QPDFObjectHandle action = next_owner.getKey("/A");
+        QPDFObjectHandle next = action.getKey("/Next");
+        if (next.isArray() && next.getArrayNItems() == 0)
+            mask |= 4;
+        return pdf->anyWarnings() ? -1 : mask;
+    } catch (...) {
+        return -1;
     }
 }
 

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -352,6 +352,76 @@ static void pdf_security_shared_selected_next_fixture(
     root.replaceKey("/QuantaPDFSharedNextOwners", owners);
 }
 
+static void pdf_security_javascript_name_tree_fixture(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    char const *head_name,
+    char const *next_name)
+{
+    QPDFObjectHandle head = pdf_security_marked_action(
+        pdf, head_name, head_name == std::string("/GoTo") ?
+            "safe-goto-name-tree" : "launch-name-tree");
+    if (next_name != nullptr) {
+        char const *marker = "other-action";
+        if (std::string(next_name) == "/JavaScript")
+            marker = "javascript-name-tree-next";
+        else if (std::string(next_name) == "/Launch")
+            marker = "launch-name-tree-next";
+        else if (std::string(next_name) == "/URI")
+            marker = "external-action";
+        QPDFObjectHandle continuation =
+            pdf_security_marked_action(pdf, next_name, marker);
+        if (std::string(next_name) == "/JavaScript") {
+            continuation.replaceKey(
+                "/Next", pdf_security_marked_action(
+                    pdf, "/Launch", "launch-name-tree-after-javascript"));
+        }
+        head.replaceKey("/Next", continuation);
+    }
+    QPDFObjectHandle names = QPDFObjectHandle::newArray();
+    names.appendItem(QPDFObjectHandle::newString("entry"));
+    names.appendItem(head);
+    QPDFObjectHandle leaf = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({{"/Names", names}}));
+    QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+    kids.appendItem(leaf);
+    QPDFObjectHandle tree = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({{"/Kids", kids}}));
+    root.replaceKey(
+        "/Names", QPDFObjectHandle::newDictionary({
+            {"/JavaScript", tree}}));
+}
+
+static void pdf_security_javascript_name_tree_budget(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    int count)
+{
+    QPDFObjectHandle leaf = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary());
+    QPDFObjectHandle shared_kids = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index)
+        shared_kids.appendItem(leaf);
+    shared_kids = pdf.makeIndirectObject(shared_kids);
+    QPDFObjectHandle root_kids = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index) {
+        root_kids.appendItem(pdf.makeIndirectObject(
+            QPDFObjectHandle::newDictionary({{"/Kids", shared_kids}})));
+    }
+    QPDFObjectHandle tree = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({{"/Kids", root_kids}}));
+    root.replaceKey(
+        "/Names", QPDFObjectHandle::newDictionary({
+            {"/JavaScript", tree}}));
+}
+
+static void pdf_security_set_custom_alias(
+    QPDFObjectHandle root,
+    QPDFObjectHandle object)
+{
+    root.replaceKey("/QuantaPDFAlias", object);
+}
+
 static void pdf_security_budget_tuner(
     QPDF& pdf,
     QPDFObjectHandle root,
@@ -392,6 +462,24 @@ extern "C" int pdf_security_create_fixture(
             pdf_security_shared_selected_aa_fixture(*pdf, root);
         } else if (scenario == "sanitize_shared_selected_next") {
             pdf_security_shared_selected_next_fixture(*pdf, root);
+        } else if (scenario == "name_tree_safe") {
+            pdf_security_javascript_name_tree_fixture(
+                *pdf, root, "/GoTo", nullptr);
+        } else if (scenario == "name_tree_head_launch") {
+            pdf_security_javascript_name_tree_fixture(
+                *pdf, root, "/Launch", nullptr);
+        } else if (scenario == "name_tree_next_javascript") {
+            pdf_security_javascript_name_tree_fixture(
+                *pdf, root, "/GoTo", "/JavaScript");
+        } else if (scenario == "name_tree_next_launch") {
+            pdf_security_javascript_name_tree_fixture(
+                *pdf, root, "/GoTo", "/Launch");
+        } else if (scenario == "name_tree_next_external") {
+            pdf_security_javascript_name_tree_fixture(
+                *pdf, root, "/GoTo", "/URI");
+        } else if (scenario == "name_tree_next_other") {
+            pdf_security_javascript_name_tree_fixture(
+                *pdf, root, "/GoTo", "/Named");
         } else if (scenario == "internal_goto") {
             pdf_security_set_open_action(*pdf, root, "/GoTo");
         } else if (scenario == "open_destination_array") {
@@ -532,6 +620,80 @@ extern "C" int pdf_security_create_fixture(
             root.replaceKey("/OpenAction", action);
         } else if (scenario == "malformed_names") {
             root.replaceKey("/Names", QPDFObjectHandle::newName("/Bad"));
+        } else if (scenario == "malformed_js_tree_node") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newName("/Bad")}}));
+        } else if (scenario == "malformed_js_tree_kids") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Kids", QPDFObjectHandle::newName("/Bad")}})}}));
+        } else if (scenario == "malformed_js_tree_kid") {
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(QPDFObjectHandle::newName("/Bad"));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Kids", kids}})}}));
+        } else if (scenario == "malformed_js_tree_names") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Names", QPDFObjectHandle::newName("/Bad")}})}}));
+        } else if (scenario == "malformed_js_tree_odd_names") {
+            QPDFObjectHandle names = QPDFObjectHandle::newArray();
+            names.appendItem(QPDFObjectHandle::newString("key"));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Names", names}})}}));
+        } else if (scenario == "malformed_js_tree_key") {
+            QPDFObjectHandle names = QPDFObjectHandle::newArray();
+            names.appendItem(QPDFObjectHandle::newName("/Bad"));
+            names.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Names", names}})}}));
+        } else if (scenario == "malformed_js_tree_value") {
+            QPDFObjectHandle names = QPDFObjectHandle::newArray();
+            names.appendItem(QPDFObjectHandle::newString("key"));
+            names.appendItem(QPDFObjectHandle::newName("/Bad"));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Names", names}})}}));
+        } else if (scenario == "malformed_js_tree_action") {
+            QPDFObjectHandle names = QPDFObjectHandle::newArray();
+            names.appendItem(QPDFObjectHandle::newString("key"));
+            names.appendItem(QPDFObjectHandle::newDictionary());
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Names", names}})}}));
+        } else if (scenario == "malformed_js_tree_both") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Kids", QPDFObjectHandle::newArray()},
+                        {"/Names", QPDFObjectHandle::newArray()}})}}));
+        } else if (scenario == "malformed_js_tree_limits") {
+            QPDFObjectHandle limits = QPDFObjectHandle::newArray();
+            limits.appendItem(QPDFObjectHandle::newString("only-one"));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Limits", limits}})}}));
+        } else if (scenario == "name_tree_cycle") {
+            QPDFObjectHandle tree = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary());
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(tree);
+            tree.replaceKey("/Kids", kids);
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
         } else if (scenario == "malformed_annots") {
             pages[0].replaceKey(
                 "/Annots", QPDFObjectHandle::newName("/Bad"));
@@ -591,6 +753,92 @@ extern "C" int pdf_security_create_fixture(
         } else if (scenario == "budget_shared_annots") {
             pdf_security_stress_shared_annots(*pdf, root, 2048);
             compressed_objects = true;
+        } else if (scenario == "budget_js_name_tree") {
+            pdf_security_javascript_name_tree_budget(*pdf, root, 1024);
+            compressed_objects = true;
+        } else if (scenario == "alias_annots_next") {
+            QPDFObjectHandle item = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/S", QPDFObjectHandle::newName("/Launch")},
+                    {"/Subtype", QPDFObjectHandle::newName("/RichMedia")}}));
+            QPDFObjectHandle shared = QPDFObjectHandle::newArray();
+            shared.appendItem(item);
+            shared = pdf->makeIndirectObject(shared);
+            pages[0].replaceKey("/Annots", shared);
+            QPDFObjectHandle safe = pdf_security_action(*pdf, "/GoTo");
+            safe.replaceKey("/Next", shared);
+            root.replaceKey(
+                "/QuantaPDFActionOwner",
+                QPDFObjectHandle::newDictionary({{"/A", safe}}));
+        } else if (scenario == "alias_names_custom") {
+            QPDFObjectHandle names = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary()}}));
+            root.replaceKey("/Names", names);
+            pdf_security_set_custom_alias(root, names);
+        } else if (scenario == "alias_js_names_array_custom") {
+            QPDFObjectHandle pairs = QPDFObjectHandle::newArray();
+            pairs.appendItem(QPDFObjectHandle::newString("entry"));
+            pairs.appendItem(pdf_security_action(*pdf, "/Launch"));
+            pairs = pdf->makeIndirectObject(pairs);
+            QPDFObjectHandle tree = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Names", pairs}}));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
+            pdf_security_set_custom_alias(root, pairs);
+        } else if (scenario == "alias_acroform_custom") {
+            QPDFObjectHandle acroform = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Fields", QPDFObjectHandle::newArray()},
+                    {"/XFA", QPDFObjectHandle::newString("xfa")}}));
+            root.replaceKey("/AcroForm", acroform);
+            pdf_security_set_custom_alias(root, acroform);
+        } else if (scenario == "alias_aa_custom") {
+            QPDFObjectHandle additional = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/E", pdf_security_action(*pdf, "/Launch")}}));
+            root.replaceKey(
+                "/QuantaPDFOwner",
+                QPDFObjectHandle::newDictionary({{"/AA", additional}}));
+            pdf_security_set_custom_alias(root, additional);
+        } else if (scenario == "alias_next_custom") {
+            QPDFObjectHandle next = QPDFObjectHandle::newArray();
+            next.appendItem(pdf_security_action(*pdf, "/Launch"));
+            next = pdf->makeIndirectObject(next);
+            QPDFObjectHandle safe = pdf_security_action(*pdf, "/GoTo");
+            safe.replaceKey("/Next", next);
+            root.replaceKey(
+                "/QuantaPDFOwner",
+                QPDFObjectHandle::newDictionary({{"/A", safe}}));
+            pdf_security_set_custom_alias(root, next);
+        } else if (scenario == "alias_openaction_next_custom") {
+            QPDFObjectHandle safe = pdf_security_action(*pdf, "/GoTo");
+            safe.replaceKey(
+                "/Next", pdf_security_action(*pdf, "/Launch"));
+            root.replaceKey("/OpenAction", safe);
+            pdf_security_set_custom_alias(root, safe);
+        } else if (scenario == "alias_annots_custom") {
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/RichMedia")}}));
+            annots = pdf->makeIndirectObject(annots);
+            pages[0].replaceKey("/Annots", annots);
+            pdf_security_set_custom_alias(root, annots);
+        } else if (scenario == "alias_af_custom") {
+            QPDFObjectHandle holder = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/AF", QPDFObjectHandle::newArray()}}));
+            QPDFObjectHandle associated = QPDFObjectHandle::newArray();
+            associated.appendItem(holder);
+            root.replaceKey("/AF", associated);
+            pdf_security_set_custom_alias(root, holder);
+        } else if (scenario == "alias_ef_custom") {
+            QPDFObjectHandle holder = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/EF", QPDFObjectHandle::newDictionary()}}));
+            root.replaceKey("/EF", holder);
+            pdf_security_set_custom_alias(root, holder);
         } else if (scenario == "mutation_budget_shared_next") {
             pdf_security_stress_shared_next(*pdf, root, 590);
             pdf_security_budget_tuner(*pdf, root, 212);

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -964,6 +964,53 @@ extern "C" int pdf_security_create_fixture(
                 {"/Subtype", QPDFObjectHandle::newName("/Text")}}));
             pages[0].replaceKey("/Annots", annots);
             pdf_security_set_custom_alias(root, pages[0]);
+        } else if (scenario == "annotation_page_backlinks") {
+            QPDFObjectHandle rich = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/RichMedia")},
+                    {"/P", pages[0]}}));
+            QPDFObjectHandle attachment = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/FileAttachment")},
+                    {"/P", pages[0]}}));
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(rich);
+            annots.appendItem(attachment);
+            pages[0].replaceKey("/Annots", annots);
+        } else if (scenario == "annotation_reply_popup_links") {
+            QPDFObjectHandle target = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/Text")},
+                    {"/A", pdf_security_action(*pdf, "/Launch")}}));
+            QPDFObjectHandle reply = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/Text")},
+                    {"/IRT", target}}));
+            QPDFObjectHandle parent = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/Text")},
+                    {"/A", pdf_security_action(*pdf, "/Launch")}}));
+            QPDFObjectHandle popup = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/Popup")},
+                    {"/Parent", parent},
+                    {"/A", pdf_security_action(*pdf, "/Launch")}}));
+            parent.replaceKey("/Popup", popup);
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(target);
+            annots.appendItem(reply);
+            annots.appendItem(parent);
+            annots.appendItem(popup);
+            pages[0].replaceKey("/Annots", annots);
+        } else if (scenario == "annotation_custom_alias") {
+            QPDFObjectHandle annotation = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Subtype", QPDFObjectHandle::newName("/Text")},
+                    {"/A", pdf_security_action(*pdf, "/Launch")}}));
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(annotation);
+            pages[0].replaceKey("/Annots", annots);
+            pdf_security_set_custom_alias(root, annotation);
         } else if (scenario == "alias_direct_js_names_custom") {
             QPDFObjectHandle pairs = QPDFObjectHandle::newArray();
             pairs.appendItem(QPDFObjectHandle::newString("a"));

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -2,120 +2,379 @@
 #include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFWriter.hh>
 
+#include <string>
+#include <vector>
+
 static QPDFObjectHandle pdf_security_action(QPDF& pdf, const char *name)
 {
     return pdf.makeIndirectObject(QPDFObjectHandle::newDictionary({
         {"/S", QPDFObjectHandle::newName(name)}}));
 }
 
+static QPDFObjectHandle pdf_security_signature(QPDF& pdf)
+{
+    return pdf.makeIndirectObject(QPDFObjectHandle::newDictionary({
+        {"/Type", QPDFObjectHandle::newName("/Sig")},
+        {"/Contents", QPDFObjectHandle::newString("signed")}}));
+}
+
 static void pdf_security_write(
     QPDF& pdf,
     const char *output_path,
-    bool preserve_unreferenced = false)
+    bool preserve_unreferenced = false,
+    bool compressed_objects = false)
 {
     QPDFWriter writer(pdf, output_path);
     writer.setDeterministicID(true);
-    writer.setObjectStreamMode(qpdf_o_disable);
+    writer.setObjectStreamMode(
+        compressed_objects ? qpdf_o_generate : qpdf_o_disable);
     writer.setStreamDataMode(qpdf_s_preserve);
+    writer.setCompressStreams(true);
     writer.setPreserveUnreferencedObjects(preserve_unreferenced);
     writer.write();
+}
+
+static void pdf_security_set_open_action(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    const char *name)
+{
+    root.replaceKey("/OpenAction", pdf_security_action(pdf, name));
+}
+
+static void pdf_security_set_a_action(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    const char *name)
+{
+    root.replaceKey(
+        "/QuantaPDFActionOwner",
+        QPDFObjectHandle::newDictionary({
+            {"/A", pdf_security_action(pdf, name)}}));
+}
+
+static void pdf_security_set_annotation(
+    QPDFObjectHandle page,
+    const char *subtype)
+{
+    QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+    annots.appendItem(QPDFObjectHandle::newDictionary({
+        {"/Subtype", QPDFObjectHandle::newName(subtype)}}));
+    page.replaceKey("/Annots", annots);
+}
+
+static void pdf_security_set_fields(
+    QPDFObjectHandle root,
+    QPDFObjectHandle field)
+{
+    QPDFObjectHandle fields = QPDFObjectHandle::newArray();
+    fields.appendItem(field);
+    root.replaceKey(
+        "/AcroForm",
+        QPDFObjectHandle::newDictionary({{"/Fields", fields}}));
+}
+
+static void pdf_security_set_perms_signature(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    const char *key)
+{
+    root.replaceKey(
+        "/Perms",
+        QPDFObjectHandle::newDictionary({
+            {key, pdf_security_signature(pdf)}}));
+}
+
+static void pdf_security_stress_shared_next(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    int count)
+{
+    std::vector<QPDFObjectHandle> actions;
+    actions.reserve(static_cast<size_t>(count));
+    for (int index = 0; index < count; ++index)
+        actions.push_back(pdf_security_action(pdf, "/GoTo"));
+
+    QPDFObjectHandle next = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index)
+        next.appendItem(actions[0]);
+    next = pdf.makeIndirectObject(next);
+
+    QPDFObjectHandle owners = QPDFObjectHandle::newArray();
+    for (QPDFObjectHandle action : actions) {
+        action.replaceKey("/Next", next);
+        owners.appendItem(QPDFObjectHandle::newDictionary({
+            {"/A", action}}));
+    }
+    root.replaceKey(
+        "/QuantaPDFStressOwners", pdf.makeIndirectObject(owners));
+}
+
+static void pdf_security_stress_shared_aa(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    int count)
+{
+    QPDFObjectHandle action = pdf_security_action(pdf, "/GoTo");
+    QPDFObjectHandle additional = QPDFObjectHandle::newDictionary();
+    for (int index = 0; index < count; ++index) {
+        additional.replaceKey(
+            "/E" + std::to_string(index), action);
+    }
+    additional = pdf.makeIndirectObject(additional);
+
+    QPDFObjectHandle owners = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index) {
+        owners.appendItem(QPDFObjectHandle::newDictionary({
+            {"/AA", additional}}));
+    }
+    root.replaceKey(
+        "/QuantaPDFStressOwners", pdf.makeIndirectObject(owners));
+}
+
+static void pdf_security_stress_shared_annots(
+    QPDF& pdf,
+    QPDFObjectHandle root,
+    int count)
+{
+    QPDFObjectHandle annotation = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({
+            {"/Subtype", QPDFObjectHandle::newName("/Text")}}));
+    QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index)
+        annots.appendItem(annotation);
+    annots = pdf.makeIndirectObject(annots);
+
+    QPDFObjectHandle owners = QPDFObjectHandle::newArray();
+    for (int index = 0; index < count; ++index) {
+        owners.appendItem(QPDFObjectHandle::newDictionary({
+            {"/Annots", annots}}));
+    }
+    root.replaceKey(
+        "/QuantaPDFStressOwners", pdf.makeIndirectObject(owners));
 }
 
 extern "C" int pdf_security_create_fixture(
     const char *source_path,
     const char *output_path,
-    int kind)
+    const char *scenario_utf8)
 {
     try {
+        std::string const scenario = scenario_utf8;
         auto pdf = QPDF::create();
         pdf->processFile(source_path);
         QPDFObjectHandle root = pdf->getRoot();
         auto pages = pdf->getAllPages();
+        bool preserve_unreferenced = false;
+        bool compressed_objects = false;
         if (pages.empty())
             return 0;
 
-        if (kind == 1) {
-            root.replaceKey("/OpenAction", pdf_security_action(*pdf, "/GoTo"));
-        } else if (kind == 2) {
+        if (scenario == "internal_goto") {
+            pdf_security_set_open_action(*pdf, root, "/GoTo");
+        } else if (scenario == "open_destination_array") {
+            root.replaceKey("/OpenAction", QPDFObjectHandle::newArray());
+        } else if (scenario == "open_destination_name") {
             root.replaceKey(
-                "/OpenAction", pdf_security_action(*pdf, "/JavaScript"));
+                "/OpenAction", QPDFObjectHandle::newName("/Destination"));
+        } else if (scenario == "open_destination_string") {
             root.replaceKey(
-                "/Names",
-                QPDFObjectHandle::newDictionary({
+                "/OpenAction", QPDFObjectHandle::newString("destination"));
+        } else if (scenario == "action_javascript") {
+            pdf_security_set_open_action(*pdf, root, "/JavaScript");
+        } else if (scenario == "names_javascript") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
                     {"/JavaScript", QPDFObjectHandle::newDictionary()}}));
-        } else if (kind == 3) {
-            QPDFObjectHandle owner = QPDFObjectHandle::newDictionary({
-                {"/A", pdf_security_action(*pdf, "/Launch")}});
-            root.replaceKey("/QuantaPDFActionOwner", owner);
-        } else if (kind == 4) {
+        } else if (scenario == "action_launch") {
+            pdf_security_set_a_action(*pdf, root, "/Launch");
+        } else if (scenario == "external_uri") {
             QPDFObjectHandle additional = QPDFObjectHandle::newDictionary({
                 {"/E", pdf_security_action(*pdf, "/URI")}});
             root.replaceKey(
                 "/QuantaPDFAdditionalOwner",
                 QPDFObjectHandle::newDictionary({{"/AA", additional}}));
-        } else if (kind == 5) {
+        } else if (scenario == "external_gotor") {
+            pdf_security_set_open_action(*pdf, root, "/GoToR");
+        } else if (scenario == "external_gotoe") {
+            pdf_security_set_open_action(*pdf, root, "/GoToE");
+        } else if (scenario == "external_submitform") {
+            pdf_security_set_open_action(*pdf, root, "/SubmitForm");
+        } else if (scenario == "external_importdata") {
+            pdf_security_set_open_action(*pdf, root, "/ImportData");
+        } else if (scenario == "other_unknown") {
+            pdf_security_set_open_action(*pdf, root, "/QuantaPDFUnknown");
+        } else if (scenario == "goto_next_other") {
             QPDFObjectHandle action = pdf_security_action(*pdf, "/GoTo");
             QPDFObjectHandle next = QPDFObjectHandle::newArray();
             next.appendItem(pdf_security_action(*pdf, "/Named"));
             action.replaceKey("/Next", next);
             root.replaceKey("/OpenAction", action);
-        } else if (kind == 6) {
+        } else if (scenario == "names_embedded") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/EmbeddedFiles", QPDFObjectHandle::newDictionary()}}));
+        } else if (scenario == "af_embedded") {
+            root.replaceKey(
+                "/AF", pdf->makeIndirectObject(
+                    QPDFObjectHandle::newDictionary()));
+        } else if (scenario == "ef_embedded") {
+            root.replaceKey(
+                "/QuantaPDFFileSpec",
+                QPDFObjectHandle::newDictionary({
+                    {"/EF", pdf->makeIndirectObject(
+                        QPDFObjectHandle::newDictionary())}}));
+        } else if (scenario == "embedded_stream") {
             QPDFObjectHandle embedded = pdf->newStream("embedded");
             embedded.getDict().replaceKey(
                 "/Type", QPDFObjectHandle::newName("/EmbeddedFile"));
-            QPDFObjectHandle associated = QPDFObjectHandle::newArray();
-            associated.appendItem(embedded);
-            root.replaceKey("/AF", associated);
+            root.replaceKey("/QuantaPDFEmbedded", embedded);
+        } else if (scenario == "file_attachment") {
+            pdf_security_set_annotation(pages[0], "/FileAttachment");
+        } else if (scenario == "xfa") {
             root.replaceKey(
-                "/Names",
-                QPDFObjectHandle::newDictionary({
-                    {"/EmbeddedFiles", QPDFObjectHandle::newDictionary()}}));
-            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
-            annots.appendItem(QPDFObjectHandle::newDictionary({
-                {"/Subtype", QPDFObjectHandle::newName("/FileAttachment")}}));
-            pages[0].replaceKey("/Annots", annots);
-        } else if (kind == 7) {
-            QPDFObjectHandle fields = QPDFObjectHandle::newArray();
-            root.replaceKey(
-                "/AcroForm",
-                QPDFObjectHandle::newDictionary({
-                    {"/Fields", fields},
+                "/AcroForm", QPDFObjectHandle::newDictionary({
+                    {"/Fields", QPDFObjectHandle::newArray()},
                     {"/XFA", QPDFObjectHandle::newString("xfa")}}));
-        } else if (kind == 8) {
-            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
-            annots.appendItem(QPDFObjectHandle::newDictionary({
-                {"/Subtype", QPDFObjectHandle::newName("/RichMedia")}}));
-            pages[0].replaceKey("/Annots", annots);
-        } else if (kind == 9) {
+        } else if (scenario == "rich_richmedia") {
+            pdf_security_set_annotation(pages[0], "/RichMedia");
+        } else if (scenario == "rich_3d") {
+            pdf_security_set_annotation(pages[0], "/3D");
+        } else if (scenario == "rich_movie") {
+            pdf_security_set_annotation(pages[0], "/Movie");
+        } else if (scenario == "rich_sound") {
+            pdf_security_set_annotation(pages[0], "/Sound");
+        } else if (scenario == "rich_screen") {
+            pdf_security_set_annotation(pages[0], "/Screen");
+        } else if (scenario == "inherited_signature") {
+            QPDFObjectHandle parent = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary());
+            QPDFObjectHandle child = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Parent", parent},
+                    {"/V", pdf_security_signature(*pdf)}}));
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(child);
+            parent.replaceKey("/FT", QPDFObjectHandle::newName("/Sig"));
+            parent.replaceKey("/Kids", kids);
+            pdf_security_set_fields(root, parent);
+        } else if (scenario == "perms_docmdp") {
+            pdf_security_set_perms_signature(*pdf, root, "/DocMDP");
+        } else if (scenario == "perms_ur") {
+            pdf_security_set_perms_signature(*pdf, root, "/UR");
+        } else if (scenario == "perms_ur3") {
+            pdf_security_set_perms_signature(*pdf, root, "/UR3");
+        } else if (scenario == "unreachable_javascript") {
             QPDFObjectHandle garbage = pdf->makeIndirectObject(
                 QPDFObjectHandle::newDictionary({
                     {"/A", pdf_security_action(*pdf, "/JavaScript")}}));
             (void)garbage;
-        } else if (kind == 10) {
+            preserve_unreferenced = true;
+        } else if (scenario == "nonroot_names") {
             root.replaceKey(
-                "/QuantaPDFMalformedAction",
-                QPDFObjectHandle::newDictionary({
+                "/QuantaPDFNonRoot", QPDFObjectHandle::newDictionary({
+                    {"/Names", QPDFObjectHandle::newDictionary({
+                        {"/JavaScript",
+                         QPDFObjectHandle::newDictionary()}})}}));
+        } else if (scenario == "nonroot_acroform") {
+            root.replaceKey(
+                "/QuantaPDFNonRoot", QPDFObjectHandle::newDictionary({
+                    {"/AcroForm", QPDFObjectHandle::newDictionary({
+                        {"/XFA", QPDFObjectHandle::newString("xfa")}})}}));
+        } else if (scenario == "action_cycle") {
+            QPDFObjectHandle left = pdf_security_action(*pdf, "/GoTo");
+            QPDFObjectHandle right = pdf_security_action(*pdf, "/GoTo");
+            left.replaceKey("/Next", right);
+            right.replaceKey("/Next", left);
+            root.replaceKey("/OpenAction", left);
+        } else if (scenario == "malformed_open_action") {
+            root.replaceKey(
+                "/OpenAction", QPDFObjectHandle::newDictionary());
+        } else if (scenario == "malformed_a") {
+            root.replaceKey(
+                "/QuantaPDFMalformed", QPDFObjectHandle::newDictionary({
                     {"/A", QPDFObjectHandle::newName("/Bad")}}));
-        } else if (kind == 11) {
+        } else if (scenario == "malformed_aa_container") {
             root.replaceKey(
-                "/QuantaPDFMalformedAdditional",
-                QPDFObjectHandle::newDictionary({
+                "/QuantaPDFMalformed", QPDFObjectHandle::newDictionary({
+                    {"/AA", QPDFObjectHandle::newName("/Bad")}}));
+        } else if (scenario == "malformed_aa_entry") {
+            root.replaceKey(
+                "/QuantaPDFMalformed", QPDFObjectHandle::newDictionary({
                     {"/AA", QPDFObjectHandle::newDictionary({
                         {"/E", QPDFObjectHandle::newDictionary()}})}}));
-        } else if (kind == 12) {
+        } else if (scenario == "malformed_next") {
+            QPDFObjectHandle action = pdf_security_action(*pdf, "/GoTo");
+            action.replaceKey(
+                "/Next", QPDFObjectHandle::newName("/Bad"));
+            root.replaceKey("/OpenAction", action);
+        } else if (scenario == "malformed_names") {
             root.replaceKey("/Names", QPDFObjectHandle::newName("/Bad"));
-        } else if (kind == 13) {
+        } else if (scenario == "malformed_annots") {
             pages[0].replaceKey(
                 "/Annots", QPDFObjectHandle::newName("/Bad"));
-        } else if (kind == 14) {
+        } else if (scenario == "malformed_annot_entry") {
             QPDFObjectHandle annots = QPDFObjectHandle::newArray();
             annots.appendItem(QPDFObjectHandle::newName("/Bad"));
             pages[0].replaceKey("/Annots", annots);
+        } else if (scenario == "malformed_acroform") {
+            root.replaceKey(
+                "/AcroForm", QPDFObjectHandle::newName("/Bad"));
+        } else if (scenario == "malformed_fields") {
+            root.replaceKey(
+                "/AcroForm", QPDFObjectHandle::newDictionary({
+                    {"/Fields", QPDFObjectHandle::newName("/Bad")}}));
+        } else if (scenario == "malformed_field") {
+            pdf_security_set_fields(
+                root, QPDFObjectHandle::newName("/Bad"));
+        } else if (scenario == "malformed_signature_value") {
+            pdf_security_set_fields(
+                root, pdf->makeIndirectObject(
+                    QPDFObjectHandle::newDictionary({
+                        {"/FT", QPDFObjectHandle::newName("/Sig")},
+                        {"/V", QPDFObjectHandle::newName("/Bad")}})));
+        } else if (scenario == "malformed_signature_type") {
+            QPDFObjectHandle signature = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/Type", QPDFObjectHandle::newName("/Bad")}}));
+            pdf_security_set_fields(
+                root, pdf->makeIndirectObject(
+                    QPDFObjectHandle::newDictionary({
+                        {"/FT", QPDFObjectHandle::newName("/Sig")},
+                        {"/V", signature}})));
+        } else if (scenario == "parent_mismatch") {
+            QPDFObjectHandle external_parent = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary());
+            pdf_security_set_fields(
+                root, pdf->makeIndirectObject(
+                    QPDFObjectHandle::newDictionary({
+                        {"/Parent", external_parent}})));
+        } else if (scenario == "malformed_perms") {
+            root.replaceKey("/Perms", QPDFObjectHandle::newName("/Bad"));
+        } else if (scenario == "malformed_perms_signature") {
+            root.replaceKey(
+                "/Perms", QPDFObjectHandle::newDictionary({
+                    {"/DocMDP", QPDFObjectHandle::newName("/Bad")}}));
+        } else if (scenario == "malformed_perms_type") {
+            root.replaceKey(
+                "/Perms", QPDFObjectHandle::newDictionary({
+                    {"/DocMDP", QPDFObjectHandle::newDictionary({
+                        {"/Type", QPDFObjectHandle::newName("/Bad")}})}}));
+        } else if (scenario == "budget_shared_next") {
+            pdf_security_stress_shared_next(*pdf, root, 2048);
+            compressed_objects = true;
+        } else if (scenario == "budget_shared_aa") {
+            pdf_security_stress_shared_aa(*pdf, root, 2048);
+            compressed_objects = true;
+        } else if (scenario == "budget_shared_annots") {
+            pdf_security_stress_shared_annots(*pdf, root, 2048);
+            compressed_objects = true;
         } else {
             return 0;
         }
 
-        pdf_security_write(*pdf, output_path, kind == 9);
+        pdf_security_write(
+            *pdf, output_path, preserve_unreferenced, compressed_objects);
         return 1;
     } catch (...) {
         return 0;

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -1,0 +1,123 @@
+#include <qpdf/QPDF.hh>
+#include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFWriter.hh>
+
+static QPDFObjectHandle pdf_security_action(QPDF& pdf, const char *name)
+{
+    return pdf.makeIndirectObject(QPDFObjectHandle::newDictionary({
+        {"/S", QPDFObjectHandle::newName(name)}}));
+}
+
+static void pdf_security_write(
+    QPDF& pdf,
+    const char *output_path,
+    bool preserve_unreferenced = false)
+{
+    QPDFWriter writer(pdf, output_path);
+    writer.setDeterministicID(true);
+    writer.setObjectStreamMode(qpdf_o_disable);
+    writer.setStreamDataMode(qpdf_s_preserve);
+    writer.setPreserveUnreferencedObjects(preserve_unreferenced);
+    writer.write();
+}
+
+extern "C" int pdf_security_create_fixture(
+    const char *source_path,
+    const char *output_path,
+    int kind)
+{
+    try {
+        auto pdf = QPDF::create();
+        pdf->processFile(source_path);
+        QPDFObjectHandle root = pdf->getRoot();
+        auto pages = pdf->getAllPages();
+        if (pages.empty())
+            return 0;
+
+        if (kind == 1) {
+            root.replaceKey("/OpenAction", pdf_security_action(*pdf, "/GoTo"));
+        } else if (kind == 2) {
+            root.replaceKey(
+                "/OpenAction", pdf_security_action(*pdf, "/JavaScript"));
+            root.replaceKey(
+                "/Names",
+                QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary()}}));
+        } else if (kind == 3) {
+            QPDFObjectHandle owner = QPDFObjectHandle::newDictionary({
+                {"/A", pdf_security_action(*pdf, "/Launch")}});
+            root.replaceKey("/QuantaPDFActionOwner", owner);
+        } else if (kind == 4) {
+            QPDFObjectHandle additional = QPDFObjectHandle::newDictionary({
+                {"/E", pdf_security_action(*pdf, "/URI")}});
+            root.replaceKey(
+                "/QuantaPDFAdditionalOwner",
+                QPDFObjectHandle::newDictionary({{"/AA", additional}}));
+        } else if (kind == 5) {
+            QPDFObjectHandle action = pdf_security_action(*pdf, "/GoTo");
+            QPDFObjectHandle next = QPDFObjectHandle::newArray();
+            next.appendItem(pdf_security_action(*pdf, "/Named"));
+            action.replaceKey("/Next", next);
+            root.replaceKey("/OpenAction", action);
+        } else if (kind == 6) {
+            QPDFObjectHandle embedded = pdf->newStream("embedded");
+            embedded.getDict().replaceKey(
+                "/Type", QPDFObjectHandle::newName("/EmbeddedFile"));
+            QPDFObjectHandle associated = QPDFObjectHandle::newArray();
+            associated.appendItem(embedded);
+            root.replaceKey("/AF", associated);
+            root.replaceKey(
+                "/Names",
+                QPDFObjectHandle::newDictionary({
+                    {"/EmbeddedFiles", QPDFObjectHandle::newDictionary()}}));
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/FileAttachment")}}));
+            pages[0].replaceKey("/Annots", annots);
+        } else if (kind == 7) {
+            QPDFObjectHandle fields = QPDFObjectHandle::newArray();
+            root.replaceKey(
+                "/AcroForm",
+                QPDFObjectHandle::newDictionary({
+                    {"/Fields", fields},
+                    {"/XFA", QPDFObjectHandle::newString("xfa")}}));
+        } else if (kind == 8) {
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/RichMedia")}}));
+            pages[0].replaceKey("/Annots", annots);
+        } else if (kind == 9) {
+            QPDFObjectHandle garbage = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({
+                    {"/A", pdf_security_action(*pdf, "/JavaScript")}}));
+            (void)garbage;
+        } else if (kind == 10) {
+            root.replaceKey(
+                "/QuantaPDFMalformedAction",
+                QPDFObjectHandle::newDictionary({
+                    {"/A", QPDFObjectHandle::newName("/Bad")}}));
+        } else if (kind == 11) {
+            root.replaceKey(
+                "/QuantaPDFMalformedAdditional",
+                QPDFObjectHandle::newDictionary({
+                    {"/AA", QPDFObjectHandle::newDictionary({
+                        {"/E", QPDFObjectHandle::newDictionary()}})}}));
+        } else if (kind == 12) {
+            root.replaceKey("/Names", QPDFObjectHandle::newName("/Bad"));
+        } else if (kind == 13) {
+            pages[0].replaceKey(
+                "/Annots", QPDFObjectHandle::newName("/Bad"));
+        } else if (kind == 14) {
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(QPDFObjectHandle::newName("/Bad"));
+            pages[0].replaceKey("/Annots", annots);
+        } else {
+            return 0;
+        }
+
+        pdf_security_write(*pdf, output_path, kind == 9);
+        return 1;
+    } catch (...) {
+        return 0;
+    }
+}

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -320,6 +320,38 @@ static void pdf_security_empty_container_fixture(
         QPDFObjectHandle::newDictionary({{"/A", safe}}));
 }
 
+static void pdf_security_shared_selected_aa_fixture(
+    QPDF& pdf,
+    QPDFObjectHandle root)
+{
+    QPDFObjectHandle additional = pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({
+            {"/E", pdf_security_action(pdf, "/JavaScript")}}));
+    QPDFObjectHandle owners = QPDFObjectHandle::newArray();
+    for (int index = 0; index < 2; ++index) {
+        owners.appendItem(QPDFObjectHandle::newDictionary({
+            {"/AA", additional}}));
+    }
+    root.replaceKey("/QuantaPDFSharedAAOwners", owners);
+}
+
+static void pdf_security_shared_selected_next_fixture(
+    QPDF& pdf,
+    QPDFObjectHandle root)
+{
+    QPDFObjectHandle next = QPDFObjectHandle::newArray();
+    next.appendItem(pdf_security_action(pdf, "/JavaScript"));
+    next = pdf.makeIndirectObject(next);
+    QPDFObjectHandle owners = QPDFObjectHandle::newArray();
+    for (int index = 0; index < 2; ++index) {
+        QPDFObjectHandle safe = pdf_security_action(pdf, "/GoTo");
+        safe.replaceKey("/Next", next);
+        owners.appendItem(QPDFObjectHandle::newDictionary({
+            {"/A", safe}}));
+    }
+    root.replaceKey("/QuantaPDFSharedNextOwners", owners);
+}
+
 static void pdf_security_budget_tuner(
     QPDF& pdf,
     QPDFObjectHandle root,
@@ -356,6 +388,10 @@ extern "C" int pdf_security_create_fixture(
             pdf_security_empty_container_fixture(*pdf, root, false);
         } else if (scenario == "sanitize_selected_to_empty") {
             pdf_security_empty_container_fixture(*pdf, root, true);
+        } else if (scenario == "sanitize_shared_selected_aa") {
+            pdf_security_shared_selected_aa_fixture(*pdf, root);
+        } else if (scenario == "sanitize_shared_selected_next") {
+            pdf_security_shared_selected_next_fixture(*pdf, root);
         } else if (scenario == "internal_goto") {
             pdf_security_set_open_action(*pdf, root, "/GoTo");
         } else if (scenario == "open_destination_array") {
@@ -617,6 +653,48 @@ extern "C" int pdf_security_inspect_empty_containers(
         QPDFObjectHandle next = action.getKey("/Next");
         if (next.isArray() && next.getArrayNItems() == 0)
             mask |= 4;
+        return pdf->anyWarnings() ? -1 : mask;
+    } catch (...) {
+        return -1;
+    }
+}
+
+extern "C" int pdf_security_inspect_shared_container_owners(
+    unsigned char const *data,
+    size_t size,
+    int inspect_next)
+{
+    if (data == nullptr || size == 0)
+        return -1;
+    try {
+        auto pdf = QPDF::create();
+        pdf->setSuppressWarnings(true);
+        pdf->setAttemptRecovery(false);
+        pdf->processMemoryFile(
+            "pdf-security-shared-container-output",
+            reinterpret_cast<char const *>(data),
+            size);
+        QPDFObjectHandle root = pdf->getRoot();
+        QPDFObjectHandle owners = root.getKey(
+            inspect_next ? "/QuantaPDFSharedNextOwners" :
+                           "/QuantaPDFSharedAAOwners");
+        if (!owners.isArray() || owners.getArrayNItems() != 2)
+            return -1;
+        int mask = 0;
+        for (int index = 0; index < 2; ++index) {
+            QPDFObjectHandle owner = owners.getArrayItem(index);
+            if (!owner.isDictionary())
+                return -1;
+            if (inspect_next) {
+                QPDFObjectHandle action = owner.getKey("/A");
+                if (!action.isDictionary())
+                    return -1;
+                if (action.hasKey("/Next"))
+                    mask |= 1 << index;
+            } else if (owner.hasKey("/AA")) {
+                mask |= 1 << index;
+            }
+        }
         return pdf->anyWarnings() ? -1 : mask;
     } catch (...) {
         return -1;

--- a/tests/pdf_security_test_helpers.cpp
+++ b/tests/pdf_security_test_helpers.cpp
@@ -397,19 +397,21 @@ static void pdf_security_javascript_name_tree_budget(
     QPDFObjectHandle root,
     int count)
 {
-    QPDFObjectHandle leaf = pdf.makeIndirectObject(
-        QPDFObjectHandle::newDictionary());
-    QPDFObjectHandle shared_kids = QPDFObjectHandle::newArray();
+    std::vector<QPDFObjectHandle> actions;
+    actions.reserve(static_cast<size_t>(count));
     for (int index = 0; index < count; ++index)
-        shared_kids.appendItem(leaf);
-    shared_kids = pdf.makeIndirectObject(shared_kids);
-    QPDFObjectHandle root_kids = QPDFObjectHandle::newArray();
-    for (int index = 0; index < count; ++index) {
-        root_kids.appendItem(pdf.makeIndirectObject(
-            QPDFObjectHandle::newDictionary({{"/Kids", shared_kids}})));
-    }
+        actions.push_back(pdf_security_action(pdf, "/GoTo"));
+    QPDFObjectHandle shared_next = QPDFObjectHandle::newArray();
+    for (QPDFObjectHandle action : actions)
+        shared_next.appendItem(action);
+    shared_next = pdf.makeIndirectObject(shared_next);
+    for (QPDFObjectHandle action : actions)
+        action.replaceKey("/Next", shared_next);
+    QPDFObjectHandle pairs = QPDFObjectHandle::newArray();
+    pairs.appendItem(QPDFObjectHandle::newString("entry"));
+    pairs.appendItem(actions[0]);
     QPDFObjectHandle tree = pdf.makeIndirectObject(
-        QPDFObjectHandle::newDictionary({{"/Kids", root_kids}}));
+        QPDFObjectHandle::newDictionary({{"/Names", pairs}}));
     root.replaceKey(
         "/Names", QPDFObjectHandle::newDictionary({
             {"/JavaScript", tree}}));
@@ -420,6 +422,30 @@ static void pdf_security_set_custom_alias(
     QPDFObjectHandle object)
 {
     root.replaceKey("/QuantaPDFAlias", object);
+}
+
+static QPDFObjectHandle pdf_security_name_tree_leaf(
+    QPDF& pdf,
+    std::initializer_list<char const *> keys)
+{
+    QPDFObjectHandle names = QPDFObjectHandle::newArray();
+    for (char const *key : keys) {
+        names.appendItem(QPDFObjectHandle::newString(key));
+        names.appendItem(pdf_security_action(pdf, "/GoTo"));
+    }
+    return pdf.makeIndirectObject(
+        QPDFObjectHandle::newDictionary({{"/Names", names}}));
+}
+
+static void pdf_security_set_name_tree_limits(
+    QPDFObjectHandle node,
+    char const *first,
+    char const *last)
+{
+    QPDFObjectHandle limits = QPDFObjectHandle::newArray();
+    limits.appendItem(QPDFObjectHandle::newString(first));
+    limits.appendItem(QPDFObjectHandle::newString(last));
+    node.replaceKey("/Limits", limits);
 }
 
 static void pdf_security_budget_tuner(
@@ -480,6 +506,43 @@ extern "C" int pdf_security_create_fixture(
         } else if (scenario == "name_tree_next_other") {
             pdf_security_javascript_name_tree_fixture(
                 *pdf, root, "/GoTo", "/Named");
+        } else if (scenario == "name_tree_valid_multilevel") {
+            QPDFObjectHandle left = pdf_security_name_tree_leaf(
+                *pdf, {"alpha", "bravo"});
+            QPDFObjectHandle right = pdf_security_name_tree_leaf(
+                *pdf, {"charlie", "delta"});
+            pdf_security_set_name_tree_limits(left, "alpha", "bravo");
+            pdf_security_set_name_tree_limits(right, "charlie", "delta");
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(left);
+            kids.appendItem(right);
+            QPDFObjectHandle tree = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Kids", kids}}));
+            pdf_security_set_name_tree_limits(tree, "alpha", "delta");
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
+        } else if (scenario == "name_tree_limited_head_launch") {
+            QPDFObjectHandle left_names = QPDFObjectHandle::newArray();
+            left_names.appendItem(QPDFObjectHandle::newString("alpha"));
+            left_names.appendItem(pdf_security_action(*pdf, "/Launch"));
+            left_names.appendItem(QPDFObjectHandle::newString("bravo"));
+            left_names.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            QPDFObjectHandle left = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Names", left_names}}));
+            QPDFObjectHandle right = pdf_security_name_tree_leaf(
+                *pdf, {"charlie", "delta"});
+            pdf_security_set_name_tree_limits(left, "alpha", "bravo");
+            pdf_security_set_name_tree_limits(right, "charlie", "delta");
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(left);
+            kids.appendItem(right);
+            QPDFObjectHandle tree = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Kids", kids}}));
+            pdf_security_set_name_tree_limits(tree, "alpha", "delta");
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
         } else if (scenario == "internal_goto") {
             pdf_security_set_open_action(*pdf, root, "/GoTo");
         } else if (scenario == "open_destination_array") {
@@ -694,6 +757,55 @@ extern "C" int pdf_security_create_fixture(
             root.replaceKey(
                 "/Names", QPDFObjectHandle::newDictionary({
                     {"/JavaScript", tree}}));
+        } else if (scenario == "name_tree_duplicate_child") {
+            QPDFObjectHandle leaf = pdf_security_name_tree_leaf(*pdf, {"a"});
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(leaf);
+            kids.appendItem(leaf);
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Kids", kids}})}}));
+        } else if (scenario == "name_tree_unordered_keys" ||
+                   scenario == "name_tree_duplicate_keys") {
+            QPDFObjectHandle names = QPDFObjectHandle::newArray();
+            names.appendItem(QPDFObjectHandle::newString(
+                scenario == "name_tree_unordered_keys" ? "b" : "a"));
+            names.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            names.appendItem(QPDFObjectHandle::newString("a"));
+            names.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Names", names}})}}));
+        } else if (scenario == "name_tree_reversed_limits" ||
+                   scenario == "name_tree_inconsistent_limits") {
+            QPDFObjectHandle tree = pdf_security_name_tree_leaf(
+                *pdf, {"a", "b"});
+            pdf_security_set_name_tree_limits(
+                tree,
+                scenario == "name_tree_reversed_limits" ? "b" : "x",
+                scenario == "name_tree_reversed_limits" ? "a" : "z");
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
+        } else if (scenario == "name_tree_overlapping_kids" ||
+                   scenario == "name_tree_out_of_order_kids") {
+            QPDFObjectHandle first = pdf_security_name_tree_leaf(
+                *pdf, scenario == "name_tree_overlapping_kids"
+                    ? std::initializer_list<char const *>{"a", "c"}
+                    : std::initializer_list<char const *>{"c", "d"});
+            QPDFObjectHandle second = pdf_security_name_tree_leaf(
+                *pdf, scenario == "name_tree_overlapping_kids"
+                    ? std::initializer_list<char const *>{"b", "d"}
+                    : std::initializer_list<char const *>{"a", "b"});
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(first);
+            kids.appendItem(second);
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary({
+                        {"/Kids", kids}})}}));
         } else if (scenario == "malformed_annots") {
             pages[0].replaceKey(
                 "/Annots", QPDFObjectHandle::newName("/Bad"));
@@ -818,6 +930,96 @@ extern "C" int pdf_security_create_fixture(
                 "/Next", pdf_security_action(*pdf, "/Launch"));
             root.replaceKey("/OpenAction", safe);
             pdf_security_set_custom_alias(root, safe);
+        } else if (scenario == "alias_direct_next_custom") {
+            QPDFObjectHandle owner = pdf_security_action(*pdf, "/GoTo");
+            QPDFObjectHandle next = QPDFObjectHandle::newArray();
+            next.appendItem(pdf_security_action(*pdf, "/Launch"));
+            next.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            owner.replaceKey("/Next", next);
+            root.replaceKey("/OpenAction", owner);
+            pdf_security_set_custom_alias(root, owner);
+        } else if (scenario == "alias_direct_aa_custom") {
+            QPDFObjectHandle owner = pdf_security_action(*pdf, "/GoTo");
+            owner.replaceKey(
+                "/AA", QPDFObjectHandle::newDictionary({
+                    {"/E", pdf_security_action(*pdf, "/Launch")},
+                    {"/X", pdf_security_action(*pdf, "/GoTo")}}));
+            root.replaceKey("/OpenAction", owner);
+            pdf_security_set_custom_alias(root, owner);
+        } else if (scenario == "alias_direct_annots_custom") {
+            QPDFObjectHandle owner = pdf_security_action(*pdf, "/GoTo");
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/RichMedia")}}));
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/Text")}}));
+            owner.replaceKey("/Annots", annots);
+            root.replaceKey("/OpenAction", owner);
+            pdf_security_set_custom_alias(root, owner);
+        } else if (scenario == "alias_direct_page_annots_custom") {
+            QPDFObjectHandle annots = QPDFObjectHandle::newArray();
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/RichMedia")}}));
+            annots.appendItem(QPDFObjectHandle::newDictionary({
+                {"/Subtype", QPDFObjectHandle::newName("/Text")}}));
+            pages[0].replaceKey("/Annots", annots);
+            pdf_security_set_custom_alias(root, pages[0]);
+        } else if (scenario == "alias_direct_js_names_custom") {
+            QPDFObjectHandle pairs = QPDFObjectHandle::newArray();
+            pairs.appendItem(QPDFObjectHandle::newString("a"));
+            pairs.appendItem(pdf_security_action(*pdf, "/Launch"));
+            pairs.appendItem(QPDFObjectHandle::newString("b"));
+            pairs.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            QPDFObjectHandle tree = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Names", pairs}}));
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
+            pdf_security_set_custom_alias(root, tree);
+        } else if (scenario == "alias_direct_js_limits_custom") {
+            QPDFObjectHandle pairs = QPDFObjectHandle::newArray();
+            pairs.appendItem(QPDFObjectHandle::newString("alpha"));
+            pairs.appendItem(pdf_security_action(*pdf, "/Launch"));
+            pairs.appendItem(QPDFObjectHandle::newString("bravo"));
+            pairs.appendItem(pdf_security_action(*pdf, "/GoTo"));
+            QPDFObjectHandle leaf = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Names", pairs}}));
+            pdf_security_set_name_tree_limits(leaf, "alpha", "bravo");
+            QPDFObjectHandle kids = QPDFObjectHandle::newArray();
+            kids.appendItem(leaf);
+            QPDFObjectHandle tree = pdf->makeIndirectObject(
+                QPDFObjectHandle::newDictionary({{"/Kids", kids}}));
+            pdf_security_set_name_tree_limits(tree, "alpha", "bravo");
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", tree}}));
+            pdf_security_set_custom_alias(root, tree);
+        } else if (scenario == "alias_direct_catalog_names_custom") {
+            root.replaceKey(
+                "/Names", QPDFObjectHandle::newDictionary({
+                    {"/JavaScript", QPDFObjectHandle::newDictionary()}}));
+            pdf_security_set_custom_alias(root, root);
+        } else if (scenario == "alias_direct_acroform_custom") {
+            root.replaceKey(
+                "/AcroForm", QPDFObjectHandle::newDictionary({
+                    {"/Fields", QPDFObjectHandle::newArray()},
+                    {"/XFA", QPDFObjectHandle::newString("xfa")}}));
+            pdf_security_set_custom_alias(root, root);
+        } else if (scenario == "alias_direct_af_ef_custom") {
+            QPDFObjectHandle owner = pdf_security_action(*pdf, "/GoTo");
+            owner.replaceKey(
+                "/QuantaPDFChild", QPDFObjectHandle::newDictionary({
+                    {"/AF", QPDFObjectHandle::newArray()},
+                    {"/EF", QPDFObjectHandle::newDictionary()}}));
+            root.replaceKey("/OpenAction", owner);
+            pdf_security_set_custom_alias(root, owner);
+        } else if (scenario == "alias_direct_action_owner_custom") {
+            QPDFObjectHandle owner = pdf_security_action(*pdf, "/GoTo");
+            owner.replaceKey(
+                "/QuantaPDFChild", QPDFObjectHandle::newDictionary({
+                    {"/A", pdf_security_action(*pdf, "/Launch")}}));
+            root.replaceKey("/OpenAction", owner);
+            pdf_security_set_custom_alias(root, owner);
         } else if (scenario == "alias_annots_custom") {
             QPDFObjectHandle annots = QPDFObjectHandle::newArray();
             annots.appendItem(QPDFObjectHandle::newDictionary({

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -919,6 +919,8 @@ static void test_sanitize_ambiguous_aliases(void)
                                        QUANTAPDF_SANITIZE_RICH_MEDIA},
         {"alias_direct_page_annots_custom", QUANTAPDF_AUDIT_RICH_MEDIA,
                                             QUANTAPDF_SANITIZE_RICH_MEDIA},
+        {"annotation_custom_alias", QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                                    QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
         {"alias_direct_js_names_custom",
                                QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
                                QUANTAPDF_AUDIT_LAUNCH_ACTION,
@@ -972,6 +974,79 @@ static void test_sanitize_ambiguous_aliases(void)
             quantapdf_close(document);
         }
     }
+}
+
+static void test_sanitize_annotation_backlinks(void)
+{
+    static const struct backlink_case {
+        uint32_t flag;
+        uint32_t remaining;
+        const char *output_name;
+    } page_cases[] = {
+        {QUANTAPDF_SANITIZE_RICH_MEDIA,
+         QUANTAPDF_AUDIT_EMBEDDED_FILE,
+         "annotation-page-rich-output"},
+        {QUANTAPDF_SANITIZE_EMBEDDED_FILES,
+         QUANTAPDF_AUDIT_RICH_MEDIA,
+         "annotation-page-attachment-output"}
+    };
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = NULL;
+    char path[512];
+    char output_path[512];
+    size_t index;
+
+    for (index = 0;
+         index < sizeof(page_cases) / sizeof(page_cases[0]);
+         ++index) {
+        begin_case(index == 0
+            ? "sanitize_rich_annotation_with_page_backlink"
+            : "sanitize_attachment_with_page_backlink");
+        if (!create_fixture("annotation_page_backlinks", path, sizeof(path)))
+            continue;
+        expect_document_audit(
+            path, NULL, QUANTAPDF_OK,
+            QUANTAPDF_AUDIT_EMBEDDED_FILE |
+                QUANTAPDF_AUDIT_RICH_MEDIA);
+        CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+        if (document == NULL)
+            continue;
+        CHECK(quantapdf_sanitize(
+                  document, page_cases[index].flag, &output) ==
+              QUANTAPDF_OK);
+        CHECK(output != NULL);
+        if (output != NULL && save_sanitized_output(
+                output, page_cases[index].output_name, output_path,
+                sizeof(output_path))) {
+            expect_document_audit(
+                output_path, NULL, QUANTAPDF_OK,
+                page_cases[index].remaining);
+        }
+        quantapdf_drop_output(output);
+        quantapdf_close(document);
+        output = NULL;
+        document = NULL;
+    }
+
+    begin_case("sanitize_actions_with_annotation_graph_backlinks");
+    if (!create_fixture("annotation_reply_popup_links", path, sizeof(path)))
+        return;
+    expect_document_audit(
+        path, NULL, QUANTAPDF_OK, QUANTAPDF_AUDIT_LAUNCH_ACTION);
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    CHECK(quantapdf_sanitize(
+              document, QUANTAPDF_SANITIZE_LAUNCH_ACTIONS, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL && save_sanitized_output(
+            output, "annotation-links-output", output_path,
+            sizeof(output_path))) {
+        expect_document_audit(output_path, NULL, QUANTAPDF_OK, 0);
+    }
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
 }
 
 static void test_sanitize_strict_failures_and_arguments(void)
@@ -1099,6 +1174,7 @@ int main(void)
     test_sanitize_shared_selected_containers();
     test_sanitize_javascript_name_tree_actions();
     test_sanitize_ambiguous_aliases();
+    test_sanitize_annotation_backlinks();
     test_sanitize_strict_failures_and_arguments();
     if (failures != 0)
         fprintf(stderr, "pdf_security: %d checks failed\n", failures);

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -17,6 +17,10 @@ int pdf_security_inspect_output(
     uint32_t *out_markers,
     int *out_has_object_stream);
 
+int pdf_security_inspect_empty_containers(
+    const unsigned char *data,
+    size_t size);
+
 enum {
     PDF_SECURITY_SAFE_GOTO_MARKER = 1u << 7
 };
@@ -130,6 +134,22 @@ static uint32_t inspect_sanitized_output(
     CHECK(pdf_security_inspect_output(
         data, size, &markers, out_has_object_stream));
     return markers;
+}
+
+static int inspect_sanitized_empty_containers(quantapdf_output *output)
+{
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    int mask;
+
+    CHECK(quantapdf_output_data(output, &data, &size) == QUANTAPDF_OK);
+    CHECK(data != NULL);
+    CHECK(size != 0);
+    if (data == NULL || size == 0)
+        return -1;
+    mask = pdf_security_inspect_empty_containers(data, size);
+    CHECK(mask >= 0);
+    return mask;
 }
 
 static int save_sanitized_output(
@@ -578,6 +598,76 @@ cleanup:
     quantapdf_close(source);
 }
 
+static void test_sanitize_empty_container_policy_isolation(void)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = NULL;
+    char path[512];
+
+    begin_case("sanitize_preserves_empty_unselected_containers");
+    if (!create_fixture(
+            "sanitize_empty_unselected", path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    audit.struct_size = sizeof(audit);
+    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    CHECK(audit.findings == 0);
+    CHECK(quantapdf_sanitize(document, QUANTAPDF_SANITIZE_XFA, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL)
+        CHECK(inspect_sanitized_empty_containers(output) == 7);
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
+
+    begin_case("sanitize_removes_containers_emptied_by_selected_content");
+    document = NULL;
+    output = NULL;
+    if (!create_fixture(
+            "sanitize_selected_to_empty", path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    audit.findings = 0;
+    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    CHECK(audit.findings == QUANTAPDF_AUDIT_JAVASCRIPT_ACTION);
+    CHECK(quantapdf_sanitize(
+              document, QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL)
+        CHECK(inspect_sanitized_empty_containers(output) == 0);
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
+}
+
+static void test_sanitize_mutation_budget_exhaustion(void)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+    char path[512];
+
+    begin_case("sanitize_mutation_budget_exhaustion");
+    if (!create_fixture(
+            "mutation_budget_shared_next", path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    audit.struct_size = sizeof(audit);
+    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    CHECK(audit.findings == 0);
+    CHECK(quantapdf_sanitize(document, QUANTAPDF_SANITIZE_XFA, &output) ==
+          QUANTAPDF_ERROR_UNSUPPORTED);
+    CHECK(output == NULL);
+    quantapdf_close(document);
+}
+
 static void expect_sanitize_failure(
     const char *path,
     const char *password,
@@ -696,6 +786,8 @@ int main(void)
     test_extended_result_and_repeatability();
     test_sanitize_policy_isolation_and_all();
     test_sanitize_ownership_and_canonical_output();
+    test_sanitize_empty_container_policy_isolation();
+    test_sanitize_mutation_budget_exhaustion();
     test_sanitize_strict_failures_and_arguments();
     if (failures != 0)
         fprintf(stderr, "pdf_security: %d checks failed\n", failures);

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -4,6 +4,29 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+enum pdf_security_fixture_kind {
+    PDF_SECURITY_FIXTURE_INTERNAL_GOTO = 1,
+    PDF_SECURITY_FIXTURE_JAVASCRIPT = 2,
+    PDF_SECURITY_FIXTURE_LAUNCH = 3,
+    PDF_SECURITY_FIXTURE_EXTERNAL = 4,
+    PDF_SECURITY_FIXTURE_OTHER = 5,
+    PDF_SECURITY_FIXTURE_EMBEDDED = 6,
+    PDF_SECURITY_FIXTURE_XFA = 7,
+    PDF_SECURITY_FIXTURE_RICH_MEDIA = 8,
+    PDF_SECURITY_FIXTURE_UNREACHABLE = 9,
+    PDF_SECURITY_FIXTURE_MALFORMED_A = 10,
+    PDF_SECURITY_FIXTURE_MALFORMED_AA = 11,
+    PDF_SECURITY_FIXTURE_MALFORMED_NAMES = 12,
+    PDF_SECURITY_FIXTURE_MALFORMED_ANNOTS = 13,
+    PDF_SECURITY_FIXTURE_MALFORMED_ANNOT_ENTRY = 14
+};
+
+int pdf_security_create_fixture(
+    const char *source_path,
+    const char *output_path,
+    int kind);
 
 static void check_impl(int condition, const char *expression, int line)
 {
@@ -14,6 +37,45 @@ static void check_impl(int condition, const char *expression, int line)
 }
 
 #define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static void fixture_path(int kind, char *path, size_t size)
+{
+    int written = snprintf(
+        path, size, "%s/pdf-security-%d.pdf", SECURITY_FIXTURE_DIR, kind);
+    CHECK(written > 0 && (size_t)written < size);
+}
+
+static void create_fixture(int kind, char *path, size_t size)
+{
+    fixture_path(kind, path, size);
+    CHECK(pdf_security_create_fixture(SECURITY_PDF, path, kind));
+}
+
+static uint32_t audit_path(const char *path, const char *password)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+
+    CHECK(quantapdf_open(path, password, &document) == QUANTAPDF_OK);
+    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
+    audit.findings = UINT32_MAX;
+    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    quantapdf_close(document);
+    return audit.findings;
+}
+
+static void expect_audit_error(const char *path, quantapdf_status expected)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
+    audit.findings = UINT32_MAX;
+    CHECK(quantapdf_document_audit(document, &audit) == expected);
+    CHECK(audit.findings == 0);
+    quantapdf_close(document);
+}
 
 static void test_public_contract(void)
 {
@@ -59,35 +121,112 @@ static void test_public_contract(void)
           QUANTAPDF_ERROR_ARGUMENT);
 }
 
-static void test_placeholder_contract(void)
+static void test_clean_internal_and_extended_result(void)
+{
+    struct extended_audit_result {
+        quantapdf_audit_result v1;
+        unsigned char suffix[16];
+    } audit;
+    unsigned char expected_suffix[sizeof(audit.suffix)];
+    quantapdf_document *document = NULL;
+    char path[512];
+
+    CHECK(audit_path(SECURITY_PDF, NULL) == 0);
+    create_fixture(PDF_SECURITY_FIXTURE_INTERNAL_GOTO, path, sizeof(path));
+    CHECK(audit_path(path, NULL) == 0);
+
+    memset(&audit, 0xa5, sizeof(audit));
+    memcpy(expected_suffix, audit.suffix, sizeof(expected_suffix));
+    audit.v1.struct_size = sizeof(audit);
+    audit.v1.findings = UINT32_MAX;
+    CHECK(quantapdf_open(SECURITY_PDF, NULL, &document) == QUANTAPDF_OK);
+    CHECK(quantapdf_document_audit(document, &audit.v1) == QUANTAPDF_OK);
+    CHECK(audit.v1.struct_size == sizeof(audit));
+    CHECK(audit.v1.findings == 0);
+    CHECK(memcmp(audit.suffix, expected_suffix, sizeof(audit.suffix)) == 0);
+    quantapdf_close(document);
+}
+
+static void test_isolated_findings_and_repeatability(void)
+{
+    static const struct {
+        int kind;
+        uint32_t finding;
+    } cases[] = {
+        {PDF_SECURITY_FIXTURE_JAVASCRIPT,
+         QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {PDF_SECURITY_FIXTURE_LAUNCH, QUANTAPDF_AUDIT_LAUNCH_ACTION},
+        {PDF_SECURITY_FIXTURE_EXTERNAL, QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {PDF_SECURITY_FIXTURE_OTHER, QUANTAPDF_AUDIT_OTHER_ACTION},
+        {PDF_SECURITY_FIXTURE_EMBEDDED, QUANTAPDF_AUDIT_EMBEDDED_FILE},
+        {PDF_SECURITY_FIXTURE_XFA, QUANTAPDF_AUDIT_XFA},
+        {PDF_SECURITY_FIXTURE_RICH_MEDIA, QUANTAPDF_AUDIT_RICH_MEDIA}
+    };
+    quantapdf_audit_result first = {0};
+    quantapdf_audit_result second = {0};
+    quantapdf_document *document = NULL;
+    size_t index;
+    char path[512];
+
+    for (index = 0; index < sizeof(cases) / sizeof(cases[0]); ++index) {
+        create_fixture(cases[index].kind, path, sizeof(path));
+        CHECK(audit_path(path, NULL) == cases[index].finding);
+    }
+    CHECK(audit_path(SECURITY_SIGNED_PDF, NULL) ==
+          QUANTAPDF_AUDIT_SIGNATURE);
+    CHECK(audit_path(SECURITY_ENCRYPTED_PDF, "user-pass") ==
+          QUANTAPDF_AUDIT_ENCRYPTION);
+
+    create_fixture(PDF_SECURITY_FIXTURE_JAVASCRIPT, path, sizeof(path));
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    first.struct_size = sizeof(first);
+    second.struct_size = sizeof(second);
+    CHECK(quantapdf_document_audit(document, &first) == QUANTAPDF_OK);
+    CHECK(quantapdf_document_audit(document, &second) == QUANTAPDF_OK);
+    CHECK(first.findings == QUANTAPDF_AUDIT_JAVASCRIPT_ACTION);
+    CHECK(second.findings == first.findings);
+    quantapdf_close(document);
+}
+
+static void test_reachability_and_malformed_inputs(void)
+{
+    static const int malformed[] = {
+        PDF_SECURITY_FIXTURE_MALFORMED_A,
+        PDF_SECURITY_FIXTURE_MALFORMED_AA,
+        PDF_SECURITY_FIXTURE_MALFORMED_NAMES,
+        PDF_SECURITY_FIXTURE_MALFORMED_ANNOTS,
+        PDF_SECURITY_FIXTURE_MALFORMED_ANNOT_ENTRY
+    };
+    size_t index;
+    char path[512];
+
+    create_fixture(PDF_SECURITY_FIXTURE_UNREACHABLE, path, sizeof(path));
+    CHECK(audit_path(path, NULL) == 0);
+    for (index = 0; index < sizeof(malformed) / sizeof(malformed[0]); ++index) {
+        create_fixture(malformed[index], path, sizeof(path));
+        expect_audit_error(path, QUANTAPDF_ERROR_FORMAT);
+    }
+}
+
+static void test_sanitize_stays_unsupported(void)
 {
     quantapdf_audit_result audit = {0};
     quantapdf_document *document = NULL;
     quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
 
     CHECK(quantapdf_open(SECURITY_PDF, NULL, &document) == QUANTAPDF_OK);
-
     audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE - 1u;
     audit.findings = UINT32_MAX;
     CHECK(quantapdf_document_audit(document, &audit) ==
           QUANTAPDF_ERROR_ARGUMENT);
     CHECK(audit.findings == UINT32_MAX);
-
-    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
-    audit.findings = UINT32_MAX;
-    CHECK(quantapdf_document_audit(document, &audit) ==
-          QUANTAPDF_ERROR_UNSUPPORTED);
-    CHECK(audit.findings == 0);
-
     CHECK(quantapdf_sanitize(document, 0, &output) ==
           QUANTAPDF_ERROR_ARGUMENT);
     CHECK(output == NULL);
-
     output = (quantapdf_output *)(uintptr_t)1;
     CHECK(quantapdf_sanitize(document, UINT32_C(1) << 31, &output) ==
           QUANTAPDF_ERROR_ARGUMENT);
     CHECK(output == NULL);
-
     output = (quantapdf_output *)(uintptr_t)1;
     CHECK(quantapdf_sanitize(document, QUANTAPDF_SANITIZE_ALL, &output) ==
           QUANTAPDF_ERROR_UNSUPPORTED);
@@ -98,6 +237,9 @@ static void test_placeholder_contract(void)
 int main(void)
 {
     test_public_contract();
-    test_placeholder_contract();
+    test_clean_internal_and_extended_result();
+    test_isolated_findings_and_repeatability();
+    test_reachability_and_malformed_inputs();
+    test_sanitize_stays_unsupported();
     return EXIT_SUCCESS;
 }

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -21,6 +21,11 @@ int pdf_security_inspect_empty_containers(
     const unsigned char *data,
     size_t size);
 
+int pdf_security_inspect_shared_container_owners(
+    const unsigned char *data,
+    size_t size,
+    int inspect_next);
+
 enum {
     PDF_SECURITY_SAFE_GOTO_MARKER = 1u << 7
 };
@@ -148,6 +153,25 @@ static int inspect_sanitized_empty_containers(quantapdf_output *output)
     if (data == NULL || size == 0)
         return -1;
     mask = pdf_security_inspect_empty_containers(data, size);
+    CHECK(mask >= 0);
+    return mask;
+}
+
+static int inspect_sanitized_shared_container_owners(
+    quantapdf_output *output,
+    int inspect_next)
+{
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    int mask;
+
+    CHECK(quantapdf_output_data(output, &data, &size) == QUANTAPDF_OK);
+    CHECK(data != NULL);
+    CHECK(size != 0);
+    if (data == NULL || size == 0)
+        return -1;
+    mask = pdf_security_inspect_shared_container_owners(
+        data, size, inspect_next);
     CHECK(mask >= 0);
     return mask;
 }
@@ -668,6 +692,46 @@ static void test_sanitize_mutation_budget_exhaustion(void)
     quantapdf_close(document);
 }
 
+static void expect_sanitize_shared_container_cleanup(
+    const char *scenario,
+    int inspect_next)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = NULL;
+    char path[512];
+
+    if (!create_fixture(scenario, path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    audit.struct_size = sizeof(audit);
+    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    CHECK(audit.findings == QUANTAPDF_AUDIT_JAVASCRIPT_ACTION);
+    CHECK(quantapdf_sanitize(
+              document, QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL) {
+        CHECK(inspect_sanitized_shared_container_owners(
+                  output, inspect_next) == 0);
+    }
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
+}
+
+static void test_sanitize_shared_selected_containers(void)
+{
+    begin_case("sanitize_cleans_all_shared_selected_aa_owners");
+    expect_sanitize_shared_container_cleanup(
+        "sanitize_shared_selected_aa", 0);
+
+    begin_case("sanitize_cleans_all_shared_selected_next_owners");
+    expect_sanitize_shared_container_cleanup(
+        "sanitize_shared_selected_next", 1);
+}
+
 static void expect_sanitize_failure(
     const char *path,
     const char *password,
@@ -788,6 +852,7 @@ int main(void)
     test_sanitize_ownership_and_canonical_output();
     test_sanitize_empty_container_policy_isolation();
     test_sanitize_mutation_budget_exhaustion();
+    test_sanitize_shared_selected_containers();
     test_sanitize_strict_failures_and_arguments();
     if (failures != 0)
         fprintf(stderr, "pdf_security: %d checks failed\n", failures);

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -1,0 +1,103 @@
+#include <quantapdf/quantapdf.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void check_impl(int condition, const char *expression, int line)
+{
+    if (!condition) {
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK(expression) check_impl((expression), #expression, __LINE__)
+
+static void test_public_contract(void)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+
+    CHECK(QUANTAPDF_AUDIT_JAVASCRIPT_ACTION == (1u << 0));
+    CHECK(QUANTAPDF_AUDIT_LAUNCH_ACTION == (1u << 1));
+    CHECK(QUANTAPDF_AUDIT_EXTERNAL_ACTION == (1u << 2));
+    CHECK(QUANTAPDF_AUDIT_OTHER_ACTION == (1u << 3));
+    CHECK(QUANTAPDF_AUDIT_EMBEDDED_FILE == (1u << 4));
+    CHECK(QUANTAPDF_AUDIT_XFA == (1u << 5));
+    CHECK(QUANTAPDF_AUDIT_RICH_MEDIA == (1u << 6));
+    CHECK(QUANTAPDF_AUDIT_SIGNATURE == (1u << 7));
+    CHECK(QUANTAPDF_AUDIT_ENCRYPTION == (1u << 8));
+    CHECK(QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS == (1u << 0));
+    CHECK(QUANTAPDF_SANITIZE_LAUNCH_ACTIONS == (1u << 1));
+    CHECK(QUANTAPDF_SANITIZE_EXTERNAL_ACTIONS == (1u << 2));
+    CHECK(QUANTAPDF_SANITIZE_OTHER_ACTIONS == (1u << 3));
+    CHECK(QUANTAPDF_SANITIZE_EMBEDDED_FILES == (1u << 4));
+    CHECK(QUANTAPDF_SANITIZE_XFA == (1u << 5));
+    CHECK(QUANTAPDF_SANITIZE_RICH_MEDIA == (1u << 6));
+    CHECK(QUANTAPDF_SANITIZE_ALL == ((1u << 7) - 1u));
+    CHECK(QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE ==
+          offsetof(quantapdf_audit_result, findings) + sizeof(audit.findings));
+    CHECK(QUANTAPDF_AUDIT_RESULT_V1_SIZE == sizeof(audit));
+
+    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
+    audit.findings = UINT32_MAX;
+    CHECK(quantapdf_document_audit(NULL, &audit) == QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(audit.findings == 0);
+    CHECK(quantapdf_document_audit(NULL, NULL) == QUANTAPDF_ERROR_ARGUMENT);
+
+    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE - 1u;
+    audit.findings = UINT32_MAX;
+    CHECK(quantapdf_document_audit(NULL, &audit) == QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(audit.findings == UINT32_MAX);
+
+    CHECK(quantapdf_sanitize(NULL, QUANTAPDF_SANITIZE_ALL, &output) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(output == NULL);
+    CHECK(quantapdf_sanitize(NULL, QUANTAPDF_SANITIZE_ALL, NULL) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+}
+
+static void test_placeholder_contract(void)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+
+    CHECK(quantapdf_open(SECURITY_PDF, NULL, &document) == QUANTAPDF_OK);
+
+    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE - 1u;
+    audit.findings = UINT32_MAX;
+    CHECK(quantapdf_document_audit(document, &audit) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(audit.findings == UINT32_MAX);
+
+    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
+    audit.findings = UINT32_MAX;
+    CHECK(quantapdf_document_audit(document, &audit) ==
+          QUANTAPDF_ERROR_UNSUPPORTED);
+    CHECK(audit.findings == 0);
+
+    CHECK(quantapdf_sanitize(document, 0, &output) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(output == NULL);
+
+    output = (quantapdf_output *)(uintptr_t)1;
+    CHECK(quantapdf_sanitize(document, UINT32_C(1) << 31, &output) ==
+          QUANTAPDF_ERROR_ARGUMENT);
+    CHECK(output == NULL);
+
+    output = (quantapdf_output *)(uintptr_t)1;
+    CHECK(quantapdf_sanitize(document, QUANTAPDF_SANITIZE_ALL, &output) ==
+          QUANTAPDF_ERROR_UNSUPPORTED);
+    CHECK(output == NULL);
+    quantapdf_close(document);
+}
+
+int main(void)
+{
+    test_public_contract();
+    test_placeholder_contract();
+    return EXIT_SUCCESS;
+}

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -331,6 +331,18 @@ static void test_valid_audit_matrix(void)
         {"open_destination_string", 0},
         {"action_javascript", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
         {"names_javascript", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {"name_tree_safe", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {"name_tree_head_launch", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                                  QUANTAPDF_AUDIT_LAUNCH_ACTION},
+        {"name_tree_next_javascript", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                                      QUANTAPDF_AUDIT_LAUNCH_ACTION},
+        {"name_tree_next_launch", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                                  QUANTAPDF_AUDIT_LAUNCH_ACTION},
+        {"name_tree_next_external", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                                    QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {"name_tree_next_other", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                                 QUANTAPDF_AUDIT_OTHER_ACTION},
+        {"name_tree_cycle", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
         {"action_launch", QUANTAPDF_AUDIT_LAUNCH_ACTION},
         {"external_uri", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
         {"external_gotor", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
@@ -386,6 +398,16 @@ static void test_malformed_and_budget_matrix(void)
         "malformed_aa_entry",
         "malformed_next",
         "malformed_names",
+        "malformed_js_tree_node",
+        "malformed_js_tree_kids",
+        "malformed_js_tree_kid",
+        "malformed_js_tree_names",
+        "malformed_js_tree_odd_names",
+        "malformed_js_tree_key",
+        "malformed_js_tree_value",
+        "malformed_js_tree_action",
+        "malformed_js_tree_both",
+        "malformed_js_tree_limits",
         "malformed_annots",
         "malformed_annot_entry",
         "malformed_acroform",
@@ -401,7 +423,8 @@ static void test_malformed_and_budget_matrix(void)
     static const char *budget[] = {
         "budget_shared_next",
         "budget_shared_aa",
-        "budget_shared_annots"
+        "budget_shared_annots",
+        "budget_js_name_tree"
     };
     size_t index;
 
@@ -749,6 +772,149 @@ static void expect_sanitize_failure(
     quantapdf_close(document);
 }
 
+static void test_sanitize_javascript_name_tree_actions(void)
+{
+    quantapdf_audit_result audit = {0};
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = NULL;
+    char path[512];
+    char output_path[512];
+    uint32_t markers;
+    int has_object_stream = -1;
+
+    begin_case("sanitize_name_tree_launch_continuation");
+    if (!create_fixture("name_tree_next_launch", path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    audit.struct_size = sizeof(audit);
+    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    CHECK(audit.findings == (QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                             QUANTAPDF_AUDIT_LAUNCH_ACTION));
+    CHECK(quantapdf_sanitize(
+              document, QUANTAPDF_SANITIZE_LAUNCH_ACTIONS, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL) {
+        markers = inspect_sanitized_output(output, &has_object_stream);
+        CHECK(markers == PDF_SECURITY_SAFE_GOTO_MARKER);
+        if (save_sanitized_output(
+                output, "name-tree-launch-output", output_path,
+                sizeof(output_path))) {
+            expect_document_audit(
+                output_path, NULL, QUANTAPDF_OK,
+                QUANTAPDF_AUDIT_JAVASCRIPT_ACTION);
+        }
+    }
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
+
+    begin_case("sanitize_name_tree_selected_head");
+    document = NULL;
+    output = NULL;
+    if (!create_fixture("name_tree_head_launch", path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    CHECK(quantapdf_sanitize(
+              document, QUANTAPDF_SANITIZE_LAUNCH_ACTIONS, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL && save_sanitized_output(
+            output, "name-tree-head-output", output_path,
+            sizeof(output_path))) {
+        expect_document_audit(
+            output_path, NULL, QUANTAPDF_OK,
+            QUANTAPDF_AUDIT_JAVASCRIPT_ACTION);
+    }
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
+
+    begin_case("sanitize_name_tree_whole_javascript_policy");
+    document = NULL;
+    output = NULL;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document != NULL) {
+        CHECK(quantapdf_sanitize(
+                  document, QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS,
+                  &output) == QUANTAPDF_OK);
+        CHECK(output != NULL);
+        if (output != NULL && save_sanitized_output(
+                output, "name-tree-javascript-output", output_path,
+                sizeof(output_path))) {
+            expect_document_audit(output_path, NULL, QUANTAPDF_OK, 0);
+        }
+        quantapdf_drop_output(output);
+        quantapdf_close(document);
+    }
+}
+
+static void test_sanitize_ambiguous_aliases(void)
+{
+    static const struct alias_case {
+        const char *scenario;
+        uint32_t findings;
+        uint32_t flag;
+    } cases[] = {
+        {"alias_annots_next", QUANTAPDF_AUDIT_LAUNCH_ACTION |
+                              QUANTAPDF_AUDIT_RICH_MEDIA,
+                              QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_annots_next", QUANTAPDF_AUDIT_LAUNCH_ACTION |
+                              QUANTAPDF_AUDIT_RICH_MEDIA,
+                              QUANTAPDF_SANITIZE_RICH_MEDIA},
+        {"alias_names_custom", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION,
+                               QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS},
+        {"alias_js_names_array_custom",
+                               QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                               QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                               QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_acroform_custom", QUANTAPDF_AUDIT_XFA,
+                                  QUANTAPDF_SANITIZE_XFA},
+        {"alias_aa_custom", QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                            QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_next_custom", QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                              QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_openaction_next_custom", QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                                         QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_annots_custom", QUANTAPDF_AUDIT_RICH_MEDIA,
+                                QUANTAPDF_SANITIZE_RICH_MEDIA},
+        {"alias_af_custom", QUANTAPDF_AUDIT_EMBEDDED_FILE,
+                            QUANTAPDF_SANITIZE_EMBEDDED_FILES},
+        {"alias_ef_custom", QUANTAPDF_AUDIT_EMBEDDED_FILE,
+                            QUANTAPDF_SANITIZE_EMBEDDED_FILES}
+    };
+    char path[512];
+    size_t index;
+
+    for (index = 0; index < sizeof(cases) / sizeof(cases[0]); ++index) {
+        begin_case(cases[index].scenario);
+        if (!create_fixture(cases[index].scenario, path, sizeof(path)))
+            continue;
+        expect_document_audit(
+            path, NULL, QUANTAPDF_OK, cases[index].findings);
+        expect_sanitize_failure(
+            path, NULL, cases[index].flag,
+            QUANTAPDF_ERROR_UNSUPPORTED);
+    }
+
+    begin_case("alias_unselected_policy_is_allowed");
+    if (create_fixture("alias_annots_next", path, sizeof(path))) {
+        quantapdf_document *document = NULL;
+        quantapdf_output *output = NULL;
+        CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+        if (document != NULL) {
+            CHECK(quantapdf_sanitize(
+                      document, QUANTAPDF_SANITIZE_XFA, &output) ==
+                  QUANTAPDF_OK);
+            CHECK(output != NULL);
+            quantapdf_drop_output(output);
+            quantapdf_close(document);
+        }
+    }
+}
+
 static void test_sanitize_strict_failures_and_arguments(void)
 {
     static const char *malformed[] = {
@@ -758,6 +924,16 @@ static void test_sanitize_strict_failures_and_arguments(void)
         "malformed_aa_entry",
         "malformed_next",
         "malformed_names",
+        "malformed_js_tree_node",
+        "malformed_js_tree_kids",
+        "malformed_js_tree_kid",
+        "malformed_js_tree_names",
+        "malformed_js_tree_odd_names",
+        "malformed_js_tree_key",
+        "malformed_js_tree_value",
+        "malformed_js_tree_action",
+        "malformed_js_tree_both",
+        "malformed_js_tree_limits",
         "malformed_annots",
         "malformed_annot_entry",
         "malformed_acroform",
@@ -773,7 +949,8 @@ static void test_sanitize_strict_failures_and_arguments(void)
     static const char *budget[] = {
         "budget_shared_next",
         "budget_shared_aa",
-        "budget_shared_annots"
+        "budget_shared_annots",
+        "budget_js_name_tree"
     };
     quantapdf_document *document = NULL;
     quantapdf_output *output;
@@ -853,6 +1030,8 @@ int main(void)
     test_sanitize_empty_container_policy_isolation();
     test_sanitize_mutation_budget_exhaustion();
     test_sanitize_shared_selected_containers();
+    test_sanitize_javascript_name_tree_actions();
+    test_sanitize_ambiguous_aliases();
     test_sanitize_strict_failures_and_arguments();
     if (failures != 0)
         fprintf(stderr, "pdf_security: %d checks failed\n", failures);

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -6,75 +6,102 @@
 #include <stdlib.h>
 #include <string.h>
 
-enum pdf_security_fixture_kind {
-    PDF_SECURITY_FIXTURE_INTERNAL_GOTO = 1,
-    PDF_SECURITY_FIXTURE_JAVASCRIPT = 2,
-    PDF_SECURITY_FIXTURE_LAUNCH = 3,
-    PDF_SECURITY_FIXTURE_EXTERNAL = 4,
-    PDF_SECURITY_FIXTURE_OTHER = 5,
-    PDF_SECURITY_FIXTURE_EMBEDDED = 6,
-    PDF_SECURITY_FIXTURE_XFA = 7,
-    PDF_SECURITY_FIXTURE_RICH_MEDIA = 8,
-    PDF_SECURITY_FIXTURE_UNREACHABLE = 9,
-    PDF_SECURITY_FIXTURE_MALFORMED_A = 10,
-    PDF_SECURITY_FIXTURE_MALFORMED_AA = 11,
-    PDF_SECURITY_FIXTURE_MALFORMED_NAMES = 12,
-    PDF_SECURITY_FIXTURE_MALFORMED_ANNOTS = 13,
-    PDF_SECURITY_FIXTURE_MALFORMED_ANNOT_ENTRY = 14
-};
-
 int pdf_security_create_fixture(
     const char *source_path,
     const char *output_path,
-    int kind);
+    const char *scenario);
+
+static int failures;
+static const char *current_case = "startup";
+
+static void begin_case(const char *name)
+{
+    current_case = name;
+    printf("CASE %s\n", name);
+}
 
 static void check_impl(int condition, const char *expression, int line)
 {
     if (!condition) {
-        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, line, expression);
-        exit(EXIT_FAILURE);
+        fprintf(
+            stderr, "%s:%d: [%s] check failed: %s\n",
+            __FILE__, line, current_case, expression);
+        ++failures;
     }
 }
 
 #define CHECK(expression) check_impl((expression), #expression, __LINE__)
 
-static void fixture_path(int kind, char *path, size_t size)
+static int fixture_path(
+    const char *scenario,
+    char *path,
+    size_t size)
 {
     int written = snprintf(
-        path, size, "%s/pdf-security-%d.pdf", SECURITY_FIXTURE_DIR, kind);
+        path, size, "%s/pdf-security-%s.pdf",
+        SECURITY_FIXTURE_DIR, scenario);
     CHECK(written > 0 && (size_t)written < size);
+    return written > 0 && (size_t)written < size;
 }
 
-static void create_fixture(int kind, char *path, size_t size)
+static int create_fixture(
+    const char *scenario,
+    char *path,
+    size_t size)
 {
-    fixture_path(kind, path, size);
-    CHECK(pdf_security_create_fixture(SECURITY_PDF, path, kind));
+    int created;
+    if (!fixture_path(scenario, path, size))
+        return 0;
+    created = pdf_security_create_fixture(SECURITY_PDF, path, scenario);
+    CHECK(created);
+    return created;
 }
 
-static uint32_t audit_path(const char *path, const char *password)
+static void expect_document_audit(
+    const char *path,
+    const char *password,
+    quantapdf_status expected_status,
+    uint32_t expected_findings)
 {
     quantapdf_audit_result audit = {0};
     quantapdf_document *document = NULL;
+    quantapdf_status open_status = quantapdf_open(path, password, &document);
+    quantapdf_status status;
 
-    CHECK(quantapdf_open(path, password, &document) == QUANTAPDF_OK);
+    CHECK(open_status == QUANTAPDF_OK);
+    if (open_status != QUANTAPDF_OK)
+        return;
     audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
     audit.findings = UINT32_MAX;
-    CHECK(quantapdf_document_audit(document, &audit) == QUANTAPDF_OK);
+    status = quantapdf_document_audit(document, &audit);
+    if (status != expected_status) {
+        fprintf(
+            stderr,
+            "[%s] audit status: expected %d, got %d\n",
+            current_case, (int)expected_status, (int)status);
+    }
+    if (audit.findings != expected_findings) {
+        fprintf(
+            stderr,
+            "[%s] audit findings: expected 0x%08x, got 0x%08x\n",
+            current_case, expected_findings, audit.findings);
+    }
+    CHECK(status == expected_status);
+    CHECK(audit.findings == expected_findings);
     quantapdf_close(document);
-    return audit.findings;
 }
 
-static void expect_audit_error(const char *path, quantapdf_status expected)
+static void expect_fixture(
+    const char *scenario,
+    quantapdf_status expected_status,
+    uint32_t expected_findings)
 {
-    quantapdf_audit_result audit = {0};
-    quantapdf_document *document = NULL;
-
-    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
-    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_SIZE;
-    audit.findings = UINT32_MAX;
-    CHECK(quantapdf_document_audit(document, &audit) == expected);
-    CHECK(audit.findings == 0);
-    quantapdf_close(document);
+    char path[512];
+    begin_case(scenario);
+    if (!create_fixture(scenario, path, sizeof(path)))
+        return;
+    expect_document_audit(
+        path, NULL, expected_status, expected_findings);
 }
 
 static void test_public_contract(void)
@@ -82,6 +109,7 @@ static void test_public_contract(void)
     quantapdf_audit_result audit = {0};
     quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
 
+    begin_case("public_contract");
     CHECK(QUANTAPDF_AUDIT_JAVASCRIPT_ACTION == (1u << 0));
     CHECK(QUANTAPDF_AUDIT_LAUNCH_ACTION == (1u << 1));
     CHECK(QUANTAPDF_AUDIT_EXTERNAL_ACTION == (1u << 2));
@@ -108,7 +136,6 @@ static void test_public_contract(void)
     CHECK(quantapdf_document_audit(NULL, &audit) == QUANTAPDF_ERROR_ARGUMENT);
     CHECK(audit.findings == 0);
     CHECK(quantapdf_document_audit(NULL, NULL) == QUANTAPDF_ERROR_ARGUMENT);
-
     audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE - 1u;
     audit.findings = UINT32_MAX;
     CHECK(quantapdf_document_audit(NULL, &audit) == QUANTAPDF_ERROR_ARGUMENT);
@@ -121,64 +148,137 @@ static void test_public_contract(void)
           QUANTAPDF_ERROR_ARGUMENT);
 }
 
-static void test_clean_internal_and_extended_result(void)
+static void test_valid_audit_matrix(void)
+{
+    static const struct audit_case {
+        const char *scenario;
+        uint32_t findings;
+    } cases[] = {
+        {"internal_goto", 0},
+        {"open_destination_array", 0},
+        {"open_destination_name", 0},
+        {"open_destination_string", 0},
+        {"action_javascript", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {"names_javascript", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {"action_launch", QUANTAPDF_AUDIT_LAUNCH_ACTION},
+        {"external_uri", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {"external_gotor", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {"external_gotoe", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {"external_submitform", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {"external_importdata", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
+        {"other_unknown", QUANTAPDF_AUDIT_OTHER_ACTION},
+        {"goto_next_other", QUANTAPDF_AUDIT_OTHER_ACTION},
+        {"names_embedded", QUANTAPDF_AUDIT_EMBEDDED_FILE},
+        {"af_embedded", QUANTAPDF_AUDIT_EMBEDDED_FILE},
+        {"ef_embedded", QUANTAPDF_AUDIT_EMBEDDED_FILE},
+        {"embedded_stream", QUANTAPDF_AUDIT_EMBEDDED_FILE},
+        {"file_attachment", QUANTAPDF_AUDIT_EMBEDDED_FILE},
+        {"xfa", QUANTAPDF_AUDIT_XFA},
+        {"rich_richmedia", QUANTAPDF_AUDIT_RICH_MEDIA},
+        {"rich_3d", QUANTAPDF_AUDIT_RICH_MEDIA},
+        {"rich_movie", QUANTAPDF_AUDIT_RICH_MEDIA},
+        {"rich_sound", QUANTAPDF_AUDIT_RICH_MEDIA},
+        {"rich_screen", QUANTAPDF_AUDIT_RICH_MEDIA},
+        {"inherited_signature", QUANTAPDF_AUDIT_SIGNATURE},
+        {"perms_docmdp", QUANTAPDF_AUDIT_SIGNATURE},
+        {"perms_ur", QUANTAPDF_AUDIT_SIGNATURE},
+        {"perms_ur3", QUANTAPDF_AUDIT_SIGNATURE},
+        {"unreachable_javascript", 0},
+        {"nonroot_names", 0},
+        {"nonroot_acroform", 0},
+        {"action_cycle", 0}
+    };
+    size_t index;
+
+    begin_case("clean");
+    expect_document_audit(SECURITY_PDF, NULL, QUANTAPDF_OK, 0);
+    for (index = 0; index < sizeof(cases) / sizeof(cases[0]); ++index)
+        expect_fixture(cases[index].scenario, QUANTAPDF_OK,
+                       cases[index].findings);
+
+    begin_case("signed_fixture");
+    expect_document_audit(
+        SECURITY_SIGNED_PDF, NULL, QUANTAPDF_OK,
+        QUANTAPDF_AUDIT_SIGNATURE);
+    begin_case("encrypted_fixture");
+    expect_document_audit(
+        SECURITY_ENCRYPTED_PDF, "user-pass", QUANTAPDF_OK,
+        QUANTAPDF_AUDIT_ENCRYPTION);
+}
+
+static void test_malformed_and_budget_matrix(void)
+{
+    static const char *malformed[] = {
+        "malformed_open_action",
+        "malformed_a",
+        "malformed_aa_container",
+        "malformed_aa_entry",
+        "malformed_next",
+        "malformed_names",
+        "malformed_annots",
+        "malformed_annot_entry",
+        "malformed_acroform",
+        "malformed_fields",
+        "malformed_field",
+        "malformed_signature_value",
+        "malformed_signature_type",
+        "parent_mismatch",
+        "malformed_perms",
+        "malformed_perms_signature",
+        "malformed_perms_type"
+    };
+    static const char *budget[] = {
+        "budget_shared_next",
+        "budget_shared_aa",
+        "budget_shared_annots"
+    };
+    size_t index;
+
+    for (index = 0; index < sizeof(malformed) / sizeof(malformed[0]); ++index)
+        expect_fixture(malformed[index], QUANTAPDF_ERROR_FORMAT, 0);
+    for (index = 0; index < sizeof(budget) / sizeof(budget[0]); ++index)
+        expect_fixture(budget[index], QUANTAPDF_ERROR_UNSUPPORTED, 0);
+}
+
+static void test_extended_result_and_repeatability(void)
 {
     struct extended_audit_result {
         quantapdf_audit_result v1;
         unsigned char suffix[16];
-    } audit;
-    unsigned char expected_suffix[sizeof(audit.suffix)];
-    quantapdf_document *document = NULL;
-    char path[512];
-
-    CHECK(audit_path(SECURITY_PDF, NULL) == 0);
-    create_fixture(PDF_SECURITY_FIXTURE_INTERNAL_GOTO, path, sizeof(path));
-    CHECK(audit_path(path, NULL) == 0);
-
-    memset(&audit, 0xa5, sizeof(audit));
-    memcpy(expected_suffix, audit.suffix, sizeof(expected_suffix));
-    audit.v1.struct_size = sizeof(audit);
-    audit.v1.findings = UINT32_MAX;
-    CHECK(quantapdf_open(SECURITY_PDF, NULL, &document) == QUANTAPDF_OK);
-    CHECK(quantapdf_document_audit(document, &audit.v1) == QUANTAPDF_OK);
-    CHECK(audit.v1.struct_size == sizeof(audit));
-    CHECK(audit.v1.findings == 0);
-    CHECK(memcmp(audit.suffix, expected_suffix, sizeof(audit.suffix)) == 0);
-    quantapdf_close(document);
-}
-
-static void test_isolated_findings_and_repeatability(void)
-{
-    static const struct {
-        int kind;
-        uint32_t finding;
-    } cases[] = {
-        {PDF_SECURITY_FIXTURE_JAVASCRIPT,
-         QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
-        {PDF_SECURITY_FIXTURE_LAUNCH, QUANTAPDF_AUDIT_LAUNCH_ACTION},
-        {PDF_SECURITY_FIXTURE_EXTERNAL, QUANTAPDF_AUDIT_EXTERNAL_ACTION},
-        {PDF_SECURITY_FIXTURE_OTHER, QUANTAPDF_AUDIT_OTHER_ACTION},
-        {PDF_SECURITY_FIXTURE_EMBEDDED, QUANTAPDF_AUDIT_EMBEDDED_FILE},
-        {PDF_SECURITY_FIXTURE_XFA, QUANTAPDF_AUDIT_XFA},
-        {PDF_SECURITY_FIXTURE_RICH_MEDIA, QUANTAPDF_AUDIT_RICH_MEDIA}
-    };
+    } extended;
+    unsigned char expected_suffix[sizeof(extended.suffix)];
     quantapdf_audit_result first = {0};
     quantapdf_audit_result second = {0};
     quantapdf_document *document = NULL;
-    size_t index;
+    quantapdf_status status;
     char path[512];
 
-    for (index = 0; index < sizeof(cases) / sizeof(cases[0]); ++index) {
-        create_fixture(cases[index].kind, path, sizeof(path));
-        CHECK(audit_path(path, NULL) == cases[index].finding);
+    begin_case("extended_result");
+    memset(&extended, 0xa5, sizeof(extended));
+    memcpy(expected_suffix, extended.suffix, sizeof(expected_suffix));
+    extended.v1.struct_size = sizeof(extended);
+    extended.v1.findings = UINT32_MAX;
+    status = quantapdf_open(SECURITY_PDF, NULL, &document);
+    CHECK(status == QUANTAPDF_OK);
+    if (status == QUANTAPDF_OK) {
+        CHECK(quantapdf_document_audit(document, &extended.v1) ==
+              QUANTAPDF_OK);
+        CHECK(extended.v1.struct_size == sizeof(extended));
+        CHECK(extended.v1.findings == 0);
+        CHECK(memcmp(
+                  extended.suffix, expected_suffix,
+                  sizeof(extended.suffix)) == 0);
+        quantapdf_close(document);
     }
-    CHECK(audit_path(SECURITY_SIGNED_PDF, NULL) ==
-          QUANTAPDF_AUDIT_SIGNATURE);
-    CHECK(audit_path(SECURITY_ENCRYPTED_PDF, "user-pass") ==
-          QUANTAPDF_AUDIT_ENCRYPTION);
 
-    create_fixture(PDF_SECURITY_FIXTURE_JAVASCRIPT, path, sizeof(path));
-    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    begin_case("repeatability");
+    document = NULL;
+    if (!create_fixture("action_javascript", path, sizeof(path)))
+        return;
+    status = quantapdf_open(path, NULL, &document);
+    CHECK(status == QUANTAPDF_OK);
+    if (status != QUANTAPDF_OK)
+        return;
     first.struct_size = sizeof(first);
     second.struct_size = sizeof(second);
     CHECK(quantapdf_document_audit(document, &first) == QUANTAPDF_OK);
@@ -188,33 +288,18 @@ static void test_isolated_findings_and_repeatability(void)
     quantapdf_close(document);
 }
 
-static void test_reachability_and_malformed_inputs(void)
-{
-    static const int malformed[] = {
-        PDF_SECURITY_FIXTURE_MALFORMED_A,
-        PDF_SECURITY_FIXTURE_MALFORMED_AA,
-        PDF_SECURITY_FIXTURE_MALFORMED_NAMES,
-        PDF_SECURITY_FIXTURE_MALFORMED_ANNOTS,
-        PDF_SECURITY_FIXTURE_MALFORMED_ANNOT_ENTRY
-    };
-    size_t index;
-    char path[512];
-
-    create_fixture(PDF_SECURITY_FIXTURE_UNREACHABLE, path, sizeof(path));
-    CHECK(audit_path(path, NULL) == 0);
-    for (index = 0; index < sizeof(malformed) / sizeof(malformed[0]); ++index) {
-        create_fixture(malformed[index], path, sizeof(path));
-        expect_audit_error(path, QUANTAPDF_ERROR_FORMAT);
-    }
-}
-
 static void test_sanitize_stays_unsupported(void)
 {
     quantapdf_audit_result audit = {0};
     quantapdf_document *document = NULL;
     quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+    quantapdf_status status;
 
-    CHECK(quantapdf_open(SECURITY_PDF, NULL, &document) == QUANTAPDF_OK);
+    begin_case("sanitize_placeholder");
+    status = quantapdf_open(SECURITY_PDF, NULL, &document);
+    CHECK(status == QUANTAPDF_OK);
+    if (status != QUANTAPDF_OK)
+        return;
     audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE - 1u;
     audit.findings = UINT32_MAX;
     CHECK(quantapdf_document_audit(document, &audit) ==
@@ -237,9 +322,11 @@ static void test_sanitize_stays_unsupported(void)
 int main(void)
 {
     test_public_contract();
-    test_clean_internal_and_extended_result();
-    test_isolated_findings_and_repeatability();
-    test_reachability_and_malformed_inputs();
+    test_valid_audit_matrix();
+    test_malformed_and_budget_matrix();
+    test_extended_result_and_repeatability();
     test_sanitize_stays_unsupported();
-    return EXIT_SUCCESS;
+    if (failures != 0)
+        fprintf(stderr, "pdf_security: %d checks failed\n", failures);
+    return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -11,6 +11,16 @@ int pdf_security_create_fixture(
     const char *output_path,
     const char *scenario);
 
+int pdf_security_inspect_output(
+    const unsigned char *data,
+    size_t size,
+    uint32_t *out_markers,
+    int *out_has_object_stream);
+
+enum {
+    PDF_SECURITY_SAFE_GOTO_MARKER = 1u << 7
+};
+
 static int failures;
 static const char *current_case = "startup";
 
@@ -102,6 +112,123 @@ static void expect_fixture(
         return;
     expect_document_audit(
         path, NULL, expected_status, expected_findings);
+}
+
+static uint32_t inspect_sanitized_output(
+    quantapdf_output *output,
+    int *out_has_object_stream)
+{
+    const unsigned char *data = NULL;
+    size_t size = 0;
+    uint32_t markers = UINT32_MAX;
+
+    CHECK(quantapdf_output_data(output, &data, &size) == QUANTAPDF_OK);
+    CHECK(data != NULL);
+    CHECK(size != 0);
+    if (data == NULL || size == 0)
+        return UINT32_MAX;
+    CHECK(pdf_security_inspect_output(
+        data, size, &markers, out_has_object_stream));
+    return markers;
+}
+
+static int save_sanitized_output(
+    quantapdf_output *output,
+    const char *scenario,
+    char *path,
+    size_t path_size)
+{
+    if (!fixture_path(scenario, path, path_size))
+        return 0;
+    CHECK(quantapdf_output_save_file(output, path) == QUANTAPDF_OK);
+    return 1;
+}
+
+static void expect_document_observations_equal(
+    const char *left_path,
+    const char *right_path)
+{
+    quantapdf_document *left = NULL;
+    quantapdf_document *right = NULL;
+    quantapdf_page *left_page = NULL;
+    quantapdf_page *right_page = NULL;
+    quantapdf_bitmap *left_bitmap = NULL;
+    quantapdf_bitmap *right_bitmap = NULL;
+    quantapdf_rect left_bounds = {0};
+    quantapdf_rect right_bounds = {0};
+    char *left_text = NULL;
+    char *right_text = NULL;
+    const unsigned char *left_pixels = NULL;
+    const unsigned char *right_pixels = NULL;
+    size_t left_text_size = 0;
+    size_t right_text_size = 0;
+    size_t left_pixel_size = 0;
+    size_t right_pixel_size = 0;
+    int left_pages = 0;
+    int right_pages = 0;
+    int left_width = 0;
+    int left_height = 0;
+    int left_stride = 0;
+    int left_components = 0;
+    int right_width = 0;
+    int right_height = 0;
+    int right_stride = 0;
+    int right_components = 0;
+
+    CHECK(quantapdf_open(left_path, NULL, &left) == QUANTAPDF_OK);
+    CHECK(quantapdf_open(right_path, NULL, &right) == QUANTAPDF_OK);
+    if (left == NULL || right == NULL)
+        goto cleanup;
+    CHECK(quantapdf_page_count(left, &left_pages) == QUANTAPDF_OK);
+    CHECK(quantapdf_page_count(right, &right_pages) == QUANTAPDF_OK);
+    CHECK(left_pages == right_pages);
+    if (left_pages <= 0 || right_pages <= 0)
+        goto cleanup;
+    CHECK(quantapdf_load_page(left, 0, &left_page) == QUANTAPDF_OK);
+    CHECK(quantapdf_load_page(right, 0, &right_page) == QUANTAPDF_OK);
+    if (left_page == NULL || right_page == NULL)
+        goto cleanup;
+    CHECK(quantapdf_page_bounds(left_page, &left_bounds) == QUANTAPDF_OK);
+    CHECK(quantapdf_page_bounds(right_page, &right_bounds) == QUANTAPDF_OK);
+    CHECK(memcmp(&left_bounds, &right_bounds, sizeof(left_bounds)) == 0);
+    CHECK(quantapdf_extract_text(
+              left_page, &left_text, &left_text_size) == QUANTAPDF_OK);
+    CHECK(quantapdf_extract_text(
+              right_page, &right_text, &right_text_size) == QUANTAPDF_OK);
+    CHECK(left_text_size == right_text_size);
+    if (left_text_size == right_text_size && left_text_size != 0)
+        CHECK(memcmp(left_text, right_text, left_text_size) == 0);
+    CHECK(quantapdf_render_page(left_page, &left_bitmap) == QUANTAPDF_OK);
+    CHECK(quantapdf_render_page(right_page, &right_bitmap) == QUANTAPDF_OK);
+    if (left_bitmap == NULL || right_bitmap == NULL)
+        goto cleanup;
+    CHECK(quantapdf_bitmap_dimensions(
+              left_bitmap, &left_width, &left_height, &left_stride,
+              &left_components) == QUANTAPDF_OK);
+    CHECK(quantapdf_bitmap_dimensions(
+              right_bitmap, &right_width, &right_height, &right_stride,
+              &right_components) == QUANTAPDF_OK);
+    CHECK(left_width == right_width);
+    CHECK(left_height == right_height);
+    CHECK(left_stride == right_stride);
+    CHECK(left_components == right_components);
+    CHECK(quantapdf_bitmap_data(
+              left_bitmap, &left_pixels, &left_pixel_size) == QUANTAPDF_OK);
+    CHECK(quantapdf_bitmap_data(
+              right_bitmap, &right_pixels, &right_pixel_size) == QUANTAPDF_OK);
+    CHECK(left_pixel_size == right_pixel_size);
+    if (left_pixel_size == right_pixel_size && left_pixel_size != 0)
+        CHECK(memcmp(left_pixels, right_pixels, left_pixel_size) == 0);
+
+cleanup:
+    quantapdf_drop_bitmap(right_bitmap);
+    quantapdf_drop_bitmap(left_bitmap);
+    quantapdf_free(right_text);
+    quantapdf_free(left_text);
+    quantapdf_drop_page(right_page);
+    quantapdf_drop_page(left_page);
+    quantapdf_close(right);
+    quantapdf_close(left);
 }
 
 static void test_public_contract(void)
@@ -288,35 +415,277 @@ static void test_extended_result_and_repeatability(void)
     quantapdf_close(document);
 }
 
-static void test_sanitize_stays_unsupported(void)
+static void test_sanitize_policy_isolation_and_all(void)
 {
-    quantapdf_audit_result audit = {0};
+    static const struct sanitize_case {
+        const char *name;
+        uint32_t flag;
+    } cases[] = {
+        {"sanitize_javascript", QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS},
+        {"sanitize_launch", QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"sanitize_external", QUANTAPDF_SANITIZE_EXTERNAL_ACTIONS},
+        {"sanitize_other", QUANTAPDF_SANITIZE_OTHER_ACTIONS},
+        {"sanitize_embedded", QUANTAPDF_SANITIZE_EMBEDDED_FILES},
+        {"sanitize_xfa", QUANTAPDF_SANITIZE_XFA},
+        {"sanitize_rich_media", QUANTAPDF_SANITIZE_RICH_MEDIA}
+    };
+    quantapdf_audit_result source_audit = {0};
     quantapdf_document *document = NULL;
-    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+    quantapdf_output *output = NULL;
     quantapdf_status status;
+    char source_path[512];
+    char output_path[512];
+    size_t index;
 
-    begin_case("sanitize_placeholder");
-    status = quantapdf_open(SECURITY_PDF, NULL, &document);
+    begin_case("sanitize_combined_fixture");
+    if (!create_fixture(
+            "sanitize_combined", source_path, sizeof(source_path)))
+        return;
+    status = quantapdf_open(source_path, NULL, &document);
     CHECK(status == QUANTAPDF_OK);
     if (status != QUANTAPDF_OK)
         return;
-    audit.struct_size = QUANTAPDF_AUDIT_RESULT_V1_MIN_SIZE - 1u;
-    audit.findings = UINT32_MAX;
-    CHECK(quantapdf_document_audit(document, &audit) ==
-          QUANTAPDF_ERROR_ARGUMENT);
-    CHECK(audit.findings == UINT32_MAX);
-    CHECK(quantapdf_sanitize(document, 0, &output) ==
-          QUANTAPDF_ERROR_ARGUMENT);
-    CHECK(output == NULL);
-    output = (quantapdf_output *)(uintptr_t)1;
-    CHECK(quantapdf_sanitize(document, UINT32_C(1) << 31, &output) ==
-          QUANTAPDF_ERROR_ARGUMENT);
-    CHECK(output == NULL);
-    output = (quantapdf_output *)(uintptr_t)1;
+    source_audit.struct_size = sizeof(source_audit);
+    CHECK(quantapdf_document_audit(document, &source_audit) == QUANTAPDF_OK);
+    CHECK(source_audit.findings == QUANTAPDF_SANITIZE_ALL);
+
+    for (index = 0; index < sizeof(cases) / sizeof(cases[0]); ++index) {
+        uint32_t expected_findings = QUANTAPDF_SANITIZE_ALL & ~cases[index].flag;
+        uint32_t expected_markers = expected_findings |
+            PDF_SECURITY_SAFE_GOTO_MARKER;
+        uint32_t markers;
+        int has_object_stream = -1;
+
+        begin_case(cases[index].name);
+        output = (quantapdf_output *)(uintptr_t)1;
+        CHECK(quantapdf_sanitize(document, cases[index].flag, &output) ==
+              QUANTAPDF_OK);
+        CHECK(output != NULL);
+        if (output == NULL || output == (quantapdf_output *)(uintptr_t)1)
+            continue;
+        markers = inspect_sanitized_output(output, &has_object_stream);
+        CHECK(markers == expected_markers);
+        CHECK(has_object_stream == 0);
+        if (save_sanitized_output(
+                output, "sanitize-policy-output", output_path,
+                sizeof(output_path))) {
+            expect_document_audit(
+                output_path, NULL, QUANTAPDF_OK, expected_findings);
+        }
+        quantapdf_drop_output(output);
+        output = NULL;
+    }
+
+    begin_case("sanitize_all");
     CHECK(quantapdf_sanitize(document, QUANTAPDF_SANITIZE_ALL, &output) ==
-          QUANTAPDF_ERROR_UNSUPPORTED);
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL) {
+        uint32_t markers;
+        int has_object_stream = -1;
+        markers = inspect_sanitized_output(output, &has_object_stream);
+        printf(
+            "RAW sanitize_all markers=0x%08x object_stream=%d\n",
+            markers, has_object_stream);
+        CHECK(markers == PDF_SECURITY_SAFE_GOTO_MARKER);
+        CHECK(has_object_stream == 0);
+        if (save_sanitized_output(
+                output, "sanitize-all-output", output_path,
+                sizeof(output_path))) {
+            expect_document_audit(output_path, NULL, QUANTAPDF_OK, 0);
+            expect_document_observations_equal(source_path, output_path);
+        }
+        quantapdf_drop_output(output);
+    }
+
+    source_audit.findings = 0;
+    CHECK(quantapdf_document_audit(document, &source_audit) == QUANTAPDF_OK);
+    CHECK(source_audit.findings == QUANTAPDF_SANITIZE_ALL);
+    quantapdf_close(document);
+}
+
+static void test_sanitize_ownership_and_canonical_output(void)
+{
+    quantapdf_document *source = NULL;
+    quantapdf_document *reopened = NULL;
+    quantapdf_output *first = NULL;
+    quantapdf_output *second = NULL;
+    quantapdf_output *resanitized = NULL;
+    const unsigned char *first_data = NULL;
+    const unsigned char *second_data = NULL;
+    const unsigned char *resanitized_data = NULL;
+    size_t first_size = 0;
+    size_t second_size = 0;
+    size_t resanitized_size = 0;
+    char source_path[512];
+    char output_path[512];
+    uint32_t markers;
+    int has_object_stream = -1;
+
+    begin_case("sanitize_ownership_and_canonical_output");
+    if (!create_fixture(
+            "sanitize_combined", source_path, sizeof(source_path)))
+        return;
+    CHECK(quantapdf_open(source_path, NULL, &source) == QUANTAPDF_OK);
+    if (source == NULL)
+        return;
+    CHECK(quantapdf_sanitize(source, QUANTAPDF_SANITIZE_ALL, &first) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_sanitize(source, QUANTAPDF_SANITIZE_ALL, &second) ==
+          QUANTAPDF_OK);
+    quantapdf_close(source);
+    source = NULL;
+    CHECK(first != NULL);
+    CHECK(second != NULL);
+    if (first == NULL || second == NULL)
+        goto cleanup;
+    CHECK(quantapdf_output_data(first, &first_data, &first_size) ==
+          QUANTAPDF_OK);
+    CHECK(quantapdf_output_data(second, &second_data, &second_size) ==
+          QUANTAPDF_OK);
+    CHECK(first_size == second_size);
+    if (first_size == second_size)
+        CHECK(memcmp(first_data, second_data, first_size) == 0);
+    markers = inspect_sanitized_output(first, &has_object_stream);
+    CHECK(markers == PDF_SECURITY_SAFE_GOTO_MARKER);
+    CHECK(has_object_stream == 0);
+
+    if (!save_sanitized_output(
+            first, "sanitize-canonical-output", output_path,
+            sizeof(output_path)))
+        goto cleanup;
+    CHECK(quantapdf_open(output_path, NULL, &reopened) == QUANTAPDF_OK);
+    if (reopened == NULL)
+        goto cleanup;
+    CHECK(quantapdf_sanitize(
+              reopened, QUANTAPDF_SANITIZE_ALL, &resanitized) ==
+          QUANTAPDF_OK);
+    CHECK(resanitized != NULL);
+    if (resanitized == NULL)
+        goto cleanup;
+    CHECK(quantapdf_output_data(
+              resanitized, &resanitized_data, &resanitized_size) ==
+          QUANTAPDF_OK);
+    CHECK(resanitized_size == first_size);
+    if (resanitized_size == first_size)
+        CHECK(memcmp(resanitized_data, first_data, first_size) == 0);
+
+cleanup:
+    quantapdf_drop_output(resanitized);
+    quantapdf_close(reopened);
+    quantapdf_drop_output(second);
+    quantapdf_drop_output(first);
+    quantapdf_close(source);
+}
+
+static void expect_sanitize_failure(
+    const char *path,
+    const char *password,
+    uint32_t flags,
+    quantapdf_status expected_status)
+{
+    quantapdf_document *document = NULL;
+    quantapdf_output *output = (quantapdf_output *)(uintptr_t)1;
+
+    CHECK(quantapdf_open(path, password, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    CHECK(quantapdf_sanitize(document, flags, &output) == expected_status);
     CHECK(output == NULL);
     quantapdf_close(document);
+}
+
+static void test_sanitize_strict_failures_and_arguments(void)
+{
+    static const char *malformed[] = {
+        "malformed_open_action",
+        "malformed_a",
+        "malformed_aa_container",
+        "malformed_aa_entry",
+        "malformed_next",
+        "malformed_names",
+        "malformed_annots",
+        "malformed_annot_entry",
+        "malformed_acroform",
+        "malformed_fields",
+        "malformed_field",
+        "malformed_signature_value",
+        "malformed_signature_type",
+        "parent_mismatch",
+        "malformed_perms",
+        "malformed_perms_signature",
+        "malformed_perms_type"
+    };
+    static const char *budget[] = {
+        "budget_shared_next",
+        "budget_shared_aa",
+        "budget_shared_annots"
+    };
+    quantapdf_document *document = NULL;
+    quantapdf_output *output;
+    char path[512];
+    size_t index;
+
+    begin_case("sanitize_arguments");
+    CHECK(quantapdf_open(SECURITY_PDF, NULL, &document) == QUANTAPDF_OK);
+    if (document != NULL) {
+        output = (quantapdf_output *)(uintptr_t)1;
+        CHECK(quantapdf_sanitize(document, 0, &output) ==
+              QUANTAPDF_ERROR_ARGUMENT);
+        CHECK(output == NULL);
+        output = (quantapdf_output *)(uintptr_t)1;
+        CHECK(quantapdf_sanitize(document, UINT32_C(1) << 31, &output) ==
+              QUANTAPDF_ERROR_ARGUMENT);
+        CHECK(output == NULL);
+        quantapdf_close(document);
+    }
+
+    begin_case("sanitize_signed");
+    expect_sanitize_failure(
+        SECURITY_SIGNED_PDF, NULL, QUANTAPDF_SANITIZE_ALL,
+        QUANTAPDF_ERROR_UNSUPPORTED);
+    begin_case("sanitize_encrypted");
+    expect_sanitize_failure(
+        SECURITY_ENCRYPTED_PDF, "user-pass", QUANTAPDF_SANITIZE_ALL,
+        QUANTAPDF_ERROR_UNSUPPORTED);
+
+    begin_case("sanitize_direct_embedded_stream");
+    if (create_fixture("embedded_stream", path, sizeof(path))) {
+        expect_sanitize_failure(
+            path, NULL, QUANTAPDF_SANITIZE_EMBEDDED_FILES,
+            QUANTAPDF_ERROR_UNSUPPORTED);
+    }
+
+    for (index = 0; index < sizeof(malformed) / sizeof(malformed[0]); ++index) {
+        begin_case(malformed[index]);
+        if (create_fixture(malformed[index], path, sizeof(path))) {
+            expect_sanitize_failure(
+                path, NULL, QUANTAPDF_SANITIZE_ALL,
+                QUANTAPDF_ERROR_FORMAT);
+        }
+    }
+    for (index = 0; index < sizeof(budget) / sizeof(budget[0]); ++index) {
+        begin_case(budget[index]);
+        if (create_fixture(budget[index], path, sizeof(path))) {
+            expect_sanitize_failure(
+                path, NULL, QUANTAPDF_SANITIZE_ALL,
+                QUANTAPDF_ERROR_UNSUPPORTED);
+        }
+    }
+
+    begin_case("sanitize_action_cycle");
+    if (create_fixture("action_cycle", path, sizeof(path))) {
+        CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+        if (document != NULL) {
+            output = NULL;
+            CHECK(quantapdf_sanitize(
+                      document, QUANTAPDF_SANITIZE_ALL, &output) ==
+                  QUANTAPDF_OK);
+            CHECK(output != NULL);
+            quantapdf_drop_output(output);
+            quantapdf_close(document);
+        }
+    }
 }
 
 int main(void)
@@ -325,7 +694,9 @@ int main(void)
     test_valid_audit_matrix();
     test_malformed_and_budget_matrix();
     test_extended_result_and_repeatability();
-    test_sanitize_stays_unsupported();
+    test_sanitize_policy_isolation_and_all();
+    test_sanitize_ownership_and_canonical_output();
+    test_sanitize_strict_failures_and_arguments();
     if (failures != 0)
         fprintf(stderr, "pdf_security: %d checks failed\n", failures);
     return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/tests/test_pdf_security.c
+++ b/tests/test_pdf_security.c
@@ -342,7 +342,10 @@ static void test_valid_audit_matrix(void)
                                     QUANTAPDF_AUDIT_EXTERNAL_ACTION},
         {"name_tree_next_other", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
                                  QUANTAPDF_AUDIT_OTHER_ACTION},
-        {"name_tree_cycle", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {"name_tree_valid_multilevel", QUANTAPDF_AUDIT_JAVASCRIPT_ACTION},
+        {"name_tree_limited_head_launch",
+                                  QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                                  QUANTAPDF_AUDIT_LAUNCH_ACTION},
         {"action_launch", QUANTAPDF_AUDIT_LAUNCH_ACTION},
         {"external_uri", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
         {"external_gotor", QUANTAPDF_AUDIT_EXTERNAL_ACTION},
@@ -408,6 +411,14 @@ static void test_malformed_and_budget_matrix(void)
         "malformed_js_tree_action",
         "malformed_js_tree_both",
         "malformed_js_tree_limits",
+        "name_tree_cycle",
+        "name_tree_duplicate_child",
+        "name_tree_unordered_keys",
+        "name_tree_duplicate_keys",
+        "name_tree_reversed_limits",
+        "name_tree_inconsistent_limits",
+        "name_tree_overlapping_kids",
+        "name_tree_out_of_order_kids",
         "malformed_annots",
         "malformed_annot_entry",
         "malformed_acroform",
@@ -832,6 +843,28 @@ static void test_sanitize_javascript_name_tree_actions(void)
     quantapdf_drop_output(output);
     quantapdf_close(document);
 
+    begin_case("sanitize_name_tree_updates_limits");
+    document = NULL;
+    output = NULL;
+    if (!create_fixture("name_tree_limited_head_launch", path, sizeof(path)))
+        return;
+    CHECK(quantapdf_open(path, NULL, &document) == QUANTAPDF_OK);
+    if (document == NULL)
+        return;
+    CHECK(quantapdf_sanitize(
+              document, QUANTAPDF_SANITIZE_LAUNCH_ACTIONS, &output) ==
+          QUANTAPDF_OK);
+    CHECK(output != NULL);
+    if (output != NULL && save_sanitized_output(
+            output, "name-tree-limits-output", output_path,
+            sizeof(output_path))) {
+        expect_document_audit(
+            output_path, NULL, QUANTAPDF_OK,
+            QUANTAPDF_AUDIT_JAVASCRIPT_ACTION);
+    }
+    quantapdf_drop_output(output);
+    quantapdf_close(document);
+
     begin_case("sanitize_name_tree_whole_javascript_policy");
     document = NULL;
     output = NULL;
@@ -878,6 +911,32 @@ static void test_sanitize_ambiguous_aliases(void)
                               QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
         {"alias_openaction_next_custom", QUANTAPDF_AUDIT_LAUNCH_ACTION,
                                          QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_direct_next_custom", QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                                     QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_direct_aa_custom", QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                                   QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_direct_annots_custom", QUANTAPDF_AUDIT_RICH_MEDIA,
+                                       QUANTAPDF_SANITIZE_RICH_MEDIA},
+        {"alias_direct_page_annots_custom", QUANTAPDF_AUDIT_RICH_MEDIA,
+                                            QUANTAPDF_SANITIZE_RICH_MEDIA},
+        {"alias_direct_js_names_custom",
+                               QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                               QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                               QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_direct_js_limits_custom",
+                               QUANTAPDF_AUDIT_JAVASCRIPT_ACTION |
+                               QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                               QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
+        {"alias_direct_catalog_names_custom",
+                               QUANTAPDF_AUDIT_JAVASCRIPT_ACTION,
+                               QUANTAPDF_SANITIZE_JAVASCRIPT_ACTIONS},
+        {"alias_direct_acroform_custom", QUANTAPDF_AUDIT_XFA,
+                                         QUANTAPDF_SANITIZE_XFA},
+        {"alias_direct_af_ef_custom", QUANTAPDF_AUDIT_EMBEDDED_FILE,
+                                       QUANTAPDF_SANITIZE_EMBEDDED_FILES},
+        {"alias_direct_action_owner_custom",
+                               QUANTAPDF_AUDIT_LAUNCH_ACTION,
+                               QUANTAPDF_SANITIZE_LAUNCH_ACTIONS},
         {"alias_annots_custom", QUANTAPDF_AUDIT_RICH_MEDIA,
                                 QUANTAPDF_SANITIZE_RICH_MEDIA},
         {"alias_af_custom", QUANTAPDF_AUDIT_EMBEDDED_FILE,
@@ -934,6 +993,14 @@ static void test_sanitize_strict_failures_and_arguments(void)
         "malformed_js_tree_action",
         "malformed_js_tree_both",
         "malformed_js_tree_limits",
+        "name_tree_cycle",
+        "name_tree_duplicate_child",
+        "name_tree_unordered_keys",
+        "name_tree_duplicate_keys",
+        "name_tree_reversed_limits",
+        "name_tree_inconsistent_limits",
+        "name_tree_overlapping_kids",
+        "name_tree_out_of_order_kids",
         "malformed_annots",
         "malformed_annot_entry",
         "malformed_acroform",

--- a/tests/test_version.c
+++ b/tests/test_version.c
@@ -3,7 +3,7 @@
 #if QUANTAPDF_VERSION_MAJOR != 2
 #error unexpected major version
 #endif
-#if QUANTAPDF_VERSION_MINOR != 2
+#if QUANTAPDF_VERSION_MINOR != 3
 #error unexpected minor version
 #endif
 #if QUANTAPDF_VERSION_PATCH != 0


### PR DESCRIPTION
## Summary

- add additive ABI-v2 `quantapdf_document_audit` and `quantapdf_sanitize` APIs
- audit catalog-reachable JavaScript/actions, embedded files, XFA, rich media, signatures, and encryption with strict bounded traversal
- sanitize selected conventional active-content structures on an immutable private graph with alias preflight, post-audit, deterministic output, and failure-atomic ownership
- document the security boundary and align release metadata to 2.3.0 while retaining ABI/SOVERSION 2

## Security model

- structural PDF inspection, not antivirus or signature cryptographic validation
- malformed conventional structures fail with `QUANTAPDF_ERROR_FORMAT`
- signed/encrypted, over-budget, or unprovable alias/removal cases fail with `QUANTAPDF_ERROR_UNSUPPORTED`
- safe internal `/GoTo` actions are preserved

## Verification

- fresh Windows Release configure/build/install: passed
- CTest: 31/31 passed on `4b94ea096e36db77c6f4bcbd035bf294c4e8e697`
- installed header: 2.3.0 / ABI 2
- installed DLL: exactly 87 unique API exports; audit and sanitize each exported once
- direct installed C consumer: compile, link, and run passed
- full branch review: no open Critical or Important findings

## Merge gate

The `full-ci` label requests Linux release/sanitizer, macOS, and Windows validation on this exact head before merge.