### PR TITLE
docs: design bounded image recompression

### DIFF
--- a/docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
@@ -80,13 +80,22 @@ class jpeg_encoder {
         Pipeline* next,
         std::unique_ptr<jpeg_encoder>* out) noexcept;
     Pipeline* pipeline() noexcept;
+
+  private:
+    class impl;
+    explicit jpeg_encoder(std::unique_ptr<impl>) noexcept;
+    std::unique_ptr<impl> impl_;
 };
 }
 ```
 
-The wrapper owns both `Pl_DCT::CompressConfig` and `Pl_DCT`, so the callback
-configuration outlives the pipeline. It accepts decoded bytes incrementally
-and does not expose a raw-sample or encoded-byte vector API.
+`jpeg_encoder::impl` declares its `std::unique_ptr<Pl_DCT::CompressConfig>`
+member before its `std::unique_ptr<Pl_DCT>` member and constructs them in that
+order, so the callback configuration outlives the pipeline and is destroyed
+after it. The private constructor accepts the fully created pImpl, allowing
+the static factory to publish only a usable encoder. The wrapper accepts
+decoded bytes incrementally and does not expose a raw-sample or encoded-byte
+vector API.
 
 - [ ] **Step 1: Add a compile-red characterization test**
 
@@ -167,9 +176,10 @@ because the scaffolded `jpeg_encoder::create()` returns BACKEND.
 - [ ] **Step 3: Implement the minimal fixed encoder**
 
 In `jpeg_encoder.cpp`, validate `next` and `out` first, clear `*out`, use
-checked `width * height * components`, require components 1 or 3 and quality
-1..100, and map observable allocation failure to `QUANTAPDF_ERROR_NOMEM`.
-Configure `Pl_DCT` exactly:
+checked `width * height * components`, independently reject width or height
+above `std::numeric_limits<JDIMENSION>::max()` before converting them, require
+components 1 or 3 and quality 1..100, and map observable allocation failure to
+`QUANTAPDF_ERROR_NOMEM`. Configure `Pl_DCT` exactly:
 
 ```cpp
 auto config = Pl_DCT::make_compress_config(
@@ -231,8 +241,11 @@ dimensions, overflowing dimensions, components 2/4, and qualities 0/101.
 Require `QUANTAPDF_ERROR_ARGUMENT` for invalid factory shape and
 `QUANTAPDF_ERROR_FORMAT` for checked image-size overflow. Exercise short and
 long sample writes and require a caught codec/runtime failure rather than
-memory over-read or partial publication. Record only the controlled-fixture
-facts that quality 40 and 90 bytes differ and quality 100 still emits JPEG.
+memory over-read or partial publication. Add a dimension just above
+`JDIMENSION` maximum when `size_t` can represent it, independent of the
+multiplication-overflow case, and require FORMAT. Record only the
+controlled-fixture facts that quality 40 and 90 bytes differ and quality 100
+still emits JPEG.
 
 Run:
 

--- a/docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
@@ -35,6 +35,7 @@
 - `src/backend/qpdf_document.h`: private recompression bridge declaration.
 - `src/backend/qpdf_document.cpp`: fresh-graph preflight, bounded resource traversal, eligibility, provider registration, and serialization.
 - `tests/test_pdf_image_recompression.c`: public C ABI, ownership, determinism, policy, and error tests.
+- `tests/image_recompression_test_helpers.h`: test-only C bridge declarations.
 - `tests/image_recompression_test_helpers.cpp`: qpdf fixture generation and structural inspection without exposing qpdf publicly.
 - `tests/fixtures/image-recompression-expected-q90.pdf`: checked complete output bytes for the controlled cross-platform quality-90 case.
 - `tests/CMakeLists.txt`: two CTest targets and fixture/output definitions.
@@ -69,21 +70,35 @@ struct jpeg_image_spec {
     int quality;
 };
 
-quantapdf_status encode_jpeg(
-    jpeg_image_spec const& spec,
-    unsigned char const* samples,
-    size_t sample_size,
-    std::vector<unsigned char>* output) noexcept;
+class jpeg_encoder {
+  public:
+    ~jpeg_encoder();
+    jpeg_encoder(jpeg_encoder const&) = delete;
+    jpeg_encoder& operator=(jpeg_encoder const&) = delete;
+    static quantapdf_status create(
+        jpeg_image_spec const& spec,
+        Pipeline* next,
+        std::unique_ptr<jpeg_encoder>* out) noexcept;
+    Pipeline* pipeline() noexcept;
+};
 }
 ```
 
+The wrapper owns both `Pl_DCT::CompressConfig` and `Pl_DCT`, so the callback
+configuration outlives the pipeline. It accepts decoded bytes incrementally
+and does not expose a raw-sample or encoded-byte vector API.
+
 - [ ] **Step 1: Add a compile-red characterization test**
 
-Create `tests/test_jpeg_encoder.cpp` with fixed 8x8 gray and 8x8 RGB arrays.
-Call `encode_jpeg()` at qualities 40, 90, and 100, call each case twice, and
-assert nonempty JPEG SOI/EOI markers plus repeat equality. Reference the
-golden arrays by exact symbol names so the first compile fails until the
-adapter and captured bytes exist:
+Create declaration scaffolding in `jpeg_encoder.h` and a `jpeg_encoder.cpp`
+factory stub that clears `*out` and returns `QUANTAPDF_ERROR_BACKEND`. Create
+`tests/test_jpeg_encoder.cpp` with fixed 8x8 gray and 8x8 RGB arrays. For each
+quality 40, 90, and 100, create a `Pl_Buffer` sink and encoder, write the fixed
+array to `encoder->pipeline()`, finish once, and collect sink bytes. Repeat
+each case and assert JPEG SOI/EOI markers plus equality. Golden arrays are
+added after the first successful local encoding in Step 4. This makes the
+initial RED a deliberate test failure, not a CMake configure failure caused
+by a nonexistent source file.
 
 ```cpp
 static void require_same(std::vector<unsigned char> const& a,
@@ -93,19 +108,29 @@ static void require_same(std::vector<unsigned char> const& a,
         std::abort();
 }
 
+static std::vector<unsigned char> encode_once(
+    quantapdf::detail::jpeg_image_spec const& spec,
+    unsigned char const* samples,
+    size_t size)
+{
+    Pl_Buffer sink("jpeg-golden", nullptr);
+    std::unique_ptr<quantapdf::detail::jpeg_encoder> encoder;
+    if (quantapdf::detail::jpeg_encoder::create(spec, &sink, &encoder) !=
+        QUANTAPDF_OK)
+        std::abort();
+    encoder->pipeline()->write(samples, size);
+    encoder->pipeline()->finish();
+    return copy_buffer(sink);
+}
+
 static void encode_twice(
     quantapdf::detail::jpeg_image_spec const& spec,
     unsigned char const* samples,
     size_t size,
     std::vector<unsigned char> const& golden)
 {
-    std::vector<unsigned char> first;
-    std::vector<unsigned char> second;
-    if (quantapdf::detail::encode_jpeg(spec, samples, size, &first) !=
-            QUANTAPDF_OK ||
-        quantapdf::detail::encode_jpeg(spec, samples, size, &second) !=
-            QUANTAPDF_OK)
-        std::abort();
+    auto first = encode_once(spec, samples, size);
+    auto second = encode_once(spec, samples, size);
     require_same(first, second);
     require_same(first, golden);
 }
@@ -133,16 +158,18 @@ Run:
 ```powershell
 cmake --fresh --preset win-release-user
 cmake --build --preset win-release-user --target quantapdf_test_jpeg_encoder
+ctest --test-dir build/Msvc-Release -R '^quantapdf\.jpeg_encoder$' --output-on-failure
 ```
 
-Expected: compilation fails because `jpeg_encoder.h`, `encode_jpeg`, or the
-golden arrays are not defined.
+Expected: configure and build succeed, then `quantapdf.jpeg_encoder` fails
+because the scaffolded `jpeg_encoder::create()` returns BACKEND.
 
 - [ ] **Step 3: Implement the minimal fixed encoder**
 
-In `jpeg_encoder.cpp`, validate output first, clear it, use checked
-`width * height * components`, require components 1 or 3 and quality 1..100,
-and map allocation to `QUANTAPDF_ERROR_NOMEM`. Configure `Pl_DCT` exactly:
+In `jpeg_encoder.cpp`, validate `next` and `out` first, clear `*out`, use
+checked `width * height * components`, require components 1 or 3 and quality
+1..100, and map observable allocation failure to `QUANTAPDF_ERROR_NOMEM`.
+Configure `Pl_DCT` exactly:
 
 ```cpp
 auto config = Pl_DCT::make_compress_config(
@@ -177,9 +204,12 @@ auto config = Pl_DCT::make_compress_config(
     });
 ```
 
-Write samples through `Pl_DCT` into `Pl_Buffer`, finish once, copy the produced
-buffer into `output`, and catch `std::bad_alloc`, `QPDFExc`, and other
-exceptions at this private boundary.
+Construct the owned configuration before the owned `Pl_DCT` and return its
+pipeline. The test writes fixed samples through it into `Pl_Buffer`; the
+production provider instead pipes decoded qpdf bytes directly into it. Catch
+`std::bad_alloc`, `QPDFExc`, and other exceptions at this private factory
+boundary, with only `std::bad_alloc` mapping to NOMEM and codec/runtime errors
+mapping to BACKEND.
 
 - [ ] **Step 4: Capture Windows bytes and make the local test GREEN**
 
@@ -196,12 +226,13 @@ byte array.
 
 - [ ] **Step 5: Verify adapter errors and byte relationships**
 
-Add cases for null output, null nonempty sample input, zero dimensions,
-overflowing dimensions, wrong sample size, components 2/4, and qualities
-0/101. Require `QUANTAPDF_ERROR_ARGUMENT` for caller-shape errors and
-`QUANTAPDF_ERROR_UNSUPPORTED` for checked size overflow. Record only the
-controlled-fixture facts that quality 40 and 90 bytes differ and quality 100
-still emits JPEG.
+Add factory cases for null downstream pipeline, null output holder, zero
+dimensions, overflowing dimensions, components 2/4, and qualities 0/101.
+Require `QUANTAPDF_ERROR_ARGUMENT` for invalid factory shape and
+`QUANTAPDF_ERROR_FORMAT` for checked image-size overflow. Exercise short and
+long sample writes and require a caught codec/runtime failure rather than
+memory over-read or partial publication. Record only the controlled-fixture
+facts that quality 40 and 90 bytes differ and quality 100 still emits JPEG.
 
 Run:
 
@@ -284,11 +315,9 @@ failure sets output to NULL.
 
 ```cmake
 add_executable(quantapdf_test_pdf_image_recompression
-  test_pdf_image_recompression.c
-  image_recompression_test_helpers.cpp)
+  test_pdf_image_recompression.c)
 target_link_libraries(quantapdf_test_pdf_image_recompression PRIVATE
-  QuantaPDF::QuantaPDF qpdf::libqpdf)
-target_compile_features(quantapdf_test_pdf_image_recompression PRIVATE cxx_std_20)
+  QuantaPDF::QuantaPDF)
 add_test(NAME quantapdf.pdf_image_recompression
   COMMAND quantapdf_test_pdf_image_recompression)
 set_tests_properties(quantapdf.pdf_image_recompression PROPERTIES TIMEOUT 60)
@@ -337,7 +366,7 @@ expects UNSUPPORTED only for valid calls until Task 3 replaces the stub.
 - [ ] **Step 5: Commit the ABI slice**
 
 ```powershell
-git add include/quantapdf/quantapdf.h src/pdf_image_recompression.c src/internal.h src/backend/qpdf_document.h src/backend/qpdf_document.cpp CMakeLists.txt abi/quantapdf-v2.exports tests/test_version.c tests/test_pdf_image_recompression.c tests/image_recompression_test_helpers.cpp tests/CMakeLists.txt
+git add include/quantapdf/quantapdf.h src/pdf_image_recompression.c src/internal.h src/backend/qpdf_document.h src/backend/qpdf_document.cpp CMakeLists.txt abi/quantapdf-v2.exports tests/test_version.c tests/test_pdf_image_recompression.c tests/CMakeLists.txt
 git commit -m "feat: add image recompression ABI"
 ```
 
@@ -345,11 +374,14 @@ git commit -m "feat: add image recompression ABI"
 
 **Files:**
 - Modify: `src/backend/qpdf_document.cpp`
-- Modify: `tests/image_recompression_test_helpers.cpp`
+- Create: `tests/image_recompression_test_helpers.h`
+- Create: `tests/image_recompression_test_helpers.cpp`
 - Modify: `tests/test_pdf_image_recompression.c`
+- Modify: `tests/CMakeLists.txt`
 
 **Interfaces:**
-- Consumes: normalized quality/cap bridge and `encode_jpeg()`.
+- Consumes: normalized quality/cap bridge and the private streaming
+  `jpeg_encoder`.
 - Produces: the complete successful implementation of
   `quantapdf_qpdf_recompress_images()` for eligible images.
 
@@ -360,14 +392,19 @@ In the C++ helper, generate one PDF containing:
 - an opaque 8-bit DeviceRGB image used on two pages;
 - an opaque 8-bit DeviceGray image;
 - the RGB image referenced through a nested Form;
-- another eligible image referenced from annotation `/AP /N` Form resources.
+- eligible images below both annotation and Widget appearances, covering
+  `/AP /N`, `/R`, and `/D` as direct streams and as appearance-state
+  subdictionaries, with a nested Form below every variant.
 
-Expose C helper functions that count unique image `QPDFObjGen` identities,
-return raw Filter/DecodeParms/Width/Height facts, and count resource
-occurrences. In the C test assert the valid transform returns OK, output
-reopens, all eligible unique identities use DCTDecode, the shared object is
-still unique, and source facts remain unchanged. Expected before implementation:
-the stub returns UNSUPPORTED.
+Create the helper header/source, then add them to the target with
+`target_sources`, link the test privately to `qpdf::libqpdf`, and enable
+C++20. Expose C helper functions that count unique image `QPDFObjGen`
+identities, return raw Filter/DecodeParms/Width/Height facts, and count
+resource occurrences. Add test-only counters keyed by `QPDFObjGen` for
+provider registration and invocation. In the C test assert the valid transform
+returns OK, output reopens, all eligible unique identities use DCTDecode, the
+shared object is still unique, and both of its counters equal one. Expected
+before implementation: the stub returns UNSUPPORTED.
 
 - [ ] **Step 2: Implement strict fresh-graph and security preflight**
 
@@ -389,17 +426,27 @@ types, and UNSUPPORTED when the budget is exhausted.
 
 For each unique image, validate keys in the spec's order, use checked
 multiplication for expected bytes, preserve valid ineligible classes, and run
-qpdf's null-pipeline filterability probe at `qpdf_dl_all`. A false probe is a
-preserve decision. For a true probe, use `pipeStreamData` into a counting
-pipeline; only plan the image when decode succeeds and the count equals the
-expected bytes. Candidate decode failure or a new qpdf warning is FORMAT.
+qpdf's null-pipeline filterability probe at `qpdf_dl_all`. Treat a correctly
+sized finite numeric non-identity `/Decode` array as valid/ineligible; treat
+wrong type/length, nonnumeric, or non-finite entries as FORMAT. A false filter
+probe is a preserve decision. For a true probe, use `pipeStreamData` into a
+counting pipeline; only plan the image when decode succeeds and the count
+equals the expected bytes. Candidate decode failure or a new qpdf warning is
+FORMAT.
 
 - [ ] **Step 5: Register providers and rewrite each identity once**
 
 Before replacement, store `image.copyStream()` keyed by `QPDFObjGen`. Register
-one retry-capable provider that decodes the copied stream, invokes the fixed
-encoder, and writes encoded bytes to the supplied writer pipeline. Install
-`/DCTDecode`; install `/ColorTransform 0` only for RGB; call
+one retry-capable provider that constructs the fixed encoder over the supplied
+writer pipeline and calls `copy.pipeStreamData(encoder->pipeline(), ..., qpdf_dl_all)`;
+do not call `getStreamData` or materialize a QuantaPDF raw/encoded vector.
+The source pipeline supplies exactly one downstream `finish()`, which finishes
+`Pl_DCT`; the provider must not finish the encoder a second time.
+Each provider has a first-error `quantapdf_status` latch: `std::bad_alloc`
+latches NOMEM, an explicit private status latches itself, and false
+`pipeStreamData` or any other provider/codec exception latches BACKEND before
+aborting the writer. The outer writer catch returns the latch when non-OK.
+Install `/DCTDecode`; install `/ColorTransform 0` only for RGB; call
 `setFilterOnWrite(false)`. Preserve all non-filter image dictionary keys.
 
 - [ ] **Step 6: Serialize and verify positive GREEN**
@@ -408,6 +455,10 @@ Use the existing deterministic memory writer. After write, reject new warnings
 and publish only the complete buffer. Extend tests to render controlled source
 and output pages with PDFium, require unchanged dimensions/quads/occurrence
 counts, and compare per-channel absolute error against fixture-specific bounds.
+Capture before/after snapshots of text, search results, links, annotations,
+forms, outline, metadata, destinations, and page boxes. Compare raw bytes for
+every page and Form content stream exactly; only eligible image stream bytes
+may change.
 
 Run:
 
@@ -431,7 +482,7 @@ the same serialization.
 - [ ] **Step 8: Commit the successful transform**
 
 ```powershell
-git add src/backend/qpdf_document.cpp tests/image_recompression_test_helpers.cpp tests/test_pdf_image_recompression.c
+git add src/backend/qpdf_document.cpp tests/image_recompression_test_helpers.h tests/image_recompression_test_helpers.cpp tests/test_pdf_image_recompression.c tests/CMakeLists.txt
 git commit -m "feat: recompress eligible PDF images"
 ```
 
@@ -466,24 +517,30 @@ cycles and that classification order handles ImageMask before ColorSpace/BPC.
 - [ ] **Step 3: Write RED malformed and security tests**
 
 Generate malformed resources, XObject containers, appearance state values,
-width/height/BPC/ImageMask/Decode scalars, overflowing dimensions, and corrupt
-eligible stream data. Reuse the repository's signed and encrypted fixtures.
-Require exact FORMAT or UNSUPPORTED outcomes and NULL output.
+width/height/BPC/ImageMask/Decode scalars, wrong-length/nonnumeric/non-finite
+Decode arrays, overflowing image dimensions/products, and corrupt eligible
+stream data. Separately force source-derived traversal-budget overflow and
+exhaustion. Reuse the repository's signed and encrypted fixtures. Require
+exact FORMAT or UNSUPPORTED outcomes and NULL output.
 
 - [ ] **Step 4: Make malformed/security behavior GREEN**
 
-Map consumed structural violations and candidate decode failure to FORMAT;
-map work/cap arithmetic limits that cannot be safely traversed to UNSUPPORTED;
-reuse audit signature/encryption findings. Check `pdf->anyWarnings()` after
-preflight and write.
+Map consumed structural violations, image dimension/product overflow, and
+candidate decode failure to FORMAT. Map only source-derived traversal-budget
+multiplication overflow/exhaustion to UNSUPPORTED; an ordinary image above the
+per-image cap remains valid/ineligible and is preserved. Reuse audit
+signature/encryption findings. Check `pdf->anyWarnings()` after preflight and
+write.
 
 - [ ] **Step 5: Add deterministic fault injection**
 
 Follow existing transform hooks: the test-only C hook exposes integer fault
 points immediately before provider registration, during provider encode, and
-before writer-buffer publication. Every injected failure must leave source
-observations unchanged and output NULL; allocation-style points return NOMEM
-and backend invariant points return BACKEND.
+before writer-buffer publication. Assert the provider's first-status latch is
+returned across the QPDFWriter exception boundary. Every injected failure must
+leave source observations unchanged and output NULL; only observable C/C++
+allocation failures return NOMEM, while simulated codec/provider runtime and
+backend invariant failures return BACKEND.
 
 - [ ] **Step 6: Run sanitizers and commit**
 
@@ -507,14 +564,13 @@ git add src/backend/qpdf_document.cpp tests/test_pdf_image_recompression.c tests
 git commit -m "test: harden image recompression policy"
 ```
 
-### Task 5: Documentation, install notice, ABI consumer, and release gate
+### Task 5: Documentation, install notice, ABI check, and release gate
 
 **Files:**
 - Modify: `README.md`
 - Modify: `THIRD_PARTY.md`
 - Modify: `CMakeLists.txt`
 - Modify: `tests/CMakeLists.txt`
-- Modify: `tests/test_installed_consumer.c`
 - Modify: `docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md`
 - Modify: `docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md`
 
@@ -537,11 +593,14 @@ Derive the package share root as the parent of `qpdf_DIR`, require
 `${CMAKE_INSTALL_DATADIR}/quantapdf/licenses/libjpeg-turbo`. Keep qpdf and
 PDFium notice installation unchanged.
 
-- [ ] **Step 3: Extend the installed C consumer**
+- [ ] **Step 3: Verify the public C and export surfaces**
 
-Compile a `quantapdf_image_recompression_options` initializer, verify the
-2.4.0/ABI 2 macros, and take the address of `quantapdf_recompress_images` so
-the install test proves header, import library, export, and calling convention.
+Keep the public transform test as C, compile its options initializer against
+the sole public header, verify the 2.4.0/ABI 2 macros, and extend the existing
+ABI checker to require exactly the new symbol. Do not claim a relocatable
+CMake package or standalone static installed-consumer test: the project does
+not yet ship package configuration for its private static dependencies, and
+that packaging work is separate from #57.
 
 - [ ] **Step 4: Run the complete local release gate**
 
@@ -553,7 +612,8 @@ cmake --install build/Msvc-Release --prefix build/install-image-recompression
 ```
 
 Expected: 33/33 CTests, version 2.4.0, ABI/SOVERSION 2, exactly 88 exports,
-installed consumer success, and all three dependency notice trees present.
+the public C target linked successfully, and all three dependency notice trees
+present.
 
 - [ ] **Step 5: Update completion evidence and commit**
 
@@ -562,7 +622,7 @@ outputs/commit SHAs. Do not claim PR, full CI, merge, or release before those
 events exist.
 
 ```powershell
-git add README.md THIRD_PARTY.md CMakeLists.txt tests/CMakeLists.txt tests/test_installed_consumer.c docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
+git add README.md THIRD_PARTY.md CMakeLists.txt tests/CMakeLists.txt docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
 git commit -m "docs: document image recompression contract"
 ```
 

--- a/docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
+++ b/docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
@@ -1,0 +1,585 @@
+# QuantaPDF Image Recompression V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship an immutable QuantaPDF 2.4.0 transform that deterministically JPEG-recompresses a strict, bounded class of opaque 8-bit DeviceGray and DeviceRGB Image XObjects.
+
+**Architecture:** qpdf owns strict reachable-resource traversal, unique indirect identity, stream decoding/replacement, and serialization; PDFium verifies render and public observation semantics. A thin private adapter configures qpdf `Pl_DCT` over the already pinned libjpeg-turbo 3.2.0, with an all-platform golden-byte gate before the public ABI is changed.
+
+**Tech Stack:** C11 public facade, C++20 qpdf 12.4.0 backend, qpdf `Pl_DCT`, libjpeg-turbo 3.2.0 from pinned vcpkg, PDFium 154.0.8021.0 verification, CMake Presets, CTest, ASan/UBSan.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md`
+
+## Global Constraints
+
+- Release version is exactly 2.4.0; `QUANTAPDF_ABI_VERSION` and SOVERSION remain 2.
+- The public export baseline grows exactly from 87 to 88 by adding only `quantapdf_recompress_images`.
+- PDFium 154.0.8021.0 and qpdf 12.4.0 remain the only PDF backends.
+- JPEG encode/decode uses qpdf `Pl_DCT` and pinned libjpeg-turbo 3.2.0; no stb, MuPDF, or AGPL dependency is added.
+- Public calls remain externally serialized under ABI v2.
+- Source documents are immutable; output is owning and failure publication is atomic.
+- Signed and encrypted inputs fail with `QUANTAPDF_ERROR_UNSUPPORTED`.
+- Eligible raw samples are bounded per image; zero selects the fixed 64 MiB default.
+- Inline images, resizing, colorspace conversion, alpha flattening, and generic compression policy remain out of scope.
+- A Linux/macOS/Windows golden-byte mismatch stops work before Task 2.
+
+---
+
+## File map
+
+- `src/backend/jpeg_encoder.h`: private fixed-profile encoder declaration and normalized image specification.
+- `src/backend/jpeg_encoder.cpp`: qpdf `Pl_DCT` adapter, checked sample-size validation, and fixed libjpeg configuration.
+- `tests/test_jpeg_encoder.cpp`: backend-private RGB/gray/repeat/golden-byte characterization.
+- `include/quantapdf/quantapdf.h`: append-only options structure, constants, and one public transform declaration.
+- `src/pdf_image_recompression.c`: C validation, option normalization, owning output shell, and failure-atomic publication.
+- `src/backend/qpdf_document.h`: private recompression bridge declaration.
+- `src/backend/qpdf_document.cpp`: fresh-graph preflight, bounded resource traversal, eligibility, provider registration, and serialization.
+- `tests/test_pdf_image_recompression.c`: public C ABI, ownership, determinism, policy, and error tests.
+- `tests/image_recompression_test_helpers.cpp`: qpdf fixture generation and structural inspection without exposing qpdf publicly.
+- `tests/fixtures/image-recompression-expected-q90.pdf`: checked complete output bytes for the controlled cross-platform quality-90 case.
+- `tests/CMakeLists.txt`: two CTest targets and fixture/output definitions.
+- `CMakeLists.txt`: 2.4.0 version, production sources, private JPEG linkage/notice installation.
+- `abi/quantapdf-v2.exports`: one appended symbol.
+- `tests/test_version.c`: 2.4.0, ABI 2, and shared-library major assertions.
+- `README.md`: public usage, lossy boundary, byte cap, ownership, and non-goals.
+- `THIRD_PARTY.md`: direct JPEG behavior, libjpeg-turbo 3.2.0 license, and notice path.
+- `.github/workflows/ci.yml`: no new platform policy; existing full-ci matrix executes both new CTests.
+
+## Phase A integration gate: qualify the encoder before public ABI work
+
+### Task 1: Fixed-profile JPEG adapter and all-platform golden bytes
+
+**Files:**
+- Create: `src/backend/jpeg_encoder.h`
+- Create: `src/backend/jpeg_encoder.cpp`
+- Create: `tests/test_jpeg_encoder.cpp`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `THIRD_PARTY.md`
+
+**Interfaces:**
+- Consumes: qpdf `Pl_DCT`, `Pl_Buffer`, and libjpeg configuration types supplied transitively by `qpdf::libqpdf`.
+- Produces:
+
+```cpp
+namespace quantapdf::detail {
+struct jpeg_image_spec {
+    size_t width;
+    size_t height;
+    int components;
+    int quality;
+};
+
+quantapdf_status encode_jpeg(
+    jpeg_image_spec const& spec,
+    unsigned char const* samples,
+    size_t sample_size,
+    std::vector<unsigned char>* output) noexcept;
+}
+```
+
+- [ ] **Step 1: Add a compile-red characterization test**
+
+Create `tests/test_jpeg_encoder.cpp` with fixed 8x8 gray and 8x8 RGB arrays.
+Call `encode_jpeg()` at qualities 40, 90, and 100, call each case twice, and
+assert nonempty JPEG SOI/EOI markers plus repeat equality. Reference the
+golden arrays by exact symbol names so the first compile fails until the
+adapter and captured bytes exist:
+
+```cpp
+static void require_same(std::vector<unsigned char> const& a,
+                         std::vector<unsigned char> const& b)
+{
+    if (a != b)
+        std::abort();
+}
+
+static void encode_twice(
+    quantapdf::detail::jpeg_image_spec const& spec,
+    unsigned char const* samples,
+    size_t size,
+    std::vector<unsigned char> const& golden)
+{
+    std::vector<unsigned char> first;
+    std::vector<unsigned char> second;
+    if (quantapdf::detail::encode_jpeg(spec, samples, size, &first) !=
+            QUANTAPDF_OK ||
+        quantapdf::detail::encode_jpeg(spec, samples, size, &second) !=
+            QUANTAPDF_OK)
+        std::abort();
+    require_same(first, second);
+    require_same(first, golden);
+}
+```
+
+- [ ] **Step 2: Register the private test and verify compile RED**
+
+Add a target that compiles `src/backend/jpeg_encoder.cpp` directly and links
+`qpdf::libqpdf` without adding the adapter to the production library yet:
+
+```cmake
+add_executable(quantapdf_test_jpeg_encoder
+  test_jpeg_encoder.cpp
+  ../src/backend/jpeg_encoder.cpp)
+target_include_directories(quantapdf_test_jpeg_encoder PRIVATE
+  "${PROJECT_SOURCE_DIR}/include"
+  "${PROJECT_SOURCE_DIR}/src")
+target_link_libraries(quantapdf_test_jpeg_encoder PRIVATE qpdf::libqpdf)
+target_compile_features(quantapdf_test_jpeg_encoder PRIVATE cxx_std_20)
+add_test(NAME quantapdf.jpeg_encoder COMMAND quantapdf_test_jpeg_encoder)
+```
+
+Run:
+
+```powershell
+cmake --fresh --preset win-release-user
+cmake --build --preset win-release-user --target quantapdf_test_jpeg_encoder
+```
+
+Expected: compilation fails because `jpeg_encoder.h`, `encode_jpeg`, or the
+golden arrays are not defined.
+
+- [ ] **Step 3: Implement the minimal fixed encoder**
+
+In `jpeg_encoder.cpp`, validate output first, clear it, use checked
+`width * height * components`, require components 1 or 3 and quality 1..100,
+and map allocation to `QUANTAPDF_ERROR_NOMEM`. Configure `Pl_DCT` exactly:
+
+```cpp
+auto config = Pl_DCT::make_compress_config(
+    [spec](jpeg_compress_struct* cinfo) {
+        jpeg_set_colorspace(
+            cinfo, spec.components == 1 ? JCS_GRAYSCALE : JCS_RGB);
+        jpeg_set_quality(cinfo, spec.quality, TRUE);
+        cinfo->dct_method = JDCT_ISLOW;
+        cinfo->optimize_coding = FALSE;
+        cinfo->arith_code = FALSE;
+        cinfo->smoothing_factor = 0;
+        cinfo->restart_interval = 0;
+        cinfo->restart_in_rows = 0;
+        cinfo->scan_info = nullptr;
+        cinfo->num_scans = 0;
+        if (spec.components == 1) {
+            cinfo->write_JFIF_header = TRUE;
+            cinfo->JFIF_major_version = 1;
+            cinfo->JFIF_minor_version = 1;
+            cinfo->density_unit = 0;
+            cinfo->X_density = 1;
+            cinfo->Y_density = 1;
+            cinfo->write_Adobe_marker = FALSE;
+        } else {
+            cinfo->write_JFIF_header = FALSE;
+            cinfo->write_Adobe_marker = TRUE;
+            for (int i = 0; i < 3; ++i) {
+                cinfo->comp_info[i].h_samp_factor = 1;
+                cinfo->comp_info[i].v_samp_factor = 1;
+            }
+        }
+    });
+```
+
+Write samples through `Pl_DCT` into `Pl_Buffer`, finish once, copy the produced
+buffer into `output`, and catch `std::bad_alloc`, `QPDFExc`, and other
+exceptions at this private boundary.
+
+- [ ] **Step 4: Capture Windows bytes and make the local test GREEN**
+
+Temporarily print each complete byte vector as a C++ initializer, copy those
+six initializers into named `static const std::vector<unsigned char>` golden
+values, remove the print path, rebuild, and run:
+
+```powershell
+ctest --test-dir build/Msvc-Release -R '^quantapdf\.jpeg_encoder$' --output-on-failure
+```
+
+Expected: 1/1 test passes and every repeated result equals its complete golden
+byte array.
+
+- [ ] **Step 5: Verify adapter errors and byte relationships**
+
+Add cases for null output, null nonempty sample input, zero dimensions,
+overflowing dimensions, wrong sample size, components 2/4, and qualities
+0/101. Require `QUANTAPDF_ERROR_ARGUMENT` for caller-shape errors and
+`QUANTAPDF_ERROR_UNSUPPORTED` for checked size overflow. Record only the
+controlled-fixture facts that quality 40 and 90 bytes differ and quality 100
+still emits JPEG.
+
+Run:
+
+```powershell
+ctest --preset win-release-user --output-on-failure
+```
+
+Expected: 32/32 CTests pass.
+
+- [ ] **Step 6: Document the direct codec boundary and notice**
+
+Add a `libjpeg-turbo` section to `THIRD_PARTY.md` stating version 3.2.0,
+pinned-vcpkg provenance, IJG/BSD-style license, that QuantaPDF calls it through
+qpdf `Pl_DCT`, and that binary redistribution installs its copyright. Do not
+claim cross-platform deterministic bytes until Step 8 passes.
+
+- [ ] **Step 7: Commit the private qualification slice**
+
+```powershell
+git add src/backend/jpeg_encoder.h src/backend/jpeg_encoder.cpp tests/test_jpeg_encoder.cpp tests/CMakeLists.txt THIRD_PARTY.md
+git commit -m "test: qualify deterministic JPEG encoding"
+```
+
+- [ ] **Step 8: Review, push, and run exact-head full CI**
+
+Request task and whole-branch review, push a qualification PR with `full-ci`,
+and require the exact commit to pass Linux static, Linux ASan/UBSan, macOS,
+and Windows. The hardcoded complete JPEG arrays make any platform difference
+fail `quantapdf.jpeg_encoder`.
+
+Expected: all jobs pass on one SHA. If any golden-byte comparison differs,
+close the public implementation gate, keep the public header unchanged, and
+revise the design with the observed byte diffs.
+
+- [ ] **Step 9: Merge the qualification PR and verify master CI**
+
+Merge only after exact-head full CI, then require the merge commit's Linux,
+macOS, and Windows jobs to pass. Start Task 2 from that integrated master
+commit; do not stack the public ABI on an unmerged qualification branch.
+
+## Phase B: public transform after the encoder gate is green
+
+### Task 2: Append-only C ABI and failure-atomic facade
+
+**Files:**
+- Modify: `include/quantapdf/quantapdf.h`
+- Create: `src/pdf_image_recompression.c`
+- Modify: `src/internal.h`
+- Modify: `src/backend/qpdf_document.h`
+- Modify: `CMakeLists.txt`
+- Modify: `abi/quantapdf-v2.exports`
+- Modify: `tests/test_version.c`
+- Create: `tests/test_pdf_image_recompression.c`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: the exact public declarations in the design spec and the private
+  encoder qualified by Task 1.
+- Produces:
+
+```c
+quantapdf_status quantapdf_qpdf_recompress_images(
+    quantapdf_qpdf_document *document,
+    int jpeg_quality,
+    size_t max_decoded_bytes_per_image,
+    unsigned char **out_data,
+    size_t *out_size);
+```
+
+- [ ] **Step 1: Write compile-red public contract tests**
+
+Create `test_pdf_image_recompression.c`. Compile references to
+`quantapdf_image_recompression_options`, both size macros, the 64 MiB default,
+and `quantapdf_recompress_images`. Add runtime assertions that null document,
+null options, null output, undersized struct, and qualities 0/101 return
+`QUANTAPDF_ERROR_ARGUMENT`; use a non-NULL sentinel and assert every reachable
+failure sets output to NULL.
+
+- [ ] **Step 2: Register the public target and verify compile RED**
+
+```cmake
+add_executable(quantapdf_test_pdf_image_recompression
+  test_pdf_image_recompression.c
+  image_recompression_test_helpers.cpp)
+target_link_libraries(quantapdf_test_pdf_image_recompression PRIVATE
+  QuantaPDF::QuantaPDF qpdf::libqpdf)
+target_compile_features(quantapdf_test_pdf_image_recompression PRIVATE cxx_std_20)
+add_test(NAME quantapdf.pdf_image_recompression
+  COMMAND quantapdf_test_pdf_image_recompression)
+set_tests_properties(quantapdf.pdf_image_recompression PROPERTIES TIMEOUT 60)
+```
+
+Run the target build. Expected: compilation fails on the missing public type,
+macros, and function.
+
+- [ ] **Step 3: Append the header and facade**
+
+Append the exact spec declarations to the sole public header. Implement the C
+facade with the established output-shell pattern:
+
+```c
+if (out_output == NULL)
+    return QUANTAPDF_ERROR_ARGUMENT;
+*out_output = NULL;
+if (document == NULL || document->qpdf_document == NULL || options == NULL)
+    return QUANTAPDF_ERROR_ARGUMENT;
+```
+
+Read only fields covered by `struct_size`, normalize a missing/zero cap to
+`QUANTAPDF_IMAGE_RECOMPRESSION_DEFAULT_MAX_DECODED_BYTES`, allocate one zeroed
+`quantapdf_output`, call the backend, free shell/data on failure, and publish
+only on success.
+
+- [ ] **Step 4: Add a temporary backend stub and make contract tests GREEN**
+
+Declare the private bridge and return `QUANTAPDF_ERROR_UNSUPPORTED` from a
+temporary backend body after validating/zeroing its raw outputs. Add the C
+source and the already qualified encoder source to the production target.
+Update the version to 2.4.0, keep ABI/SOVERSION 2, append the one export, and
+update exact version/export assertions.
+
+Run:
+
+```powershell
+cmake --fresh --preset win-release-user
+cmake --build --preset win-release-user
+ctest --preset win-release-user --output-on-failure
+```
+
+Expected: 33/33 CTests pass; the new public test passes argument cases and
+expects UNSUPPORTED only for valid calls until Task 3 replaces the stub.
+
+- [ ] **Step 5: Commit the ABI slice**
+
+```powershell
+git add include/quantapdf/quantapdf.h src/pdf_image_recompression.c src/internal.h src/backend/qpdf_document.h src/backend/qpdf_document.cpp CMakeLists.txt abi/quantapdf-v2.exports tests/test_version.c tests/test_pdf_image_recompression.c tests/image_recompression_test_helpers.cpp tests/CMakeLists.txt
+git commit -m "feat: add image recompression ABI"
+```
+
+### Task 3: Bounded graph discovery, eligibility, and positive transform
+
+**Files:**
+- Modify: `src/backend/qpdf_document.cpp`
+- Modify: `tests/image_recompression_test_helpers.cpp`
+- Modify: `tests/test_pdf_image_recompression.c`
+
+**Interfaces:**
+- Consumes: normalized quality/cap bridge and `encode_jpeg()`.
+- Produces: the complete successful implementation of
+  `quantapdf_qpdf_recompress_images()` for eligible images.
+
+- [ ] **Step 1: Generate positive fixtures and write runtime RED tests**
+
+In the C++ helper, generate one PDF containing:
+
+- an opaque 8-bit DeviceRGB image used on two pages;
+- an opaque 8-bit DeviceGray image;
+- the RGB image referenced through a nested Form;
+- another eligible image referenced from annotation `/AP /N` Form resources.
+
+Expose C helper functions that count unique image `QPDFObjGen` identities,
+return raw Filter/DecodeParms/Width/Height facts, and count resource
+occurrences. In the C test assert the valid transform returns OK, output
+reopens, all eligible unique identities use DCTDecode, the shared object is
+still unique, and source facts remain unchanged. Expected before implementation:
+the stub returns UNSUPPORTED.
+
+- [ ] **Step 2: Implement strict fresh-graph and security preflight**
+
+Mirror the lossless/sanitize strict open sequence: create a new QPDF, suppress
+warnings, disable recovery, process the original bytes/password, force pages
+and objects, reject warnings, run the existing audit, and reject signature or
+encryption findings before discovery.
+
+- [ ] **Step 3: Implement iterative reachable-resource discovery**
+
+Reuse `quantapdf_qpdf_work_budget` and its overflow-checked initializer. Seed
+every page effective resource owner plus appearance streams from strict
+`/Annots` and `/AP` traversal. Maintain `std::set<QPDFObjGen>` for resource
+owners and images. For every `/Resources /XObject` entry, collect Image streams
+and queue Form streams. Return FORMAT for consumed wrong container/stream
+types, and UNSUPPORTED when the budget is exhausted.
+
+- [ ] **Step 4: Implement exact eligibility and decode preflight**
+
+For each unique image, validate keys in the spec's order, use checked
+multiplication for expected bytes, preserve valid ineligible classes, and run
+qpdf's null-pipeline filterability probe at `qpdf_dl_all`. A false probe is a
+preserve decision. For a true probe, use `pipeStreamData` into a counting
+pipeline; only plan the image when decode succeeds and the count equals the
+expected bytes. Candidate decode failure or a new qpdf warning is FORMAT.
+
+- [ ] **Step 5: Register providers and rewrite each identity once**
+
+Before replacement, store `image.copyStream()` keyed by `QPDFObjGen`. Register
+one retry-capable provider that decodes the copied stream, invokes the fixed
+encoder, and writes encoded bytes to the supplied writer pipeline. Install
+`/DCTDecode`; install `/ColorTransform 0` only for RGB; call
+`setFilterOnWrite(false)`. Preserve all non-filter image dictionary keys.
+
+- [ ] **Step 6: Serialize and verify positive GREEN**
+
+Use the existing deterministic memory writer. After write, reject new warnings
+and publish only the complete buffer. Extend tests to render controlled source
+and output pages with PDFium, require unchanged dimensions/quads/occurrence
+counts, and compare per-channel absolute error against fixture-specific bounds.
+
+Run:
+
+```powershell
+ctest --test-dir build/Msvc-Release -R '^quantapdf\.(jpeg_encoder|pdf_image_recompression)$' --output-on-failure
+```
+
+Expected: 2/2 selected tests pass.
+
+- [ ] **Step 7: Add determinism, lifetime, and quality cases**
+
+Call the transform twice at quality 90 and require byte equality. Close the
+source before reading/reopening output. Require quality 40 and 90 image stream
+bytes to differ and record controlled fixture size/error ordering. Require
+quality 100 to replace the eligible stream rather than copy its original
+bytes. Save the reviewed quality-90 controlled output as
+`tests/fixtures/image-recompression-expected-q90.pdf`, then compare every test
+run's complete output bytes with that file so Linux, macOS, and Windows prove
+the same serialization.
+
+- [ ] **Step 8: Commit the successful transform**
+
+```powershell
+git add src/backend/qpdf_document.cpp tests/image_recompression_test_helpers.cpp tests/test_pdf_image_recompression.c
+git commit -m "feat: recompress eligible PDF images"
+```
+
+### Task 4: Preservation, limits, malformed input, and fault atomicity
+
+**Files:**
+- Modify: `src/backend/qpdf_document.cpp`
+- Modify: `tests/image_recompression_test_helpers.cpp`
+- Modify: `tests/test_pdf_image_recompression.c`
+- Create: `tests/pdf_image_recompression_fault_hook.c`
+- Create: `tests/pdf_image_recompression_test_api.h`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: Task 3 discovery/eligibility/provider flow.
+- Produces: complete fail-closed and preservation matrix.
+
+- [ ] **Step 1: Write RED preservation and cap-boundary tests**
+
+Generate valid images covering CMYK, ICCBased, Indexed, soft mask, explicit
+mask, color-key mask, stencil, 1/16-bpc, non-identity Decode, unsupported
+filter, inline content, and an XObject/Form cycle. Snapshot each raw ineligible
+stream before and after. For a 2x1 RGB image, require cap 5 to preserve and cap
+6 to rewrite. Expected: any missing classifier or cap rule fails.
+
+- [ ] **Step 2: Make the preservation matrix GREEN**
+
+Refine classification so valid unsupported classes return a preserve decision
+without decoding or mutation. Ensure the image and owner identity sets stop
+cycles and that classification order handles ImageMask before ColorSpace/BPC.
+
+- [ ] **Step 3: Write RED malformed and security tests**
+
+Generate malformed resources, XObject containers, appearance state values,
+width/height/BPC/ImageMask/Decode scalars, overflowing dimensions, and corrupt
+eligible stream data. Reuse the repository's signed and encrypted fixtures.
+Require exact FORMAT or UNSUPPORTED outcomes and NULL output.
+
+- [ ] **Step 4: Make malformed/security behavior GREEN**
+
+Map consumed structural violations and candidate decode failure to FORMAT;
+map work/cap arithmetic limits that cannot be safely traversed to UNSUPPORTED;
+reuse audit signature/encryption findings. Check `pdf->anyWarnings()` after
+preflight and write.
+
+- [ ] **Step 5: Add deterministic fault injection**
+
+Follow existing transform hooks: the test-only C hook exposes integer fault
+points immediately before provider registration, during provider encode, and
+before writer-buffer publication. Every injected failure must leave source
+observations unchanged and output NULL; allocation-style points return NOMEM
+and backend invariant points return BACKEND.
+
+- [ ] **Step 6: Run sanitizers and commit**
+
+```powershell
+ctest --preset win-release-user --output-on-failure
+```
+
+Then on Linux:
+
+```bash
+cmake --fresh --preset linux-dev-user
+cmake --build --preset linux-dev-user --parallel 2
+ctest --preset linux-dev-user --output-on-failure
+```
+
+Expected: 33/33 tests pass in Release and sanitizer configurations, with no
+ASan/UBSan report.
+
+```powershell
+git add src/backend/qpdf_document.cpp tests/test_pdf_image_recompression.c tests/image_recompression_test_helpers.cpp tests/pdf_image_recompression_fault_hook.c tests/pdf_image_recompression_test_api.h tests/CMakeLists.txt
+git commit -m "test: harden image recompression policy"
+```
+
+### Task 5: Documentation, install notice, ABI consumer, and release gate
+
+**Files:**
+- Modify: `README.md`
+- Modify: `THIRD_PARTY.md`
+- Modify: `CMakeLists.txt`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `tests/test_installed_consumer.c`
+- Modify: `docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md`
+- Modify: `docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md`
+
+**Interfaces:**
+- Consumes: the complete API and backend behavior from Tasks 1-4.
+- Produces: documented/installable QuantaPDF 2.4.0 candidate with exact
+  completion evidence.
+
+- [ ] **Step 1: Document the public call and limits**
+
+Add a README example initializing the full options structure, calling the
+transform, saving/dropping output, and explaining explicit loss, strict
+eligibility, 64 MiB default cap, quality 100 behavior, immutable ownership,
+signed/encrypted failures, and the absence of resizing/inline-image rewriting.
+
+- [ ] **Step 2: Install the libjpeg-turbo notice**
+
+Derive the package share root as the parent of `qpdf_DIR`, require
+`${share_root}/libjpeg-turbo/copyright`, and install it under
+`${CMAKE_INSTALL_DATADIR}/quantapdf/licenses/libjpeg-turbo`. Keep qpdf and
+PDFium notice installation unchanged.
+
+- [ ] **Step 3: Extend the installed C consumer**
+
+Compile a `quantapdf_image_recompression_options` initializer, verify the
+2.4.0/ABI 2 macros, and take the address of `quantapdf_recompress_images` so
+the install test proves header, import library, export, and calling convention.
+
+- [ ] **Step 4: Run the complete local release gate**
+
+```powershell
+cmake --fresh --preset win-release-user
+cmake --build --preset win-release-user
+ctest --preset win-release-user --output-on-failure
+cmake --install build/Msvc-Release --prefix build/install-image-recompression
+```
+
+Expected: 33/33 CTests, version 2.4.0, ABI/SOVERSION 2, exactly 88 exports,
+installed consumer success, and all three dependency notice trees present.
+
+- [ ] **Step 5: Update completion evidence and commit**
+
+Mark only locally proven checklist items complete and record exact command
+outputs/commit SHAs. Do not claim PR, full CI, merge, or release before those
+events exist.
+
+```powershell
+git add README.md THIRD_PARTY.md CMakeLists.txt tests/CMakeLists.txt tests/test_installed_consumer.c docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md docs/superpowers/plans/2026-09-01-quantapdf-image-recompression.md
+git commit -m "docs: document image recompression contract"
+```
+
+- [ ] **Step 6: Request task and whole-branch review**
+
+Review the full Phase B range against the spec. Fix all Critical and Important
+findings through the original task implementer and re-review each fix. Require
+a final whole-branch verdict of ready to merge.
+
+- [ ] **Step 7: Push the feature PR and require full CI**
+
+Push without force, open a PR that links #57, add `full-ci`, and verify the PR
+head SHA equals the reviewed local SHA. Require Linux static, Linux ASan/UBSan,
+macOS, and Windows to pass, including both new CTests and the 88-export check.
+
+- [ ] **Step 8: Stop before integration**
+
+Report the exact PR URL, reviewed head SHA, local 33/33 evidence, and exact-head
+full-ci run. Do not merge the Phase B feature PR until the user explicitly
+authorizes integration.

--- a/docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md
@@ -1,0 +1,351 @@
+# QuantaPDF Image Recompression V1 Design
+
+**Date:** 2026-09-01
+
+**Issue:** [#57](https://github.com/qigao/QuantaPDF/issues/57)
+
+**Target release:** 2.4.0
+
+**Public ABI:** additive ABI v2
+
+## Goal
+
+Add one immutable, explicitly lossy whole-document transform that re-encodes a
+strict class of opaque 8-bit DeviceGray and DeviceRGB Image XObjects as JPEG.
+It preserves image geometry, indirect-object sharing, resource names, content
+operators, page structure, interactive structures, and all ineligible images.
+
+The transform is not part of `quantapdf_rewrite_lossless()`. A caller opts into
+pixel loss only by calling the new API with an explicit JPEG quality.
+
+## Locked backend and codec decision
+
+The implementation uses the existing backend split:
+
+- qpdf 12.4.0 discovers the reachable resource graph, decodes supported image
+  stream filters, preserves indirect identity, replaces stream data, and
+  serializes the private graph;
+- PDFium 154.0.8021.0 supplies render and public observation semantics used by
+  acceptance tests;
+- qpdf's `Pl_DCT` adapter supplies JPEG compression through the libjpeg API;
+- the pinned vcpkg baseline resolves that API to libjpeg-turbo 3.2.0.
+
+`stb_image` and `stb_image_write` are not added. QuantaPDF already ships the
+qpdf/libjpeg-turbo dependency chain, and adding stb would create a second JPEG
+implementation, another notice/audit surface, and a second encoding policy.
+The selected components remain permissively licensed: qpdf is Apache-2.0 or
+Artistic-2.0, and libjpeg-turbo uses IJG plus BSD-style terms. No MuPDF or AGPL
+dependency is permitted.
+
+Upstream evidence:
+
+- qpdf 12.4.0's
+  [`pdf-invert-images.cc`](https://github.com/qpdf/qpdf/blob/v12.4.0/examples/pdf-invert-images.cc)
+  demonstrates cycle-safe image identity handling, `copyStream()`,
+  `qpdf_dl_all`, and `replaceStreamData()`;
+- qpdf 12.4.0's
+  [`Pl_DCT.hh`](https://github.com/qpdf/qpdf/blob/v12.4.0/include/qpdf/Pl_DCT.hh)
+  exposes compression with a per-instance libjpeg configuration callback;
+- libjpeg-turbo
+  [3.2.0](https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.2.0)
+  is the exact version resolved by the repository's pinned vcpkg baseline.
+
+This selection is conditional on the deterministic encoder gate below. A
+cross-platform byte mismatch stops implementation before the public API is
+committed. It does not silently switch codec or weaken the contract.
+
+## Public API
+
+```c
+#define QUANTAPDF_IMAGE_RECOMPRESSION_DEFAULT_MAX_DECODED_BYTES \
+    ((size_t)64u * (size_t)1024u * (size_t)1024u)
+
+typedef struct quantapdf_image_recompression_options {
+    size_t struct_size;
+    int jpeg_quality;
+    size_t max_decoded_bytes_per_image;
+} quantapdf_image_recompression_options;
+
+#define QUANTAPDF_IMAGE_RECOMPRESSION_OPTIONS_V1_MIN_SIZE \
+    (offsetof(quantapdf_image_recompression_options, jpeg_quality) + \
+     sizeof(int))
+#define QUANTAPDF_IMAGE_RECOMPRESSION_OPTIONS_V1_SIZE \
+    (sizeof(quantapdf_image_recompression_options))
+
+QUANTAPDF_API quantapdf_status quantapdf_recompress_images(
+    quantapdf_document *document,
+    const quantapdf_image_recompression_options *options,
+    quantapdf_output **out_output);
+```
+
+The options structure is a single append-only structure:
+
+- a size smaller than `QUANTAPDF_IMAGE_RECOMPRESSION_OPTIONS_V1_MIN_SIZE`
+  returns `QUANTAPDF_ERROR_ARGUMENT`;
+- a larger structure is accepted and unknown tail bytes are ignored;
+- `jpeg_quality` must be in `[1, 100]`;
+- if `max_decoded_bytes_per_image` is covered by `struct_size`, zero selects
+  the 64 MiB default and a nonzero value becomes the per-image hard cap;
+- when that field is not covered, the 64 MiB default applies.
+
+`document`, `options`, and `out_output` are required. Whenever `out_output` is
+non-NULL, `*out_output` is set to NULL before any other validation or work.
+Success publishes a new owning `quantapdf_output`; it remains valid after the
+source document is closed. The source and all existing observations remain
+unchanged.
+
+This adds one export. The v2 export baseline grows from 87 to 88, the release
+version becomes 2.4.0, and `QUANTAPDF_ABI_VERSION` plus SOVERSION remain 2.
+
+## Data flow and responsibility boundary
+
+```text
+source bytes + password (borrowed for call; never mutated)
+    -> fresh strict QPDF graph (private owner)
+    -> signed/encrypted audit and structural preflight
+    -> bounded reachable resource traversal
+    -> unique eligible QPDFObjGen plan
+    -> copied original streams + replacement providers
+    -> qpdf decode -> fixed Pl_DCT/libjpeg-turbo profile -> writer pipeline
+    -> deterministic QPDFWriter memory buffer
+    -> owning quantapdf_output
+
+published output -> reopened through QuantaPDF
+    -> PDFium render/observation acceptance checks
+```
+
+The public page-image snapshot APIs are not an input to this transform. They
+are occurrence-oriented PDFium observations and cannot represent complete
+document resource identity. No qpdf, PDFium, JPEG, colorspace, or encoder type
+enters the public header.
+
+## Reachable resource graph
+
+The private traversal has these roots:
+
+1. every page's effective `/Resources` dictionary, including inherited page
+   resources;
+2. recursively reachable Form XObjects from each page resource graph;
+3. every page annotation or Widget appearance selected through `/AP` keys
+   `/N`, `/R`, and `/D`, including state subdictionaries whose values are
+   appearance streams;
+4. recursively reachable Form XObjects from each valid appearance stream's
+   `/Resources` dictionary.
+
+For each resource owner, only `/Resources /XObject` entries are interpreted.
+An Image stream is collected; a Form stream is queued; other XObject subtypes
+are ignored. Inline images inside page or Form content streams are never
+parsed or rewritten.
+
+Traversal is iterative and cycle-safe. Form/resource owners and collected
+images are deduplicated by full `QPDFObjGen`, not object number alone. It
+reuses the audit/sanitize work budget:
+
+```text
+work_limit = max(4096, source_size * 64)
+```
+
+The multiplication is overflow-checked. Each root, appearance edge, resource
+owner, XObject edge, and planned image consumes one unit. Exhaustion returns
+`QUANTAPDF_ERROR_UNSUPPORTED`; it never falls back to partial traversal.
+
+Malformed structures that this traversal consumes return
+`QUANTAPDF_ERROR_FORMAT`, including a non-dictionary effective resources
+value, non-dictionary `/XObject`, non-stream Form/Image entry, malformed page
+`/Annots`, malformed `/AP`, or an appearance state value that is not a stream.
+Unrelated custom dictionary edges are outside this reachability claim.
+
+## Strict eligibility policy
+
+Every reachable Image XObject is classified before mutation.
+
+An image is eligible only when all of these statements are true:
+
+- it is an indirect stream with `/Subtype /Image`;
+- `/Width` and `/Height` are positive integers representable as both
+  libjpeg `JDIMENSION` and `size_t` calculations;
+- `/BitsPerComponent` is exactly integer 8;
+- `/ColorSpace` resolves to the name `/DeviceGray` or `/DeviceRGB`;
+- `/ImageMask` is absent, null, or boolean false;
+- `/SMask` and `/Mask` are absent or null;
+- `/Decode` is absent/null or is exactly the identity array for the component
+  count: `[0 1]` for gray and `[0 1 0 1 0 1]` for RGB;
+- checked `width * height * components` does not exceed the normalized
+  `max_decoded_bytes_per_image`;
+- qpdf's filterability probe reports that the complete filter chain is
+  supported at `qpdf_dl_all`;
+- actual decoding succeeds and the decoded byte count is exactly
+  `width * height * components`.
+
+The byte cap is part of eligibility. A valid image above it is preserved
+unchanged. This makes the maximum raw sample buffer for one encoder invocation
+explicit and caller-controlled without making normal calls unbounded.
+
+Valid but ineligible images are preserved byte-for-byte at the stream level.
+This includes CMYK, ICCBased, CalRGB/CalGray, Lab, Indexed, Separation,
+DeviceN, JPX, soft masks, explicit or color-key masks, stencil masks,
+non-8-bpc samples, non-identity Decode arrays, unsupported filter chains,
+inline images, and images above the per-image byte cap.
+
+Filter support is classified without consuming decoded bytes by the qpdf
+filterability probe. A false probe result is an ineligible/preserve decision.
+After a true probe result, a failure while actually decoding that otherwise
+eligible candidate is malformed input and returns FORMAT.
+
+Malformed required scalar types, non-finite/out-of-range dimensions, checked
+arithmetic overflow, or a decode failure after an image otherwise satisfies
+the eligible structural class return `QUANTAPDF_ERROR_FORMAT`. The transform
+does not publish a partially processed output.
+
+## Encoder profile
+
+The encoder profile is fixed rather than inheriting library defaults:
+
+- libjpeg API sample precision: 8 bits;
+- input and encoded colorspace: `JCS_GRAYSCALE` for DeviceGray and `JCS_RGB`
+  for DeviceRGB;
+- RGB sampling factors: 1x1 for all three components (no chroma subsampling);
+- `jpeg_set_quality(cinfo, jpeg_quality, TRUE)` forces baseline-compatible
+  quantization tables;
+- DCT method: `JDCT_ISLOW`;
+- sequential Huffman coding, `optimize_coding = FALSE`, arithmetic coding
+  disabled, no progressive scan script, no restart interval, and no smoothing;
+- grayscale writes a fixed JFIF 1.01 marker with density unit 0 and 1x1
+  density; RGB writes no JFIF marker and writes an Adobe marker with transform
+  0;
+- quality 100 is still an encode operation and is not a semantic no-op.
+
+The replacement stream keeps `/Width`, `/Height`, `/ColorSpace`,
+`/BitsPerComponent`, placement, and object identity. It installs
+`/Filter /DCTDecode`. DeviceRGB also installs
+`/DecodeParms << /ColorTransform 0 >>`; DeviceGray removes `/DecodeParms`.
+An accepted explicit identity `/Decode` is preserved. `/Length` is managed by
+qpdf. The stream is marked not to be filtered again on write.
+
+## Determinism gate
+
+Before the public header or ABI baseline changes, a backend-private encoder
+characterization test must encode fixed DeviceGray and DeviceRGB sample arrays
+at qualities 40, 90, and 100. It compares complete encoded bytes with checked
+golden byte arrays and runs on the same exact commit on Linux, macOS, and
+Windows. Repeated calls in one process must also match.
+
+The gate is intentionally stronger than a semantic render comparison. If any
+platform produces different JPEG bytes, implementation stops at the private
+adapter commit and this design is revised. Runtime environment mutation such
+as setting `JSIMD_FORCENONE` is not an accepted workaround because ABI v2 uses
+external serialization but does not grant permission to mutate process-wide
+environment or codec state.
+
+For a fixed source, normalized options, pinned qpdf/libjpeg-turbo versions,
+and platform-independent encoder bytes, the complete PDF output must be
+byte-identical across repeated calls. Cross-platform CI compares the same
+golden JPEG bytes and one complete checked-in golden output PDF, so both the
+codec and serialization boundaries are checked on every platform.
+
+## Memory and lifetime protocol
+
+| Item | Contract |
+|---|---|
+| Data unit | One indirect Image stream plus checked width, height, component count, and normalized options. |
+| Fact source | Original stream bytes in a `copyStream()` handle; the private QPDF graph owns replacement providers. |
+| Public inputs | `document` and `options` are borrowed for the synchronous call and are never retained after return. |
+| Decoded samples | At most one image is decoded/encoded at a time; the encoder owns the raw sample buffer until its `finish()` returns. |
+| Encoded bytes | Written directly through the qpdf writer pipeline; providers do not retain a second PDF-wide encoded-image cache. |
+| Output | The C facade copies the completed writer buffer into the new owning `quantapdf_output`. |
+| Capacity | `width * height * components` uses checked multiplication and must be at most the normalized per-image cap. The resource traversal uses the source-derived work limit. |
+| Concurrency | One producer/consumer call stack, no queue and no worker threads. ABI v2 still requires caller-side serialization of all public calls. |
+| Failure | Any validation, decode, encode, allocation, provider, or writer failure destroys the private graph and shell; `*out_output` remains NULL. |
+| Shutdown | The synchronous writer finishes every provider before the private graph is destroyed. No borrowed sample pointer escapes the call. |
+
+The cap bounds raw samples for this feature; it is not a claim that total
+process memory equals the cap. QPDF parsing and the existing memory-output
+writer also retain their documented graph/output storage. Peak memory and
+runtime are measured in implementation benchmarks before release, and no
+throughput or allocation reduction is promised by this design.
+
+## Security and error semantics
+
+The transform opens a fresh QPDF graph with warning suppression, recovery
+disabled, and later warning inspection. It forces page/object loading, runs the
+existing document audit, and returns:
+
+- `QUANTAPDF_ERROR_UNSUPPORTED` for encrypted input, even with a valid open
+  password;
+- `QUANTAPDF_ERROR_UNSUPPORTED` for any recognized signature structure;
+- `QUANTAPDF_ERROR_FORMAT` for required parser recovery, consumed malformed
+  resource/image structures, or eligible-stream decode failure;
+- `QUANTAPDF_ERROR_NOMEM` for allocation failure;
+- `QUANTAPDF_ERROR_BACKEND` for an unexpected qpdf/libjpeg invariant failure.
+
+There is no JavaScript or event execution and no page rasterization. The
+private graph is fully discovered and structurally preflighted before its
+first replacement. Mutations affect only that private graph.
+
+## Observability
+
+V1 adds no report handle or callback. Success means every image in the strict
+eligible class and within the caller's byte cap was recompressed; all valid
+ineligible images were preserved. A later additive inspection API may expose
+candidate, recompressed, preserved, and reason counts without changing this
+transform's behavior.
+
+## Acceptance matrix
+
+The implementation must prove all of the following:
+
+1. undersized/oversized option structures and quality bounds follow the ABI
+   contract, and every failure nulls `out_output`;
+2. one DeviceRGB and one DeviceGray image becomes `/DCTDecode` with the fixed
+   encoder profile;
+3. page dimensions, image dimensions, occurrence count, placement quads, and
+   page geometry remain unchanged;
+4. PDFium render comparison stays within a documented per-channel lossy
+   tolerance on controlled fixtures;
+5. a shared Image XObject used by multiple pages remains one indirect object
+   and is encoded once;
+6. nested Form resources and annotation/Widget appearance Form resources are
+   traversed;
+7. resource/Form cycles terminate and preserve unique identity;
+8. valid CMYK, ICCBased, Indexed, mask, soft-mask, stencil, non-8-bpc,
+   non-identity Decode, inline, unsupported-filter, and over-cap images remain
+   unchanged;
+9. a cap of 5 bytes preserves a 2x1 RGB image while a cap of 6 bytes permits
+   it, proving the boundary without large allocations;
+10. malformed consumed resources and eligible stream data return FORMAT;
+11. text, search, links, annotations, forms, outline, metadata, destinations,
+    page boxes, and content streams remain semantically unchanged;
+12. source observations are unchanged after success and failure;
+13. output survives source close and reopens through both backends;
+14. repeated same-quality output is byte-identical;
+15. qualities 40 and 90 produce different controlled-image bytes, with the
+    expected measured size/error ordering recorded as test evidence rather
+    than generalized as a universal promise;
+16. quality 100 still rewrites the eligible stream;
+17. signed and encrypted inputs fail closed;
+18. injected allocation/provider faults publish no output;
+19. the installed C consumer compiles, links, and calls the new API;
+20. the ABI export checker reports exactly 88 public exports;
+21. a controlled quality-90 transform equals the complete checked-in golden
+    output PDF on Linux, macOS, and Windows;
+22. Linux static, Linux ASan/UBSan, macOS, and Windows pass on one exact SHA.
+
+Two CTest targets are added: the private encoder characterization target and
+the public transform target. The integrated baseline grows from 31 to 33.
+
+## Non-goals
+
+V1 does not resize or downsample, select target DPI, choose among codecs,
+encode PNG/Flate/JPX, convert colorspaces, flatten alpha, rasterize pages,
+rewrite inline images, deduplicate different image objects, target a whole-PDF
+size, preserve signatures, compose encryption, incrementally save, expose
+qpdf/PDFium/libjpeg types, or provide a generic `compress_pdf` API.
+
+The explicit future composition remains:
+
+```text
+decrypt -> recompress_images -> rewrite_lossless -> encrypt
+```
+
+Issue #58 owns encryption transforms. Neither composition nor encryption is
+part of Image Recompression V1.

--- a/docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md
+++ b/docs/superpowers/specs/2026-09-01-quantapdf-image-recompression-design.md
@@ -187,6 +187,11 @@ DeviceN, JPX, soft masks, explicit or color-key masks, stencil masks,
 non-8-bpc samples, non-identity Decode arrays, unsupported filter chains,
 inline images, and images above the per-image byte cap.
 
+A `/Decode` array of the correct length whose entries are finite numbers but
+which is not the identity array is valid and ineligible. A `/Decode` value
+with the wrong type or length, a nonnumeric entry, or a non-finite entry is a
+malformed consumed image dictionary and returns `QUANTAPDF_ERROR_FORMAT`.
+
 Filter support is classified without consuming decoded bytes by the qpdf
 filterability probe. A false probe result is an ineligible/preserve decision.
 After a true probe result, a failure while actually decoding that otherwise
@@ -250,18 +255,19 @@ codec and serialization boundaries are checked on every platform.
 | Data unit | One indirect Image stream plus checked width, height, component count, and normalized options. |
 | Fact source | Original stream bytes in a `copyStream()` handle; the private QPDF graph owns replacement providers. |
 | Public inputs | `document` and `options` are borrowed for the synchronous call and are never retained after return. |
-| Decoded samples | At most one image is decoded/encoded at a time; the encoder owns the raw sample buffer until its `finish()` returns. |
-| Encoded bytes | Written directly through the qpdf writer pipeline; providers do not retain a second PDF-wide encoded-image cache. |
+| Decoded samples | The copied source stream pipes decoded samples directly into `Pl_DCT`. `Pl_DCT` owns at most one complete raw image buffer, bounded by the normalized per-image cap, until `finish()` returns; QuantaPDF does not make a second raw-sample copy. |
+| Encoded bytes | `Pl_DCT` writes directly to the QPDF writer's supplied pipeline; providers do not retain a per-image encoded vector or a second PDF-wide encoded-image cache. |
 | Output | The C facade copies the completed writer buffer into the new owning `quantapdf_output`. |
 | Capacity | `width * height * components` uses checked multiplication and must be at most the normalized per-image cap. The resource traversal uses the source-derived work limit. |
 | Concurrency | One producer/consumer call stack, no queue and no worker threads. ABI v2 still requires caller-side serialization of all public calls. |
 | Failure | Any validation, decode, encode, allocation, provider, or writer failure destroys the private graph and shell; `*out_output` remains NULL. |
 | Shutdown | The synchronous writer finishes every provider before the private graph is destroyed. No borrowed sample pointer escapes the call. |
 
-The cap bounds raw samples for this feature; it is not a claim that total
-process memory equals the cap. QPDF parsing and the existing memory-output
-writer also retain their documented graph/output storage. Peak memory and
-runtime are measured in implementation benchmarks before release, and no
+The cap bounds the one complete raw-sample buffer owned internally by
+`Pl_DCT`; it is not a claim that total process memory equals the cap. QPDF may
+also retain compressed source data while decoding, and QPDF parsing plus the
+existing memory-output writer retain their graph/output storage. Peak memory
+and runtime are measured in implementation benchmarks before release, and no
 throughput or allocation reduction is promised by this design.
 
 ## Security and error semantics
@@ -273,10 +279,24 @@ existing document audit, and returns:
 - `QUANTAPDF_ERROR_UNSUPPORTED` for encrypted input, even with a valid open
   password;
 - `QUANTAPDF_ERROR_UNSUPPORTED` for any recognized signature structure;
+- `QUANTAPDF_ERROR_UNSUPPORTED` when the source-derived traversal work-budget
+  multiplication overflows or the budget is exhausted;
 - `QUANTAPDF_ERROR_FORMAT` for required parser recovery, consumed malformed
-  resource/image structures, or eligible-stream decode failure;
-- `QUANTAPDF_ERROR_NOMEM` for allocation failure;
-- `QUANTAPDF_ERROR_BACKEND` for an unexpected qpdf/libjpeg invariant failure.
+  resource/image structures (including image-dimension/product overflow), or
+  eligible-stream decode failure;
+- `QUANTAPDF_ERROR_NOMEM` only for observable C or C++ allocation failure;
+- `QUANTAPDF_ERROR_BACKEND` for a qpdf/libjpeg runtime failure or unexpected
+  backend invariant failure after structurally valid preflight.
+
+Each retry-capable replacement provider owns a latched `quantapdf_status`.
+Provider setup or execution records its first non-OK status before throwing to
+abort `QPDFWriter`: `std::bad_alloc` latches NOMEM, an explicit private status
+latches that status, and `pipeStreamData()` failure or any other codec/provider
+exception latches BACKEND. The outer writer boundary returns the latched
+status when present; otherwise it applies the normal QPDF exception mapping.
+This makes the provider's boolean protocol lossless at the public status
+boundary. Candidate decode failures are detected during preflight and remain
+FORMAT rather than reaching this provider path.
 
 There is no JavaScript or event execution and no page rasterization. The
 private graph is fully discovered and structurally preflighted before its
@@ -304,17 +324,21 @@ The implementation must prove all of the following:
    tolerance on controlled fixtures;
 5. a shared Image XObject used by multiple pages remains one indirect object
    and is encoded once;
-6. nested Form resources and annotation/Widget appearance Form resources are
-   traversed;
+6. nested Form resources and both annotation and Widget appearances are
+   traversed for `/N`, `/R`, and `/D`, covering direct appearance streams,
+   appearance-state subdictionaries, and nested Forms below every variant;
 7. resource/Form cycles terminate and preserve unique identity;
 8. valid CMYK, ICCBased, Indexed, mask, soft-mask, stencil, non-8-bpc,
    non-identity Decode, inline, unsupported-filter, and over-cap images remain
    unchanged;
 9. a cap of 5 bytes preserves a 2x1 RGB image while a cap of 6 bytes permits
    it, proving the boundary without large allocations;
-10. malformed consumed resources and eligible stream data return FORMAT;
-11. text, search, links, annotations, forms, outline, metadata, destinations,
-    page boxes, and content streams remain semantically unchanged;
+10. malformed consumed resources, malformed Decode arrays, image-dimension or
+    sample-product overflow, and eligible stream data return FORMAT, while
+    traversal-budget overflow/exhaustion returns UNSUPPORTED;
+11. before/after snapshots prove text, search results, links, annotations,
+    forms, outline, metadata, destinations, and page boxes unchanged, and raw
+    page/Form content stream bytes compare exactly;
 12. source observations are unchanged after success and failure;
 13. output survives source close and reopens through both backends;
 14. repeated same-quality output is byte-identical;
@@ -323,9 +347,12 @@ The implementation must prove all of the following:
     than generalized as a universal promise;
 16. quality 100 still rewrites the eligible stream;
 17. signed and encrypted inputs fail closed;
-18. injected allocation/provider faults publish no output;
-19. the installed C consumer compiles, links, and calls the new API;
-20. the ABI export checker reports exactly 88 public exports;
+18. injected allocation/provider faults publish no output and return the
+    precisely latched NOMEM or BACKEND status;
+19. a test-only counter keyed by `QPDFObjGen` proves each shared eligible image
+    has one provider registration and one provider invocation;
+20. the public C test compiles against the sole public header and the
+    ABI export checker reports exactly 88 public exports;
 21. a controlled quality-90 transform equals the complete checked-in golden
     output PDF on Linux, macOS, and Windows;
 22. Linux static, Linux ASan/UBSan, macOS, and Windows pass on one exact SHA.
@@ -340,6 +367,9 @@ encode PNG/Flate/JPX, convert colorspaces, flatten alpha, rasterize pages,
 rewrite inline images, deduplicate different image objects, target a whole-PDF
 size, preserve signatures, compose encryption, incrementally save, expose
 qpdf/PDFium/libjpeg types, or provide a generic `compress_pdf` API.
+Adding a relocatable CMake package configuration or a standalone static-install
+consumer harness is also separate packaging work; this feature does not claim
+that capability.
 
 The explicit future composition remains:
 


### PR DESCRIPTION
## Summary

- replace the historical ExtractPDF/MuPDF proposal in #57 with a QuantaPDF 2.4.0 / ABI 2 design
- keep PDFium for observation/render verification and qpdf for strict graph rewrite
- select qpdf `Pl_DCT` over pinned libjpeg-turbo 3.2.0; add neither stb nor MuPDF/AGPL
- require a private Linux/macOS/Windows golden-byte qualification PR before any public ABI change
- specify bounded direct decode-to-encoder streaming, failure-atomic provider status propagation, strict eligibility, appearance traversal, and semantic preservation tests

## Scope

Documentation only. This PR intentionally stops at the committed design-review gate required by #57. It does not implement or expose `quantapdf_recompress_images` and does not close #57.

## Verification

- `git diff 5f66be7f50ae60240e3a9fd6995eb68880c21aef..694a289b684dae5f9678a66a62b416b46136ce09 --check`
- checked all referenced upstream/issue links (HTTP 200)
- independent design review: no Critical, Important, or Minor findings; Ready for design PR

Related: #57, #48, #2