### PR TITLE
docs: close QuantaPDF 2.3.0 release evidence

### DIFF
--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,0 +1,78 @@
+# QuantaPDF 2.3.0
+
+QuantaPDF 2.3.0 is a source-only release of the native PDF kernel. It publishes
+the stable v2 C11 ABI using the `quantapdf_*` namespace and the PDFium + qpdf
+backend only.
+
+## Highlights
+
+- document, page, render, text, structured-text, search, image, link,
+  annotation, form, metadata, and outline APIs;
+- immutable page export, range export, merge, and UTF-8 file output;
+- isolated annotation and AcroForm value editing;
+- immutable CropBox crop, MediaBox trim, poster split, interactive flattening,
+  and deterministic lossless rewrite/garbage collection;
+- catalog-reachable structural security audit;
+- selective immutable sanitization of JavaScript/actions, embedded files, XFA,
+  and rich-media structures.
+
+## ABI and dependencies
+
+- library version: 2.3.0;
+- ABI/SOVERSION: 2;
+- public exports: 87;
+- public header: `<quantapdf/quantapdf.h>`;
+- document/render backend: PDFium 154.0.8021.0;
+- structural rewrite backend: qpdf 12.4.0;
+- no MuPDF or AGPL dependency.
+
+The public ABI exposes no PDFium or qpdf types. Append-only functions and enum
+values may be added within ABI 2; incompatible changes require a new ABI and
+shared-library major version.
+
+## Security boundary
+
+The audit API is strict structural inspection of conventional,
+catalog-reachable PDF mechanisms. It is not antivirus, JavaScript source
+analysis, URL reputation checking, or cryptographic signature validation.
+
+Sanitization never mutates the opened source. It publishes owning immutable
+bytes only after a strict post-audit. Signed, encrypted, over-budget, or
+ambiguous cross-role/custom-alias inputs fail closed with
+`QUANTAPDF_ERROR_UNSUPPORTED`; malformed conventional structures return
+`QUANTAPDF_ERROR_FORMAT`. Safe internal `/GoTo` navigation is preserved.
+
+## Verification
+
+Feature-head evidence belongs to
+[PR #63](https://github.com/qigao/QuantaPDF/pull/63) at
+`75f0f3466ed9e8e374a495855dd261fb17bff2f4`. Release content is rooted at its
+integrated-master merge commit `67d0e0a6c8685e13d524752dd1c1627a05ed7464`,
+plus this release-closure documentation commit.
+
+The feature and integrated-master gates verified:
+
+- Linux static build and Linux ASan/UBSan build;
+- macOS build;
+- Windows DLL build and 31/31 CTests, including Windows-only ABI export checks;
+- installed header version 2.3.0 and ABI 2;
+- exactly 87 unique public exports;
+- direct installed C consumer compile, link, and execution.
+
+The [integrated-master CI run](https://github.com/qigao/QuantaPDF/actions/runs/33461905426)
+passed all four jobs; Linux and macOS completed their respective platform test
+suites.
+
+## Intentional limitations
+
+- image recompression is tracked by [issue #57](https://github.com/qigao/QuantaPDF/issues/57)
+  and is not part of 2.3.0;
+- encryption/decryption/re-encryption transforms are tracked by
+  [issue #58](https://github.com/qigao/QuantaPDF/issues/58) and are not part
+  of 2.3.0;
+- the installed SDK does not yet provide a CMake package config; consumers use
+  the installed header and platform library directly;
+- caller-side serialization remains required by ABI 2.
+
+This release contains no platform-specific SDK or binary assets. Such assets
+may be deliberately added separately without changing the public ABI.

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -60,8 +60,8 @@ The feature and integrated-master gates verified:
 - direct installed C consumer compile, link, and execution.
 
 The [integrated-master CI run](https://github.com/qigao/QuantaPDF/actions/runs/33461905426)
-passed all four jobs; Linux and macOS completed their respective platform test
-suites.
+passed all three jobs: Linux (static and ASan/UBSan), macOS, and Windows. Linux
+and macOS completed their respective platform test suites.
 
 ## Intentional limitations
 

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -50,18 +50,27 @@ Feature-head evidence belongs to
 integrated-master merge commit `67d0e0a6c8685e13d524752dd1c1627a05ed7464`,
 plus this release-closure documentation commit.
 
-The feature and integrated-master gates verified:
+### Pre-merge local Windows Release verification
+
+The completed local Windows Release verification recorded:
+
+- a full configure, build, CTest, and release-install pass;
+- installed header version 2.3.0 and ABI 2;
+- exactly 87 unique public exports; and
+- direct installed C consumer compilation, linking, and execution.
+
+### GitHub CI evidence
+
+The feature head passed the required pre-merge matrix in
+[PR #63](https://github.com/qigao/QuantaPDF/pull/63). The
+[integrated-master CI run](https://github.com/qigao/QuantaPDF/actions/runs/33461905426)
+then passed all three jobs:
 
 - Linux static build and Linux ASan/UBSan build;
 - macOS build;
 - Windows DLL build and 31/31 CTests, including Windows-only ABI export checks;
-- installed header version 2.3.0 and ABI 2;
-- exactly 87 unique public exports;
-- direct installed C consumer compile, link, and execution.
 
-The [integrated-master CI run](https://github.com/qigao/QuantaPDF/actions/runs/33461905426)
-passed all three jobs: Linux (static and ASan/UBSan), macOS, and Windows. Linux
-and macOS completed their respective platform test suites.
+Linux and macOS completed their respective platform test suites.
 
 ## Intentional limitations
 

--- a/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-audit-sanitize.md
@@ -335,8 +335,17 @@ Inspect the diff, search for implementation placeholders and forbidden legacy
 backend/license references, and confirm no generated build/vcpkg files are
 tracked.
 
-- [ ] **Step 5: Complete branch workflow**
+- [x] **Step 5: Complete branch workflow**
 
 Use the finishing-development-branch process, push the reviewed branch, open a
 PR, and require Linux release/sanitizer, macOS, and Windows success on the exact
 head before merge.
+
+Completed by [PR #63](https://github.com/qigao/QuantaPDF/pull/63). Feature head
+`75f0f3466ed9e8e374a495855dd261fb17bff2f4` passed Linux release and
+ASan/UBSan, macOS, and Windows CI before merge. Merge commit
+`67d0e0a6c8685e13d524752dd1c1627a05ed7464` then passed the same integrated
+master matrix in
+[workflow run 33461905426](https://github.com/qigao/QuantaPDF/actions/runs/33461905426).
+The Windows job completed all 31 CTests, including its Windows-only ABI export
+checks; Linux and macOS completed their respective platform test suites.

--- a/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-audit-sanitize-design.md
@@ -208,9 +208,15 @@ Tests prove:
 - NULL, short-structure, zero-flag, unknown-flag, and sentinel-output behavior;
 - exact v2 exports, installed header version, and full local Windows tests.
 
-Before merge, the exact reviewed head must also pass Linux release/sanitizer,
-macOS, and Windows CI. That cross-platform evidence is a pending branch
-integration gate, not evidence supplied by the local Task 4 verification.
+The exact reviewed feature head
+`75f0f3466ed9e8e374a495855dd261fb17bff2f4` passed Linux release and
+ASan/UBSan, macOS, and Windows CI before merge in
+[PR #63](https://github.com/qigao/QuantaPDF/pull/63). PR #63 was integrated as
+`67d0e0a6c8685e13d524752dd1c1627a05ed7464`; the
+[integrated-master workflow run](https://github.com/qigao/QuantaPDF/actions/runs/33461905426)
+repeated that matrix successfully. Its Windows job completed all 31 CTests,
+including the Windows-only ABI export checks; the Linux and macOS jobs
+completed their respective platform test suites.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- close the audit/sanitize implementation and design evidence with exact PR, commit, and CI references
- add QuantaPDF 2.3.0 release notes for the first tagged release
- document version 2.3.0, ABI/SOVERSION 2, 87 exports, PDFium 154.0.8021.0, and qpdf 12.4.0

## Scope

Documentation only. No production code, public headers, ABI baseline, CMake, presets, or workflows change.

## Verification

- Windows Release build completed
- 31/31 CTests passed locally
- independent task review: PASS / APPROVED
- independent whole-branch review: ready to merge

This PR must pass full CI before merge. The v2.3.0 tag and GitHub Release will be created only after the merge commit also passes CI.